### PR TITLE
fix(sms): address PR29 codex review follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,12 @@ python3 send_sms.py --to "+14155551234" "+14155555678" --message "Group message"
 # From specific caller ID
 python3 send_sms.py --to "+14155551234" --message "Hello!" --from "+14159901234"
 
-# Send using a named sender profile
-python3 send_sms.py --to "+14155551234" --message "Hello!" --profile work
+# Send using a named sender profile (wrapper)
+python3 bin/send_sms.py --to "+14155551234" --message "Hello!" --profile work
 
-# Use default profile
+# Use default profile (wrapper)
 export DIALPAD_DEFAULT_PROFILE=work
-python3 send_sms.py --to "+14155551234" --message "Hello!"
+python3 bin/send_sms.py --to "+14155551234" --message "Hello!"
 ```
 
 Sender resolution in `bin/send_sms.py`:

--- a/bin/send_sms.py
+++ b/bin/send_sms.py
@@ -47,10 +47,17 @@ def _build_payload(args, sender_number: str) -> dict[str, object]:
 
 
 def main() -> int:
-    if not generated_cli_available():
-        return run_legacy("send_sms.py", sys.argv[1:])
-
     args = build_parser().parse_args()
+
+    if not generated_cli_available():
+        if args.profile or args.allow_profile_mismatch or args.dry_run:
+            print_wrapper_error(
+                WrapperError(
+                    "This command requires generated/dialpad for --profile, --allow-profile-mismatch, and --dry-run."
+                )
+            )
+            return 2
+        return run_legacy("send_sms.py", sys.argv[1:])
 
     try:
         sender_number, sender_source = resolve_sender(

--- a/tests/test_send_sms_group_intro.py
+++ b/tests/test_send_sms_group_intro.py
@@ -155,6 +155,20 @@ class SendSmsWrapperTests(unittest.TestCase):
         self.assertIn("Dry run: SMS not sent", out)
         self.assertIn("Selected sender: +14155201316", out)
 
+    def test_send_sms_rejects_new_flags_when_generated_cli_unavailable(self):
+        with patch("send_sms.generated_cli_available", return_value=False), \
+                patch("send_sms.run_legacy") as run_legacy:
+            code, out, err = self._run_main(send_sms, [
+                "--to", "+14155550111",
+                "--message", "Hello",
+                "--profile", "work",
+            ])
+
+        self.assertEqual(code, 2)
+        self.assertEqual(out, "")
+        self.assertEqual(run_legacy.call_count, 0)
+        self.assertIn("requires generated/dialpad", err)
+
 
 class SendGroupIntroTests(unittest.TestCase):
     def _run_main(self, args):


### PR DESCRIPTION
## What
- fix README sender-profile examples to use `bin/send_sms.py` (wrapper that actually supports `--profile`)
- tighten wrapper fallback behavior in `bin/send_sms.py`:
  - parse args before fallback decision
  - if generated CLI is unavailable and wrapper-only flags are used (`--profile`, `--allow-profile-mismatch`, `--dry-run`), fail with explicit compatibility error instead of forwarding to legacy argparse failure
- add regression test for this fallback guard in `tests/test_send_sms_group_intro.py`

## Why
Addresses Codex feedback on PR #29:
- docs mismatch for profile command examples
- unsupported wrapper-only flags being forwarded into legacy fallback path

## Tests
- `python3 -m unittest tests/test_send_sms_group_intro.py`
- `python3 -m unittest discover -s tests -p 'test_*.py'`
- `bash scripts/parity-check.sh`
- `pytest -q`
- `codex review --base main`

## AI Assistance
- AI-assisted: yes (Codex review + implementation)
- Testing level: full touched-scope tests + full suite pass
- I understand this code: yes

Refs:
- https://github.com/kesslerio/dialpad-openclaw-skill/pull/29#pullrequestreview-3851398293
