### PR TITLE
feat: optional SMS security filter for 2FA/OTP

### DIFF
--- a/sms_filter_compat.py
+++ b/sms_filter_compat.py
@@ -1,0 +1,28 @@
+"""
+Optional SMS security filter compatibility layer.
+
+Provides no-op fallbacks when sms_security_filter module is not installed,
+so consumers can import unconditionally without try/except boilerplate.
+
+Install sms_security_filter (from shapescale-openclaw-skills/security)
+to enable filtering. Without it, all messages pass through unchanged.
+"""
+
+try:
+    from sms_security_filter import (
+        is_sensitive_message,
+        filter_messages,
+        redact_preview,
+    )
+    FILTER_AVAILABLE = True
+except ImportError:
+    FILTER_AVAILABLE = False
+
+    def is_sensitive_message(**_kwargs):
+        return False
+
+    def filter_messages(messages, **_kwargs):
+        return messages
+
+    def redact_preview(text, **_kwargs):
+        return text


### PR DESCRIPTION
## Summary

- Adds optional SMS security filtering to prevent AI agents from reading 2FA/OTP codes, password reset texts, and security alerts
- Filter is opt-in: requires `sms_security_filter` Python module (from [shapescale-openclaw-skills/security](https://github.com/kesslerio/shapescale-openclaw-skills/tree/feat/sms-security-filter/security)). Without it, all messages pass through unchanged
- Short codes (4-6 digit senders) auto-blocked when filter is installed
- Messages are still stored in SQLite for human access — only agent-visible output is filtered

## Changes

| File | Change |
|------|--------|
| `sms_sqlite.py` | Filter `get_thread()`, `search_messages()`; redact previews in `get_all_threads()`, `get_unread()` |
| `webhook_server.py` | Suppress Telegram notification for sensitive inbound messages |
| `webhook_sqlite.py` | Redact previews in `format_notification()` |

## Test plan

- [ ] `python3 sms_sqlite.py search "code"` — OTP messages filtered from results
- [ ] `python3 sms_sqlite.py thread <short-code>` — short code thread returns empty
- [ ] `python3 sms_sqlite.py unread` — sensitive previews show `[FILTERED]`
- [ ] POST mock OTP to webhook — verify Telegram notification suppressed
- [ ] Uninstall filter module — verify all messages pass through (optional feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)