### PR TITLE
refactor(wrappers): remove legacy fallback execution paths

### DIFF
--- a/bin/create_contact.py
+++ b/bin/create_contact.py
@@ -6,15 +6,13 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import sys
 from typing import Any
 
 from _dialpad_compat import (
-    generated_cli_available,
     print_wrapper_error,
+    require_generated_cli,
     require_api_key,
     run_generated_json,
-    run_legacy,
     WrapperError,
 )
 
@@ -279,12 +277,10 @@ def sync_local_contact(
 
 
 def main() -> int:
-    if not generated_cli_available():
-        return run_legacy("create_contact.py", sys.argv[1:])
-
     args = build_parser().parse_args()
 
     try:
+        require_generated_cli()
         require_api_key()
 
         phones = parse_repeated(args.phone)

--- a/bin/create_sms_webhook.py
+++ b/bin/create_sms_webhook.py
@@ -5,15 +5,13 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from typing import Any
 
 from _dialpad_compat import (
-    generated_cli_available,
     print_wrapper_error,
+    require_generated_cli,
     require_api_key,
     run_generated_json,
-    run_legacy,
     WrapperError,
 )
 
@@ -162,12 +160,10 @@ def handle_webhooks(args: argparse.Namespace) -> int:
 
 
 def main() -> int:
-    if not generated_cli_available():
-        return run_legacy("create_sms_webhook.py", sys.argv[1:])
-
     args = build_parser().parse_args()
 
     try:
+        require_generated_cli()
         require_api_key()
 
         if args.command == "create":

--- a/bin/export_sms.py
+++ b/bin/export_sms.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 import time
 import urllib.error
 import urllib.request
@@ -13,11 +12,10 @@ from datetime import date, datetime
 from typing import Any
 
 from _dialpad_compat import (
-    generated_cli_available,
     print_wrapper_error,
+    require_generated_cli,
     require_api_key,
     run_generated_json,
-    run_legacy,
     WrapperError,
 )
 
@@ -108,12 +106,10 @@ def poll_for_completion(request_id: str, timeout: int, interval: int) -> dict[st
 
 
 def main() -> int:
-    if not generated_cli_available():
-        return run_legacy("export_sms.py", sys.argv[1:])
-
     args = build_parser().parse_args()
 
     try:
+        require_generated_cli()
         require_api_key()
 
         payload = build_payload(args.start_date, args.end_date, args.office_id)

--- a/bin/lookup_contact.py
+++ b/bin/lookup_contact.py
@@ -10,11 +10,10 @@ import sys
 from typing import Any
 
 from _dialpad_compat import (
-    generated_cli_available,
     print_wrapper_error,
+    require_generated_cli,
     require_api_key,
     run_generated_json,
-    run_legacy,
     WrapperError,
 )
 
@@ -95,9 +94,6 @@ def find_contact(query: str, owner_id: str | None, include_local: bool, max_page
 
 
 def main() -> int:
-    if not generated_cli_available():
-        return run_legacy("lookup_contact.py", sys.argv[1:])
-
     args = build_parser().parse_args()
 
     query = args.query or args.query_pos
@@ -106,6 +102,7 @@ def main() -> int:
         return 2
 
     try:
+        require_generated_cli()
         require_api_key()
         match = find_contact(query, args.owner_id, args.include_local, args.max_pages)
 

--- a/bin/make_call.py
+++ b/bin/make_call.py
@@ -6,14 +6,12 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import sys
 
 from _dialpad_compat import (
-    generated_cli_available,
     print_wrapper_error,
+    require_generated_cli,
     require_api_key,
     run_generated_json,
-    run_legacy,
     WrapperError,
 )
 
@@ -68,12 +66,10 @@ def resolve_user_id(from_number: str | None, explicit_user_id: str | None) -> st
 
 
 def main() -> int:
-    if not generated_cli_available():
-        return run_legacy("make_call.py", sys.argv[1:])
-
     args = build_parser().parse_args()
 
     try:
+        require_generated_cli()
         require_api_key()
         user_id = resolve_user_id(args.from_number, args.user_id)
 

--- a/bin/send_group_intro.py
+++ b/bin/send_group_intro.py
@@ -5,15 +5,13 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 
 from _dialpad_compat import (
-    generated_cli_available,
     print_wrapper_error,
+    require_generated_cli,
     require_api_key,
     resolve_sender,
     run_generated_json,
-    run_legacy,
     WrapperError,
 )
 
@@ -81,10 +79,8 @@ def _send_single_sms(sender: str, to_number: str, message: str) -> dict[str, obj
 
 
 def main() -> int:
-    if not generated_cli_available():
-        return run_legacy("send_group_intro.py", sys.argv[1:])
-
     try:
+        require_generated_cli()
         args = build_parser().parse_args()
         if not args.confirm_share:
             raise WrapperError(

--- a/bin/send_sms.py
+++ b/bin/send_sms.py
@@ -5,15 +5,13 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 
 from _dialpad_compat import (
-    generated_cli_available,
     print_wrapper_error,
+    require_generated_cli,
     require_api_key,
     resolve_sender,
     run_generated_json,
-    run_legacy,
     WrapperError,
 )
 
@@ -49,17 +47,8 @@ def _build_payload(args, sender_number: str) -> dict[str, object]:
 def main() -> int:
     args = build_parser().parse_args()
 
-    if not generated_cli_available():
-        if args.profile or args.allow_profile_mismatch or args.dry_run:
-            print_wrapper_error(
-                WrapperError(
-                    "This command requires generated/dialpad for --profile, --allow-profile-mismatch, and --dry-run."
-                )
-            )
-            return 2
-        return run_legacy("send_sms.py", sys.argv[1:])
-
     try:
+        require_generated_cli()
         sender_number, sender_source = resolve_sender(
             args.from_number, args.profile, allow_profile_mismatch=args.allow_profile_mismatch
         )

--- a/bin/update_contact.py
+++ b/bin/update_contact.py
@@ -6,15 +6,13 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import sys
 from typing import Any
 
 from _dialpad_compat import (
-    generated_cli_available,
     print_wrapper_error,
+    require_generated_cli,
     require_api_key,
     run_generated_json,
-    run_legacy,
     WrapperError,
 )
 
@@ -118,12 +116,10 @@ def clear_not_found_error(contact_id: str, message: str) -> None:
 
 
 def main() -> int:
-    if not generated_cli_available():
-        return run_legacy("update_contact.py", sys.argv[1:])
-
     args = build_parser().parse_args()
 
     try:
+        require_generated_cli()
         require_api_key()
 
         phones = parse_repeated(args.phone)

--- a/tests/test_create_contact.py
+++ b/tests/test_create_contact.py
@@ -32,7 +32,7 @@ class CreateContactTests(unittest.TestCase):
                 return {"id": "contact-123"}
             raise AssertionError(f"Unexpected command: {cmd}")
 
-        with patch("create_contact.generated_cli_available", return_value=True), \
+        with patch("create_contact.require_generated_cli"), \
                 patch("create_contact.require_api_key"), \
                 patch("create_contact.run_generated_json", side_effect=fake_run_generated):
             code, out, err = self._run_main([
@@ -59,7 +59,7 @@ class CreateContactTests(unittest.TestCase):
         self.assertEqual(payload["emails"], ["alice@example.com"])
 
     def test_create_contact_api_error_propagates(self):
-        with patch("create_contact.generated_cli_available", return_value=True), \
+        with patch("create_contact.require_generated_cli"), \
                 patch("create_contact.require_api_key"), \
                 patch("create_contact.run_generated_json", side_effect=WrapperError("permission denied")):
             code, out, err = self._run_main([
@@ -91,7 +91,7 @@ class CreateContactTests(unittest.TestCase):
                 return {"id": "contact-555"}
             raise AssertionError(f"Unexpected command: {cmd}")
 
-        with patch("create_contact.generated_cli_available", return_value=True), \
+        with patch("create_contact.require_generated_cli"), \
                 patch("create_contact.require_api_key"), \
                 patch("create_contact.run_generated_json", side_effect=fake_run_generated):
             code, out, err = self._run_main([
@@ -123,7 +123,7 @@ class CreateContactTests(unittest.TestCase):
                 return {"id": "shared-1"}
             raise AssertionError(f"Unexpected command: {cmd}")
 
-        with patch("create_contact.generated_cli_available", return_value=True), \
+        with patch("create_contact.require_generated_cli"), \
                 patch("create_contact.require_api_key"), \
                 patch("create_contact.run_generated_json", side_effect=fake_run_generated):
             code, out, err = self._run_main([
@@ -163,7 +163,7 @@ class CreateContactTests(unittest.TestCase):
                 return {"id": "contact-777"}
             raise AssertionError(f"Unexpected command: {cmd}")
 
-        with patch("create_contact.generated_cli_available", return_value=True), \
+        with patch("create_contact.require_generated_cli"), \
                 patch("create_contact.require_api_key"), \
                 patch("create_contact.run_generated_json", side_effect=fake_run_generated):
             code, out, err = self._run_main([
@@ -195,7 +195,7 @@ class CreateContactTests(unittest.TestCase):
                 return {"id": "shared-1"}
             raise AssertionError(f"Unexpected command: {cmd}")
 
-        with patch("create_contact.generated_cli_available", return_value=True), \
+        with patch("create_contact.require_generated_cli"), \
                 patch("create_contact.require_api_key"), \
                 patch("create_contact.run_generated_json", side_effect=fake_run_generated):
             code, out, err = self._run_main([
@@ -227,7 +227,7 @@ class CreateContactTests(unittest.TestCase):
                 }
             raise AssertionError(f"Unexpected command: {cmd}")
 
-        with patch("create_contact.generated_cli_available", return_value=True), \
+        with patch("create_contact.require_generated_cli"), \
                 patch("create_contact.require_api_key"), \
                 patch("create_contact.run_generated_json", side_effect=fake_run_generated):
             code, out, err = self._run_main([
@@ -251,7 +251,7 @@ class CreateContactTests(unittest.TestCase):
                 }
             raise AssertionError(f"Unexpected command: {cmd}")
 
-        with patch("create_contact.generated_cli_available", return_value=True), \
+        with patch("create_contact.require_generated_cli"), \
                 patch("create_contact.require_api_key"), \
                 patch("create_contact.run_generated_json", side_effect=fake_run_generated):
             code, out, err = self._run_main([
@@ -267,7 +267,7 @@ class CreateContactTests(unittest.TestCase):
         self.assertIn("Ambiguous contact match", err)
 
     def test_create_contact_rejects_zero_max_pages(self):
-        with patch("create_contact.generated_cli_available", return_value=True), \
+        with patch("create_contact.require_generated_cli"), \
                 patch("create_contact.require_api_key"), \
                 patch("create_contact.run_generated_json"):
             code, out, err = self._run_main([
@@ -282,7 +282,7 @@ class CreateContactTests(unittest.TestCase):
         self.assertIn("Invalid --max-pages value. Use a positive integer.", err)
 
     def test_create_contact_rejects_negative_max_pages(self):
-        with patch("create_contact.generated_cli_available", return_value=True), \
+        with patch("create_contact.require_generated_cli"), \
                 patch("create_contact.require_api_key"), \
                 patch("create_contact.run_generated_json"):
             code, out, err = self._run_main([
@@ -295,6 +295,20 @@ class CreateContactTests(unittest.TestCase):
         self.assertEqual(code, 2)
         self.assertEqual(out, "")
         self.assertIn("Invalid --max-pages value. Use a positive integer.", err)
+
+    def test_create_contact_fails_when_generated_cli_unavailable(self):
+        with patch(
+            "create_contact.require_generated_cli",
+            side_effect=WrapperError("Generated CLI not found at /tmp/generated/dialpad"),
+        ):
+            code, out, err = self._run_main([
+                "--first-name", "Alice",
+                "--last-name", "Miller",
+            ])
+
+        self.assertEqual(code, 2)
+        self.assertEqual(out, "")
+        self.assertIn("Generated CLI not found", err)
 
 
 if __name__ == "__main__":

--- a/tests/test_wrapper_missing_generated_cli.py
+++ b/tests/test_wrapper_missing_generated_cli.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import io
+import sys
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "bin"))
+
+import create_sms_webhook
+import export_sms
+import lookup_contact
+import make_call
+from _dialpad_compat import WrapperError
+
+
+class MissingGeneratedCliTests(unittest.TestCase):
+    def _run(self, module, argv: list[str]) -> tuple[int, str, str]:
+        with patch.object(sys, "argv", argv):
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                code = module.main()
+        return code, stdout.getvalue(), stderr.getvalue()
+
+    def test_make_call_fails_when_generated_cli_unavailable(self):
+        with patch(
+            "make_call.require_generated_cli",
+            side_effect=WrapperError("Generated CLI not found at /tmp/generated/dialpad"),
+        ):
+            code, out, err = self._run(make_call, ["bin/make_call.py", "--to", "+14155550111"])
+
+        self.assertEqual(code, 2)
+        self.assertEqual(out, "")
+        self.assertIn("Generated CLI not found", err)
+
+    def test_lookup_contact_fails_when_generated_cli_unavailable(self):
+        with patch(
+            "lookup_contact.require_generated_cli",
+            side_effect=WrapperError("Generated CLI not found at /tmp/generated/dialpad"),
+        ):
+            code, out, err = self._run(lookup_contact, ["bin/lookup_contact.py", "+14155550111"])
+
+        self.assertEqual(code, 2)
+        self.assertEqual(out, "")
+        self.assertIn("Generated CLI not found", err)
+
+    def test_create_sms_webhook_fails_when_generated_cli_unavailable(self):
+        with patch(
+            "create_sms_webhook.require_generated_cli",
+            side_effect=WrapperError("Generated CLI not found at /tmp/generated/dialpad"),
+        ):
+            code, out, err = self._run(
+                create_sms_webhook,
+                ["bin/create_sms_webhook.py", "list"],
+            )
+
+        self.assertEqual(code, 2)
+        self.assertEqual(out, "")
+        self.assertIn("Generated CLI not found", err)
+
+    def test_export_sms_fails_when_generated_cli_unavailable(self):
+        with patch(
+            "export_sms.require_generated_cli",
+            side_effect=WrapperError("Generated CLI not found at /tmp/generated/dialpad"),
+        ):
+            code, out, err = self._run(export_sms, ["bin/export_sms.py"])
+
+        self.assertEqual(code, 2)
+        self.assertEqual(out, "")
+        self.assertIn("Generated CLI not found", err)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove runtime fallback from all `bin/*` wrappers to legacy `scripts/*` entrypoints
- add shared `require_generated_cli()` guard in `bin/_dialpad_compat.py`
- remove `run_legacy()` helper from compat layer
- update wrapper tests to assert deterministic missing-CLI failure
- add consolidated missing-CLI tests for uncovered wrappers (`make_call`, `lookup_contact`, `create_sms_webhook`, `export_sms`)

## Why
Agent-facing wrapper behavior is now deterministic: wrappers either execute via generated CLI or fail fast with a clear error and exit code `2`.

Closes #34

## Validation
- `python3 -m unittest -v tests.test_send_sms_group_intro`
- `python3 -m unittest -v tests.test_create_contact`
- `python3 -m unittest -v tests.test_update_contact`
- `python3 -m unittest -v tests.test_wrapper_missing_generated_cli`
- `python3 -m unittest discover -s tests -v`
