### PR TITLE
feat(webhook): missed call and voicemail notifications

### DIFF
--- a/webhook_server.py
+++ b/webhook_server.py
@@ -386,7 +386,11 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
 
         direction = data.get("call_direction", data.get("direction", "unknown"))
         call_missed = data.get("call_missed", False)
-        duration = data.get("duration", data.get("call_duration", 0))
+        raw_duration = data.get("duration", data.get("call_duration", 0))
+        try:
+            duration = int(float(raw_duration))
+        except (TypeError, ValueError):
+            duration = 0
         call_state = str(data.get("call_state", "")).lower()
 
         should_notify = (
@@ -540,8 +544,9 @@ def main():
     print(f"Configuration:")
     print(f"  - Dialpad API: {'✓' if DIALPAD_API_KEY else '✗ (contact lookup disabled)'}")
     print(f"  - Telegram: {'✓' if TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID else '✗ (notifications disabled)'}")
-    print(f"  - Call Notifications: {'✓' if TELEGRAM_BOT_TOKEN else '✗'}")
-    print(f"  - Voicemail Notifications: {'✓' if TELEGRAM_BOT_TOKEN else '✗'}")
+    tg_ready = bool(TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID)
+    print(f"  - Call Notifications: {'✓' if tg_ready else '✗ (Telegram not fully configured)'}")
+    print(f"  - Voicemail Notifications: {'✓' if tg_ready else '✗ (Telegram not fully configured)'}")
     print(f"  - JWT Verification: {'✓' if WEBHOOK_SECRET else '✗ (disabled)'}")
     print(f"  - Line Names:")
     for number in sorted(LINE_NAMES.keys()):


### PR DESCRIPTION
## What
Adds two new webhook handlers for real-time call and voicemail notifications in Telegram. Closes #8. Partially addresses #9 (see blocker below).

## Why
Closes #8. Missed calls from prospects go unnoticed without checking Dialpad manually. Now they fire into Telegram like SMS does.

## Changes

### Issue #8: Missed Call Notifications (`/webhook/dialpad-call`)
- `handle_call_webhook()`: parses Dialpad call events, notifies only on inbound missed calls
- Missed detection: `call_direction=inbound` AND (`call_missed=true` OR `call_state='missed'` OR `duration=0`)
- Resolves caller via `get_contact_name()`, line via `get_line_name()`  
- Format: `📞 Missed Call / To: Sales (415) 520-1316 / From: Name (`+1...`) / Time: 4:32 PM`
- Non-missed calls → 200 OK, no notification (silent pass-through)

### Issue #9: Voicemail Notifications (`/webhook/dialpad-voicemail`)
- `handle_voicemail_webhook()`: notifies on all voicemails with caller, line, duration
- Includes transcription block when present in payload
- Format: `📬 New Voicemail / To / From / Duration / Transcription (if available)`

### Webhook Subscription Created
- Call (missed state): ID `6224109496311808` — active on existing endpoint `5449480264228864`

## ⚠️ Blocker for #9 (Voicemail Webhook)
Dialpad does **not** have a `/api/v2/subscriptions/voicemail` endpoint. The generated CLI has no voicemail subscription commands either. The `webhook_voicemail_event_subscription` mentioned in the issue does not exist in the current Dialpad API.

Options:
1. **Poll Dialpad API** for new voicemails on a schedule (workaround)
2. **Check Dialpad developer docs / support** — may be a newer/enterprise feature
3. **Close #9 as won't fix** until Dialpad adds the webhook

The voicemail handler code is included and ready — it just has no subscription to trigger it.

## Tests
```bash
cd /home/art/projects/skills/work/dialpad
python3 -c "
import webhook_server
assert hasattr(webhook_server.DialpadWebhookHandler, 'handle_call_webhook')
assert hasattr(webhook_server.DialpadWebhookHandler, 'handle_voicemail_webhook')
import inspect
src = inspect.getsource(webhook_server.DialpadWebhookHandler.do_POST)
assert '/webhook/dialpad-call' in src
assert '/webhook/dialpad-voicemail' in src
print('All checks passed')
"
```

## AI Assistance
- Implementation: Codex CLI (gpt-5.3-codex, yolo mode, tmux wrapper)
- Review: Codex CLI (gpt-5.3-codex, medium reasoning) — pending
- Bug fix: Codex dropped backticks from f-strings in `from_display`; caught and fixed manually
- Testing level: module-level import + structural assertions
- I understand this code.