### PR TITLE
feat(sms): add group intro flow and sender routing safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,36 @@ python3 send_sms.py --to "+14155551234" "+14155555678" --message "Group message"
 
 # From specific caller ID
 python3 send_sms.py --to "+14155551234" --message "Hello!" --from "+14159901234"
+
+# Send using a named sender profile
+python3 send_sms.py --to "+14155551234" --message "Hello!" --profile work
+
+# Use default profile
+export DIALPAD_DEFAULT_PROFILE=work
+python3 send_sms.py --to "+14155551234" --message "Hello!"
 ```
+
+Sender resolution in `bin/send_sms.py`:
+- `--from` takes priority.
+- `--profile work|sales` reads configured numbers from:
+  - `DIALPAD_PROFILE_WORK_FROM`
+  - `DIALPAD_PROFILE_SALES_FROM`
+- `DIALPAD_DEFAULT_FROM_NUMBER` has priority over `DIALPAD_DEFAULT_PROFILE`.
+- `DIALPAD_DEFAULT_PROFILE` sets default profile when `--from`/`--profile` are omitted.
+- `--allow-profile-mismatch` allows `--from` and mapped profile number to differ.
+- `--dry-run` prints resolved sender and payload intent without calling API.
+
+### Group Intro (mirrored fallback)
+
+```bash
+python3 bin/send_group_intro.py \
+  --prospect "+14155550111" \
+  --reference "+14155550999" \
+  --confirm-share \
+  --from "+14153602954"
+```
+
+This wrapper does not create true multi-recipient Dialpad threads. It mirrors the intro by sending two separate one-to-one SMS messages and returns `mode: mirrored_fallback`.
 
 ### Make Voice Calls
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -31,6 +31,11 @@ Use this skill to:
 bin/send_sms.py --to "+14155551234" --message "Hello from OpenClaw!"
 ```
 
+**Group Intro (mirrored fallback):**
+```bash
+bin/send_group_intro.py --prospect "+14155550111" --reference "+14155559999" --confirm-share --from "+14153602954"
+```
+
 **Make Call (TTS):**
 ```bash
 bin/make_call.py --to "+14155551234" --text "This is a call from the agent."
@@ -56,8 +61,15 @@ python3 sms_sqlite.py list
 1. **Format:** Always use E.164 format for numbers (e.g., `+14155551234`).
 2. **Escaping:** Use single quotes for messages containing `$` to prevent shell expansion (e.g., `'Price is $10'`).
 3. **Environment:** `DIALPAD_API_KEY` must be set. `ELEVENLABS_API_KEY` is optional for premium voices.
-4. **Wrappers:** Use `bin/*.py` for simple tasks; use `generated/dialpad` for advanced API features.
-5. **Create/Update Contact Behavior:** `bin/create_contact.py` upserts shared/local contacts by phone/email match (or forces create with `--allow-duplicate`). `bin/update_contact.py` updates by `--id` with partial fields.
+4. **SMS sender safety:** `--from` and `--profile work|sales` are supported. `--profile` maps to configured env vars:
+   - work: `DIALPAD_PROFILE_WORK_FROM`
+   - sales: `DIALPAD_PROFILE_SALES_FROM`
+   - default fallback order: `DIALPAD_DEFAULT_FROM_NUMBER`, then `DIALPAD_DEFAULT_PROFILE`
+   - `--allow-profile-mismatch` permits explicit/profile mismatches when intentional
+   - `--dry-run` prints sender resolution and request intent without API call
+5. **Group intro:** `bin/send_group_intro.py` mirrors intro messages as two one-to-one SMS sends (`mirrored_fallback`) because true group threads are unsupported via this wrapper.
+6. **Wrappers:** Use `bin/*.py` for simple tasks; use `generated/dialpad` for advanced API features.
+7. **Create/Update Contact Behavior:** `bin/create_contact.py` upserts shared/local contacts by phone/email match (or forces create with `--allow-duplicate`). `bin/update_contact.py` updates by `--id` with partial fields.
 
 ## Reference Documentation
 
@@ -77,4 +89,8 @@ export DIALPAD_API_KEY="your_key"
 ```bash
 export ELEVENLABS_API_KEY="your_key"
 export DIALPAD_USER_MAP='{"+14153602954": "5765607478525952"}'
+export DIALPAD_PROFILE_WORK_FROM="+14153602954"
+export DIALPAD_PROFILE_SALES_FROM="+14155201316"
+export DIALPAD_DEFAULT_PROFILE="work"
+export DIALPAD_DEFAULT_FROM_NUMBER="+14155201316"
 ```

--- a/bin/_dialpad_compat.py
+++ b/bin/_dialpad_compat.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -17,10 +18,81 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 GENERATED_DIALPAD = ROOT / "generated" / "dialpad"
+PROFILE_ENV_KEYS = {
+    "work": "DIALPAD_PROFILE_WORK_FROM",
+    "sales": "DIALPAD_PROFILE_SALES_FROM",
+}
+E164_RE = re.compile(r"^\+\d{7,15}$")
 
 
 class WrapperError(Exception):
     """Raised when wrapper execution fails."""
+
+
+def _normalize_profile(profile: str | None) -> str | None:
+    if not profile:
+        return None
+
+    normalized = profile.strip().lower()
+    if normalized in PROFILE_ENV_KEYS:
+        return normalized
+
+    raise WrapperError(f"Invalid profile '{profile}'. Use work or sales.")
+
+
+def _validate_e164(number: str, source: str) -> str:
+    normalized = number.strip()
+    if not normalized or not E164_RE.match(normalized):
+        raise WrapperError(f"Invalid sender number from {source}: '{number}'. Use E.164 format like +14155551234.")
+    return normalized
+
+
+def _profile_from_env(profile: str) -> str:
+    env_key = PROFILE_ENV_KEYS[profile]
+    raw = os.environ.get(env_key, "")
+    if not raw.strip():
+        raise WrapperError(
+            f"Profile '{profile}' is not configured. Set {env_key} to an E.164 number."
+        )
+    return _validate_e164(raw, env_key)
+
+
+def resolve_sender(
+    from_number: str | None,
+    profile: str | None,
+    *,
+    allow_profile_mismatch: bool = False,
+) -> tuple[str, str]:
+    resolved_profile = _normalize_profile(profile)
+
+    if from_number and resolved_profile:
+        normalized_from = _validate_e164(from_number, "--from")
+        mapped = _profile_from_env(resolved_profile)
+        if mapped != normalized_from and not allow_profile_mismatch:
+            raise WrapperError(
+                "--from conflicts with --profile. "
+                f"Use --allow-profile-mismatch to keep --from={normalized_from} while using --profile={resolved_profile}"
+            )
+        return normalized_from, f"--from with matching --profile={resolved_profile}"
+
+    if from_number:
+        return _validate_e164(from_number, "--from"), "--from"
+
+    if resolved_profile:
+        return _profile_from_env(resolved_profile), f"--profile={resolved_profile}"
+
+    default_from = os.environ.get("DIALPAD_DEFAULT_FROM_NUMBER", "")
+    if default_from.strip():
+        return _validate_e164(default_from, "DIALPAD_DEFAULT_FROM_NUMBER"), "DIALPAD_DEFAULT_FROM_NUMBER"
+
+    default_profile = _normalize_profile(os.environ.get("DIALPAD_DEFAULT_PROFILE"))
+    if default_profile:
+        return _profile_from_env(default_profile), f"DIALPAD_DEFAULT_PROFILE={default_profile}"
+
+    raise WrapperError(
+        "No sender resolved. Provide --from, --profile, or set "
+        "DIALPAD_DEFAULT_FROM_NUMBER / DIALPAD_DEFAULT_PROFILE."
+    )
 
 
 

--- a/bin/send_group_intro.py
+++ b/bin/send_group_intro.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Compatibility wrapper: send_group_intro.py -> mirrored SMS intro fallback."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from _dialpad_compat import (
+    generated_cli_available,
+    print_wrapper_error,
+    require_api_key,
+    resolve_sender,
+    run_generated_json,
+    run_legacy,
+    WrapperError,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Send a mirrored one-to-one group intro")
+    parser.add_argument("--prospect", required=True, help="Prospect phone number (E.164)")
+    parser.add_argument("--reference", required=True, help="Reference phone number (E.164)")
+    parser.add_argument("--from", dest="from_number", help="Sender number")
+    parser.add_argument("--profile", choices=("work", "sales"), help="Sender profile")
+    parser.add_argument(
+        "--allow-profile-mismatch",
+        action="store_true",
+        help="Allow --from to differ from mapped profile number",
+    )
+    parser.add_argument("--prospect-name", help="Prospect display name")
+    parser.add_argument("--reference-name", help="Reference display name")
+    parser.add_argument("--message", help="Custom intro body text")
+    parser.add_argument(
+        "--confirm-share",
+        action="store_true",
+        help="Confirm that prospect and reference numbers are being shared",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print request intent without sending")
+    parser.add_argument("--json", action="store_true", help="Output JSON")
+    return parser
+
+
+def _label_for_party(name: str | None, fallback: str) -> str:
+    return name.strip() if name and name.strip() else fallback
+
+
+def _build_intro_text(
+    to_name: str | None,
+    to_number: str,
+    other_name: str,
+    other_number: str,
+    custom_message: str | None,
+    to_role: str,
+) -> str:
+    recipient = _label_for_party(to_name, to_role)
+    intro_body = custom_message.strip() if custom_message and custom_message.strip() else (
+        f"Hi {recipient}, I’m connecting you with {other_name}."
+        f" You can respond to this number directly at {other_number}."
+    )
+    details = (
+        f"\n\nShared intro details:\n"
+        f"{other_name}: {other_number}\n"
+    )
+    return f"{intro_body}{details}"
+
+
+def _build_payload(sender: str, to_number: str, message: str) -> dict[str, object]:
+    return {
+        "to_numbers": [to_number],
+        "text": message,
+        "infer_country_code": False,
+        "from_number": sender,
+    }
+
+
+def _send_single_sms(sender: str, to_number: str, message: str) -> dict[str, object]:
+    payload = _build_payload(sender, to_number, message)
+    return run_generated_json(["sms", "send", "--data", json.dumps(payload)])
+
+
+def main() -> int:
+    if not generated_cli_available():
+        return run_legacy("send_group_intro.py", sys.argv[1:])
+
+    try:
+        args = build_parser().parse_args()
+        if not args.confirm_share:
+            raise WrapperError(
+                "Refusing to send group intro without --confirm-share because it shares phone numbers."
+            )
+        sender_number, sender_source = resolve_sender(
+            args.from_number, args.profile, allow_profile_mismatch=args.allow_profile_mismatch
+        )
+
+        prospect_name = _label_for_party(args.prospect_name, "the prospect")
+        reference_name = _label_for_party(args.reference_name, "the reference")
+
+        prospect_message = _build_intro_text(
+            args.prospect_name,
+            args.prospect,
+            reference_name,
+            args.reference,
+            args.message,
+            "prospect",
+        )
+        reference_message = _build_intro_text(
+            args.reference_name,
+            args.reference,
+            prospect_name,
+            args.prospect,
+            args.message,
+            "reference",
+        )
+
+        if args.dry_run:
+            summary = {
+                "mode": "mirrored_fallback",
+                "sender_number": sender_number,
+                "sender_source": sender_source,
+                "prospect": {
+                    "to": args.prospect,
+                    "message": prospect_message,
+                    "status": "pending",
+                },
+                "reference": {
+                    "to": args.reference,
+                    "message": reference_message,
+                    "status": "pending",
+                },
+                "dry_run": True,
+            }
+            if args.json:
+                print(json.dumps(summary, indent=2))
+            else:
+                print("Dry run: no messages sent")
+                print(f"Mode: {summary['mode']}")
+                print(f"Selected sender: {summary['sender_number']} ({summary['sender_source']})")
+                print(f"Prospect: {summary['prospect']['to']} -> length {len(summary['prospect']['message'])}")
+                print(f"Reference: {summary['reference']['to']} -> length {len(summary['reference']['message'])}")
+            return 0
+
+        require_api_key()
+        prospect_result = _send_single_sms(sender_number, args.prospect, prospect_message)
+        prospect_id = prospect_result.get("id") or "N/A"
+
+        try:
+            reference_result = _send_single_sms(sender_number, args.reference, reference_message)
+        except WrapperError as err:
+            raise WrapperError(
+                "Prospect message sent successfully "
+                f"(first_message_id={prospect_id}). "
+                f"Reference message failed: {err}. This is a partial success state."
+            ) from err
+
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "mode": "mirrored_fallback",
+                        "sender_number": sender_number,
+                        "sender_source": sender_source,
+                        "prospect": {
+                            "to": args.prospect,
+                            "id": prospect_result.get("id"),
+                            "status": prospect_result.get("message_status"),
+                        },
+                        "reference": {
+                            "to": args.reference,
+                            "id": reference_result.get("id"),
+                            "status": reference_result.get("message_status"),
+                        },
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print("Mode: mirrored_fallback")
+            print(f"Selected sender: {sender_number} ({sender_source})")
+            print(
+                "Prospect message: "
+                f"{prospect_result.get('id')} / {prospect_result.get('message_status')}"
+            )
+            print(
+                "Reference message: "
+                f"{reference_result.get('id')} / {reference_result.get('message_status')}"
+            )
+        return 0
+    except WrapperError as err:
+        print_wrapper_error(err)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/send_sms.py
+++ b/bin/send_sms.py
@@ -11,6 +11,7 @@ from _dialpad_compat import (
     generated_cli_available,
     print_wrapper_error,
     require_api_key,
+    resolve_sender,
     run_generated_json,
     run_legacy,
     WrapperError,
@@ -23,9 +24,25 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--to", nargs="+", required=True, help="Recipient E.164 numbers")
     parser.add_argument("--message", required=True, help="SMS text content")
     parser.add_argument("--from", dest="from_number", help="Sender number")
+    parser.add_argument("--profile", choices=("work", "sales"), help="Sender profile")
+    parser.add_argument(
+        "--allow-profile-mismatch",
+        action="store_true",
+        help="Allow --from to differ from mapped profile number",
+    )
     parser.add_argument("--infer-country-code", action="store_true", help="Infer country code from sender")
+    parser.add_argument("--dry-run", action="store_true", help="Print request and selected sender without sending")
     parser.add_argument("--json", action="store_true", help="Output JSON")
     return parser
+
+
+def _build_payload(args, sender_number: str) -> dict[str, object]:
+    return {
+        "to_numbers": args.to,
+        "text": args.message,
+        "infer_country_code": args.infer_country_code,
+        "from_number": sender_number,
+    }
 
 
 
@@ -36,25 +53,41 @@ def main() -> int:
     args = build_parser().parse_args()
 
     try:
+        sender_number, sender_source = resolve_sender(
+            args.from_number, args.profile, allow_profile_mismatch=args.allow_profile_mismatch
+        )
+        payload = _build_payload(args, sender_number)
+
+        if args.dry_run:
+            if args.json:
+                print(json.dumps(
+                    {
+                        "mode": "dry_run",
+                        "command": "sms send",
+                        "sender_number": sender_number,
+                        "sender_source": sender_source,
+                        "payload": payload,
+                    },
+                    indent=2,
+                ))
+            else:
+                print("Dry run: SMS not sent")
+                print(f"Selected sender: {sender_number} ({sender_source})")
+                print(f"To: {', '.join(args.to)}")
+                print(f"Message length: {len(args.message)}")
+            return 0
+
         require_api_key()
-
-        payload = {
-            "to_numbers": args.to,
-            "text": args.message,
-            "infer_country_code": args.infer_country_code,
-        }
-        if args.from_number:
-            payload["from_number"] = args.from_number
-
         result = run_generated_json(["sms", "send", "--data", json.dumps(payload)])
 
         if args.json:
             print(json.dumps(result, indent=2))
         else:
+            print(f"Selected sender: {sender_number} ({sender_source})")
             print("SMS sent successfully!")
             print(f"   ID: {result.get('id', 'N/A')}")
             print(f"   Status: {result.get('message_status') or result.get('status', 'unknown')}")
-            print(f"   From: {result.get('from_number', 'N/A')}")
+            print(f"   From: {sender_number}")
             to_numbers = result.get("to_numbers") or args.to
             print(f"   To: {', '.join(to_numbers)}")
 

--- a/references/api-reference.md
+++ b/references/api-reference.md
@@ -18,6 +18,25 @@
 
 The OpenAPI-generated CLI (`generated/dialpad`) exposes 241 endpoints.
 
+### Wrapper Behavior Notes
+
+- `bin/send_sms.py` resolves sender with precedence:
+  - `--from`
+  - `--profile work|sales`
+  - `DIALPAD_DEFAULT_FROM_NUMBER`
+  - `DIALPAD_DEFAULT_PROFILE`
+- `--profile` maps to configured env vars:
+  - `DIALPAD_PROFILE_WORK_FROM`
+  - `DIALPAD_PROFILE_SALES_FROM`
+- `--allow-profile-mismatch` bypasses strict profile/number binding.
+- `--dry-run` shows resolved sender and intended payload without sending.
+- `bin/send_group_intro.py` performs a mirrored fallback (`mode: mirrored_fallback`) by sending two separate one-to-one SMS messages because the wrapper does not guarantee a true group thread.
+
+```bash
+bin/send_sms.py --to "+14155550111" --message "Hello" --profile work
+bin/send_group_intro.py --prospect "+14155550111" --reference "+14155559999" --confirm-share --from "+14153602954"
+```
+
 ### Campaign & Automation
 ```bash
 # Bulk SMS campaigns

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -4,6 +4,7 @@
 Dialpad SMS Skill
 ├── bin/                          # Backward-compatible wrappers
 │   ├── send_sms.py              # Send SMS (wrapper → dialpad sms send)
+│   ├── send_group_intro.py       # Mirrored intro fallback (prospect/reference one-to-one)
 │   ├── make_call.py             # Make voice calls (wrapper → dialpad call make)
 │   ├── lookup_contact.py        # Contact lookup (wrapper → dialpad contact lookup)
 │   ├── create_contact.py        # Contact create/upsert (wrapper → dialpad contacts create)
@@ -35,6 +36,8 @@ Legacy scripts in `bin/` provide backward compatibility while delegating to the 
 2. **Transforms** to generated CLI format (payload JSON)
 3. **Executes** `generated/dialpad` with proper auth
 4. **Returns** results in legacy format
+
+`send_group_intro.py` shares sender-resolution helpers with `send_sms.py` and intentionally falls back to mirrored one-to-one sends (`mirrored_fallback`) because true group thread support is not guaranteed by this wrapper.
 
 This allows gradual migration: old scripts keep working, new features accessible via `generated/dialpad` directly.
 

--- a/scripts/parity-check.sh
+++ b/scripts/parity-check.sh
@@ -17,6 +17,7 @@ declare -a legacy_scripts=(
   "create_sms_webhook.py"
   "create_contact.py"
   "update_contact.py"
+  "send_group_intro.py"
 )
 
 declare -A wrapper_map=(
@@ -27,6 +28,7 @@ declare -A wrapper_map=(
   [create_sms_webhook.py]="bin/create_sms_webhook.py"
   [create_contact.py]="bin/create_contact.py"
   [update_contact.py]="bin/update_contact.py"
+  [send_group_intro.py]="bin/send_group_intro.py"
 )
 
 declare -A new_command_map=(
@@ -37,6 +39,7 @@ declare -A new_command_map=(
   [create_sms_webhook.py]="webhook create"
   [create_contact.py]="contacts contacts.create"
   [update_contact.py]="contacts contacts.update"
+  [send_group_intro.py]="sms send"
 )
 
 failures=0
@@ -49,7 +52,7 @@ for script in "${legacy_scripts[@]}"; do
   wrapper_ok="ok"
   cmd_ok="ok"
 
-  if [[ "$script" == "create_contact.py" || "$script" == "update_contact.py" ]]; then
+  if [[ "$script" == "create_contact.py" || "$script" == "update_contact.py" || "$script" == "send_group_intro.py" ]]; then
     legacy_ok="n/a"
   elif [[ ! -f "$script" ]]; then
     legacy_ok="missing"

--- a/tests/test_send_sms_group_intro.py
+++ b/tests/test_send_sms_group_intro.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "bin"))
+
+import send_sms
+from _dialpad_compat import WrapperError
+import send_group_intro
+
+
+class SendSmsWrapperTests(unittest.TestCase):
+    def _run_main(self, module, args):
+        with patch.object(sys, "argv", ["bin/send_sms.py", *args]):
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                code = module.main()
+        return code, stdout.getvalue(), stderr.getvalue()
+
+    def test_send_sms_requires_sender_without_flags_or_env(self):
+        with patch("send_sms.generated_cli_available", return_value=True), \
+                patch("send_sms.require_api_key"), \
+                patch.dict("os.environ", {
+                    "DIALPAD_DEFAULT_PROFILE": "",
+                    "DIALPAD_DEFAULT_FROM_NUMBER": "",
+                    "DIALPAD_PROFILE_WORK_FROM": "",
+                    "DIALPAD_PROFILE_SALES_FROM": "",
+                }, clear=False), \
+                patch("send_sms.run_generated_json"):
+            code, out, err = self._run_main(send_sms, [
+                "--to", "+14155550111",
+                "--message", "Hello",
+            ])
+
+        self.assertEqual(code, 2)
+        self.assertEqual(out, "")
+        self.assertIn("No sender resolved", err)
+        self.assertIn("Provide --from", err)
+
+    def test_send_sms_resolves_profile_mapping(self):
+        calls: list[list[str]] = []
+
+        def fake_run_generated(cmd: list[str]):
+            calls.append(cmd)
+            return {"id": "msg-1", "status": "pending"}
+
+        with patch("send_sms.generated_cli_available", return_value=True), \
+                patch("send_sms.require_api_key"), \
+                patch.dict("os.environ", {"DIALPAD_PROFILE_WORK_FROM": "+14153602954"}, clear=False), \
+                patch("send_sms.run_generated_json", side_effect=fake_run_generated):
+            code, out, err = self._run_main(send_sms, [
+                "--to", "+14155550111",
+                "--profile", "work",
+                "--message", "Hello",
+            ])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(err, "")
+        self.assertIn("Selected sender: +14153602954", out)
+        payload = json.loads(calls[0][3])
+        self.assertEqual(payload["from_number"], "+14153602954")
+
+    def test_send_sms_profile_requires_configured_sender(self):
+        with patch("send_sms.generated_cli_available", return_value=True), \
+                patch("send_sms.require_api_key"), \
+                patch.dict("os.environ", {"DIALPAD_PROFILE_WORK_FROM": ""}, clear=False), \
+                patch("send_sms.run_generated_json"):
+            code, out, err = self._run_main(send_sms, [
+                "--to", "+14155550111",
+                "--profile", "work",
+                "--message", "Hello",
+            ])
+
+        self.assertEqual(code, 2)
+        self.assertEqual(out, "")
+        self.assertIn("Profile 'work' is not configured", err)
+
+    def test_send_sms_rejects_invalid_default_from_number(self):
+        with patch("send_sms.generated_cli_available", return_value=True), \
+                patch("send_sms.require_api_key"), \
+                patch.dict("os.environ", {"DIALPAD_DEFAULT_FROM_NUMBER": "not-a-number"}, clear=False), \
+                patch("send_sms.run_generated_json"):
+            code, out, err = self._run_main(send_sms, [
+                "--to", "+14155550111",
+                "--message", "Hello",
+            ])
+
+        self.assertEqual(code, 2)
+        self.assertEqual(out, "")
+        self.assertIn("Invalid sender number", err)
+
+    def test_send_sms_conflict_between_from_and_profile(self):
+        with patch("send_sms.generated_cli_available", return_value=True), \
+                patch("send_sms.require_api_key"), \
+                patch.dict("os.environ", {"DIALPAD_PROFILE_WORK_FROM": "+14153602954"}, clear=False), \
+                patch("send_sms.run_generated_json"):
+            code, out, err = self._run_main(send_sms, [
+                "--to", "+14155550111",
+                "--from", "+14155201316",
+                "--profile", "work",
+                "--message", "Hello",
+            ])
+
+        self.assertEqual(code, 2)
+        self.assertEqual(out, "")
+        self.assertIn("--from conflicts with --profile", err)
+
+    def test_send_sms_allows_profile_conflict_with_override(self):
+        calls: list[list[str]] = []
+
+        def fake_run_generated(cmd: list[str]):
+            calls.append(cmd)
+            return {"id": "msg-1", "message_status": "pending"}
+
+        with patch("send_sms.generated_cli_available", return_value=True), \
+                patch("send_sms.require_api_key"), \
+                patch.dict("os.environ", {"DIALPAD_PROFILE_WORK_FROM": "+14153602954"}, clear=False), \
+                patch("send_sms.run_generated_json", side_effect=fake_run_generated):
+            code, out, err = self._run_main(send_sms, [
+                "--to", "+14155550111",
+                "--from", "+14155201316",
+                "--profile", "work",
+                "--allow-profile-mismatch",
+                "--message", "Hello",
+            ])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(err, "")
+        payload = json.loads(calls[0][3])
+        self.assertEqual(payload["from_number"], "+14155201316")
+        self.assertIn("Selected sender: +14155201316", out)
+
+    def test_send_sms_dry_run_does_not_call_api(self):
+        with patch("send_sms.generated_cli_available", return_value=True), \
+                patch("send_sms.require_api_key") as require_key, \
+                patch("send_sms.run_generated_json") as run_json:
+            code, out, err = self._run_main(send_sms, [
+                "--to", "+14155550111",
+                "--from", "+14155201316",
+                "--message", "Hello",
+                "--dry-run",
+            ])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(err, "")
+        self.assertEqual(require_key.call_count, 0)
+        self.assertEqual(run_json.call_count, 0)
+        self.assertIn("Dry run: SMS not sent", out)
+        self.assertIn("Selected sender: +14155201316", out)
+
+
+class SendGroupIntroTests(unittest.TestCase):
+    def _run_main(self, args):
+        with patch.object(sys, "argv", ["bin/send_group_intro.py", *args]):
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                code = send_group_intro.main()
+        return code, stdout.getvalue(), stderr.getvalue()
+
+    def test_send_group_intro_requires_confirm_share(self):
+        with patch("send_group_intro.generated_cli_available", return_value=True), \
+                patch("send_group_intro.require_api_key"):
+            code, out, err = self._run_main([
+                "--prospect", "+14155550111",
+                "--reference", "+14155559999",
+                "--from", "+14155201316",
+                "--message", "Please connect",
+            ])
+
+        self.assertEqual(code, 2)
+        self.assertEqual(out, "")
+        self.assertIn("without --confirm-share", err)
+
+    def test_send_group_intro_dry_run_outputs_structure(self):
+        with patch("send_group_intro.generated_cli_available", return_value=True), \
+                patch("send_group_intro.require_api_key") as require_key, \
+                patch("send_group_intro.run_generated_json") as run_json:
+            code, out, err = self._run_main([
+                "--prospect", "+14155550111",
+                "--reference", "+14155559999",
+                "--from", "+14155201316",
+                "--confirm-share",
+                "--dry-run",
+                "--json",
+            ])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(err, "")
+        self.assertEqual(require_key.call_count, 0)
+        self.assertEqual(run_json.call_count, 0)
+        parsed = json.loads(out)
+        self.assertEqual(parsed["mode"], "mirrored_fallback")
+        self.assertTrue(parsed["dry_run"])
+        self.assertEqual(parsed["prospect"]["to"], "+14155550111")
+        self.assertEqual(parsed["reference"]["to"], "+14155559999")
+
+    def test_send_group_intro_success_sends_two_messages(self):
+        calls: list[list[str]] = []
+
+        def fake_run_generated(cmd: list[str]):
+            calls.append(cmd)
+            if len(calls) == 1:
+                return {"id": "prospect-msg", "message_status": "pending"}
+            return {"id": "reference-msg", "message_status": "pending"}
+
+        with patch("send_group_intro.generated_cli_available", return_value=True), \
+                patch("send_group_intro.require_api_key"), \
+                patch("send_group_intro.run_generated_json", side_effect=fake_run_generated):
+            code, out, err = self._run_main([
+                "--prospect", "+14155550111",
+                "--reference", "+14155559999",
+                "--from", "+14155201316",
+                "--confirm-share",
+                "--json",
+            ])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(err, "")
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0][:2], ["sms", "send"])
+        self.assertEqual(calls[1][:2], ["sms", "send"])
+        payload_a = json.loads(calls[0][3])
+        payload_b = json.loads(calls[1][3])
+        self.assertEqual(payload_a["to_numbers"], ["+14155550111"])
+        self.assertEqual(payload_b["to_numbers"], ["+14155559999"])
+        self.assertEqual(payload_a["from_number"], "+14155201316")
+        self.assertEqual(payload_b["from_number"], "+14155201316")
+        parsed = json.loads(out)
+        self.assertEqual(parsed["mode"], "mirrored_fallback")
+        self.assertEqual(parsed["prospect"]["id"], "prospect-msg")
+        self.assertEqual(parsed["reference"]["id"], "reference-msg")
+
+    def test_send_group_intro_partial_failure_returns_first_message_id(self):
+        calls: list[list[str]] = []
+
+        def fake_run_generated(cmd: list[str]):
+            calls.append(cmd)
+            if len(calls) == 1:
+                return {"id": "prospect-msg", "message_status": "pending"}
+            raise WrapperError("Boom")
+
+        with patch("send_group_intro.generated_cli_available", return_value=True), \
+                patch("send_group_intro.require_api_key"), \
+                patch("send_group_intro.run_generated_json", side_effect=fake_run_generated):
+            code, out, err = self._run_main([
+                "--prospect", "+14155550111",
+                "--reference", "+14155559999",
+                "--from", "+14155201316",
+                "--confirm-share",
+            ])
+
+        self.assertEqual(code, 2)
+        self.assertEqual(out, "")
+        self.assertEqual(len(calls), 2)
+        self.assertIn("first_message_id=prospect-msg", err)
+        self.assertIn("partial success", err.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What
- add sender routing safety to `bin/send_sms.py`:
  - `--profile work|sales`
  - explicit sender resolution order (`--from` > `--profile` > `DIALPAD_DEFAULT_FROM_NUMBER` > `DIALPAD_DEFAULT_PROFILE`)
  - mismatch guard for `--from` vs `--profile` with `--allow-profile-mismatch` override
  - strict E.164 sender validation for env/flag-derived sender values
  - `--dry-run` mode that resolves sender + prints payload intent without requiring API auth or sending
- add `bin/send_group_intro.py` for referral-style intros:
  - requires `--confirm-share`
  - mirrored fallback flow (two one-to-one messages) with `mode: mirrored_fallback`
  - partial-failure handling includes first message ID and actionable error
  - supports `--from` / `--profile` / dry-run / json output
- extend parity checks for `send_group_intro.py`
- update docs (`README.md`, `SKILL.md`, `references/api-reference.md`, `references/architecture.md`) for sender profiles and group intro behavior/limitations
- add tests in `tests/test_send_sms_group_intro.py` for sender resolution, validation, dry-run behavior, and group intro success/failure paths

## Why
- closes #28 by making sender selection explicit, safer, and deterministic for work-vs-sales routing
- closes #27 by providing a first-class group-intro command path with clear mirrored fallback semantics

## Tests
- `python3 -m unittest discover -s tests -p 'test_*.py'`
- `bash scripts/parity-check.sh`
- `pytest -q`
- `codex review --base main`

## AI Assistance
- AI-assisted: yes (Codex CLI implementation + review)
- Testing level: full touched-scope tests + parity + codex review
- Prompt/session log: local Codex CLI runs in this branch
- I understand this code: yes

Closes #27
Closes #28
