### PR TITLE
fix(webhook): harden missed-call history backfill evidence gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,6 @@
 - fix(webhook): add deterministic resolution paths (`payload_direct`, `payload_inferred`, `history_backfill`, `unresolved`) and include them in debug logs.
 - fix(webhook): backfill unresolved missed-call caller/line from recent Dialpad call history near event timestamp (non-blocking).
 - test(webhook): cover nested payload parsing, inferred line labels, history backfill, and unresolved guard behavior.
+- fix(webhook): require caller/line match evidence before applying missed-call history backfill to unresolved fields.
+- fix(webhook): treat unparsable call-history duration as unknown (`None`) instead of missed (`0`) to avoid false missed-like classification.
+- test(webhook): add regressions for no-match backfill rejection and duration-parse-failure non-missed behavior.

--- a/THEORY.MD
+++ b/THEORY.MD
@@ -61,6 +61,8 @@ Concrete discoveries from this cycle:
 - `401` is not a single diagnosis; remediation depends on classification (expired token vs scope vs environment/audience mismatch).
 - Inbound paths must share one enrichment result per event to avoid inconsistent outputs and duplicated failure surfaces.
 - Sparse/inconsistent webhook payloads are common enough that missed-call handling must be multi-stage (`payload_direct` → `payload_inferred` → `history_backfill`), with explicit unresolved semantics.
+- History backfill must be evidence-gated: inbound+missed-like is necessary but not sufficient; at least one normalized caller/line match should exist before enriching unresolved fields.
+- Missing or unparsable duration should remain unknown (`None`) rather than coerced to zero, otherwise answered/ambiguous rows can be misclassified as missed-like.
 - Preserving graceful behavior (webhook continuity) and increasing observability are compatible if failure semantics are structured.
 
 ## Open Questions

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -786,7 +786,7 @@ def _extract_call_history_row(call):
     try:
         duration = int(float(str(duration_raw)))
     except (TypeError, ValueError):
-        duration = 0
+        duration = None
     return {
         "from_number": from_number,
         "to_number": to_number,
@@ -913,18 +913,21 @@ def resolve_missed_call_context(data, history_fetcher=None):
                 score += 1
             row_from_norm = normalize_phone_number(row["from_number"])
             row_to_norm = normalize_phone_number(row["to_number"])
-            if caller_norm and row_from_norm and caller_norm == row_from_norm:
+            caller_match = bool(caller_norm and row_from_norm and caller_norm == row_from_norm)
+            line_match = bool(line_norm and row_to_norm and line_norm == row_to_norm)
+            if caller_match:
                 score += 3
-            if line_norm and row_to_norm and line_norm == row_to_norm:
+            if line_match:
                 score += 3
             row["_missed_inbound"] = bool(is_inbound and is_missed_like)
+            row["_has_match_evidence"] = bool(caller_match or line_match)
             time_delta = abs((row["started_ms"] or event_ts_ms) - event_ts_ms) if event_ts_ms is not None else 0
-            ranking = (1 if row["_missed_inbound"] else 0, score, -time_delta)
+            ranking = (1 if row["_missed_inbound"] else 0, 1 if row["_has_match_evidence"] else 0, score, -time_delta)
             if best is None or ranking > best_key:
                 best = row
                 best_key = ranking
 
-        if best and best.get("_missed_inbound") and best_key[1] >= 2:
+        if best and best.get("_missed_inbound") and best.get("_has_match_evidence"):
             if caller_path == "unresolved" and best.get("from_number"):
                 from_number = best["from_number"]
                 caller_path = "history_backfill"

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -132,6 +132,7 @@ class MissedCallResolutionTests(unittest.TestCase):
         payload = {
             "date_started": 1760000000000,
             "event_type": "call.missed",
+            "from_number": "+14155550999",
         }
 
         def fake_history(_event_ts_ms):
@@ -151,7 +152,7 @@ class MissedCallResolutionTests(unittest.TestCase):
         resolved = resolve_missed_call_context(payload, history_fetcher=fake_history)
         self.assertEqual(resolved["from_number"], "+14155550999")
         self.assertEqual(resolved["to_number"], "+14159917155")
-        self.assertEqual(resolved["caller_resolution_path"], "history_backfill")
+        self.assertEqual(resolved["caller_resolution_path"], "payload_direct")
         self.assertEqual(resolved["line_resolution_path"], "history_backfill")
 
     def test_unresolved_guard_behavior(self):
@@ -181,6 +182,54 @@ class MissedCallResolutionTests(unittest.TestCase):
         self.assertEqual(resolved["from_number"], "Unknown")
         self.assertIsNone(resolved["line_display"])
         self.assertEqual(resolved["caller_resolution_path"], "unresolved")
+        self.assertEqual(resolved["line_resolution_path"], "unresolved")
+
+    def test_history_backfill_requires_number_match_evidence(self):
+        payload = {
+            "event_type": "call.missed",
+            "timestamp": 1760000000000,
+            "from_number": "+14155550000",
+        }
+
+        def fake_history(_event_ts_ms):
+            return [
+                {
+                    "direction": "inbound",
+                    "state": "missed",
+                    "duration": 0,
+                    "date_started": 1760000000050,
+                    "external_number": "+14155550999",
+                    "entry_point_target": {"phone": "+14159917155", "name": "Support"},
+                }
+            ]
+
+        resolved = resolve_missed_call_context(payload, history_fetcher=fake_history)
+        self.assertEqual(resolved["from_number"], "+14155550000")
+        self.assertIsNone(resolved["to_number"])
+        self.assertEqual(resolved["caller_resolution_path"], "payload_direct")
+        self.assertEqual(resolved["line_resolution_path"], "unresolved")
+
+    def test_history_duration_parse_failure_not_missed_like(self):
+        payload = {
+            "event_type": "call.missed",
+            "timestamp": 1760000000000,
+            "from_number": "+14155550000",
+        }
+
+        def fake_history(_event_ts_ms):
+            return [
+                {
+                    "direction": "inbound",
+                    "state": "",
+                    "duration": "",
+                    "date_started": 1760000000050,
+                    "external_number": "+14155550000",
+                    "entry_point_target": {"phone": "+14159917155", "name": "Support"},
+                }
+            ]
+
+        resolved = resolve_missed_call_context(payload, history_fetcher=fake_history)
+        self.assertIsNone(resolved["to_number"])
         self.assertEqual(resolved["line_resolution_path"], "unresolved")
 
 


### PR DESCRIPTION
## Summary
Follow-up hotfix for post-merge Codex feedback on PR #43 review `3892761931`.

This PR addresses two safety concerns in missed-call history backfill:

1. Require caller/line match evidence before applying history backfill.
2. Treat unparsable history durations as unknown (`None`) rather than missed (`0`).

## What changed
- `scripts/webhook_server.py`
  - `_extract_call_history_row`: duration parse failure now yields `None`.
  - `resolve_missed_call_context`:
    - tracks caller/line normalized match evidence per candidate row
    - only applies `history_backfill` when best row is inbound + missed-like **and** has match evidence
    - keeps unresolved fields unresolved when evidence is insufficient
- `tests/test_webhook_server.py`
  - updated backfill test to include deterministic match evidence
  - added `test_history_backfill_requires_number_match_evidence`
  - added `test_history_duration_parse_failure_not_missed_like`
- Updated `CHANGELOG.md` and `THEORY.MD`

## Tests
- `pytest -q tests/test_webhook_server.py tests/test_webhook_hooks.py`
- `pytest -q tests/test_sender_enrichment.py tests/test_webhook_server.py tests/test_webhook_hooks.py`
- Result: `34 passed`

## Context
This follows up merged PR #43 to close the remaining review comments from:
- https://github.com/kesslerio/dialpad-openclaw-skill/pull/43#pullrequestreview-3892761931
