### PR TITLE
fix: show actual from_number from API response

### DIFF
--- a/send_sms.py
+++ b/send_sms.py
@@ -126,7 +126,8 @@ def main():
         else:
             print("SMS sent successfully!")
             print(f"   ID: {result.get('id')}")
-            print(f"   Status: {result.get('status')}")
+            print(f"   Status: {result.get('message_status')}")
+            print(f"   From: {result.get('from_number')}")
             print(f"   To: {', '.join(result.get('to_numbers', []))}")
 
         sys.exit(0)


### PR DESCRIPTION
## Summary

Fixes a misleading output in `send_sms.py` where the requested `--from` parameter was shown instead of the actual number used by Dialpad.

## Changes

- Show `from_number` from API response (actual number used by Dialpad)
- Show `message_status` instead of `status` (correct field name)
- Previously: "From: +14153602954" (requested, but not what was used)
- Now: "From: +14155201316" (actual number from API response)

## Context

When sending SMS, Dialpad may not use the requested sender number if:
- The number isn't assigned to your account
- Dialpad routes through a department/office number

The script now reflects reality by showing what Dialpad actually used.

## Testing

```bash
$ python3 send_sms.py --from "+14153602954" --to "+14158235304" --message "Test"
SMS sent successfully!
   ID: 5998107332190208
   Status: pending
   From: +14155201316  ← Actual number used (not what was requested)
   To: +14158235304
```

🤖 *Review requested: Niemand Code*