### PR TITLE
fix(webhook): prevent OTP/2FA bypass in inbound Telegram SMS alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-03-04
 
+- fix(webhook): close inbound Telegram OTP/2FA bypass by centralizing inbound SMS alert eligibility (`assess_inbound_sms_alert_eligibility`) and applying the same sensitive/shortcode decision to both OpenClaw hook forwarding and direct Telegram alerts.
+- fix(webhook): add safe inbound alert observability reason codes (`inbound_alert_reason`, `inbound_alert_eligible`, `telegram_status`) without exposing message secrets/tokens.
+- test(webhook): cover sensitive OTP filtering, shortcode filtering, benign SMS allow-path, and hook/Telegram decision consistency for inbound SMS.
 - fix(webhook): classify Dialpad contact lookup `401` failures (`expired_token`, `missing_scope`, `invalid_audience_or_environment`, `unauthorized`) and emit explicit degraded sender-enrichment status while preserving cached-contact fallback for inbound SMS hook and Telegram notification flows.
 - fix(webhook): resolve missed-call caller/line across sparse nested payloads before defaulting to `Unknown`.
 - fix(webhook): add deterministic resolution paths (`payload_direct`, `payload_inferred`, `history_backfill`, `unresolved`) and include them in debug logs.

--- a/THEORY.MD
+++ b/THEORY.MD
@@ -1,61 +1,33 @@
 # Theory: Dialpad Skill as a Reliable Communications Control Plane
 
 ## Problem
-The Dialpad skill exists to turn OpenClaw from a chat assistant into an operational communications endpoint for real-world workflows. The broad problem is not “send an SMS” or “make a call.” The real problem is enabling automated and human-in-the-loop outreach that is deterministic, auditable, and safe across multiple channels and business contexts.
+The Dialpad skill is not just an API wrapper. It is the control plane that decides which communication events are safe to fan out, how they are enriched, and how they remain observable when dependencies fail. The core failure mode is boundary drift: when two outbound paths consume the same inbound event but enforce policy differently, sensitive data can leak even when one path appears protected.
 
-Without this skill, phone/SMS actions are fragmented across ad-hoc scripts, inconsistent sender selection, and weak observability. That creates five recurring failure classes:
-
-1. **Delivery ambiguity** — messages may send from the wrong line or profile.
-2. **Identity loss** — inbound events without contact context reduce triage quality.
-3. **Auth drift fragility** — token/scope/env issues degrade behavior without actionable signals.
-4. **State blindness** — no durable local query layer for “what happened?” after sends/receives.
-5. **Tooling mismatch** — high-level workflow usage and low-level API control are often disconnected.
-
-The Dialpad skill is intended to solve those classes systematically, not just provide thin endpoint wrappers.
+In practical terms, the highest-risk boundary is inbound SMS fan-out. The system stores all messages for auditability, but notification channels (OpenClaw hooks and Telegram alerts) must gate sensitive content consistently. If policy is duplicated or implicit, regressions appear as bypasses rather than explicit failures.
 
 ## Operating Theory
-The skill should be treated as a **communications control plane** with layered responsibilities:
+The skill should operate as a layered system with one policy source per boundary:
 
-- **Execution layer**: generated OpenAPI CLI for full Dialpad API surface.
-- **Safety/UX layer**: `bin/*.py` wrappers enforce sane defaults, auth bridging, sender resolution, and predictable operator behavior.
-- **Event ingress layer**: webhook server normalizes inbound traffic and routes it into OpenClaw hooks/Telegram while preserving graceful degradation.
-- **Persistence/inspection layer**: SQLite + FTS enables local history, debugging, and retrospective analysis.
+- Execution layer: generated OpenAPI CLI for complete Dialpad API access.
+- Safety/UX layer: wrappers in `bin/` for predictable operator behavior.
+- Event ingress layer: `scripts/webhook_server.py` normalizes inbound payloads and applies policy before fan-out.
+- Persistence layer: SQLite/FTS stores full event history regardless of downstream notification outcomes.
 
-In this model, success is measured by **reliable outcomes under imperfect conditions**: stale tokens, partial contact data, malformed payloads, and operational drift. The system must continue delivering messages/events while making degradations visible and diagnosable.
+For inbound SMS, the correct model is: one event -> one eligibility decision -> many outputs. Hook forwarding and Telegram alerting are downstream effects of a shared decision, not independent checks.
 
 ## Strategy
-The long-term strategy is to harden each layer while preserving operator ergonomics:
+The strategy is to harden boundaries where divergence risk is highest while preserving graceful service behavior:
 
-1. **Deterministic sending behavior**
-   - explicit E.164 handling
-   - clear sender/profile resolution rules
-   - dry-run and mismatch guardrails
-
-2. **Auth as a first-class boundary**
-   - canonical key source (`DIALPAD_API_KEY`) with controlled bridges
-   - explicit classification of auth failures where possible
-   - no secret leakage in logs
-
-3. **Inbound normalization with continuity guarantees**
-   - always-200 webhook semantics for resilience
-   - robust filtering/classification for notification quality
-   - hook payloads that preserve context for downstream automations
-
-4. **Progressive observability**
-   - structured status fields for degraded modes
-   - durable local storage for message/search/debug loops
-   - concise operator-facing release notes to reduce hidden behavior changes
-
-5. **Two-speed interface contract**
-   - wrappers for routine usage and safer defaults
-   - generated CLI for advanced and complete API access
-
-This keeps the skill useful to both daily operators and deep-debug maintainers.
+1. Keep webhook continuity strict: storage and response semantics remain non-blocking with always-200 success for valid authenticated events.
+2. Centralize high-risk policy checks: sensitive-content and shortcode filtering must be decided once and reused.
+3. Make decisions observable with safe reason codes instead of payload dumps.
+4. Preserve enrichment and routing determinism so sender context is resolved once per event and reused.
+5. Maintain two-speed ergonomics: safe defaults for daily use, full API/tooling depth for advanced operations.
 
 ## Key Discoveries
-Recent hardening cycles reinforced a broader point: communication systems fail more often at **boundaries** (auth, identity resolution, endpoint assumptions) than at transport.
+The previous assumption was that a shared boolean (`sensitive_filtered`) was enough to coordinate hook and Telegram behavior. The flaw is that implicit coupling is brittle: policy intent was spread across separate branches, making bypasses easier to introduce during routine changes.
 
-Concrete discoveries from this cycle:
+Current understanding:
 
 - Silent fallback hides operational debt; explicit degraded-state signaling is mandatory.
 - `401` is not a single diagnosis; remediation depends on classification (expired token vs scope vs environment/audience mismatch).
@@ -63,19 +35,15 @@ Concrete discoveries from this cycle:
 - Sparse/inconsistent webhook payloads are common enough that missed-call handling must be multi-stage (`payload_direct` → `payload_inferred` → `history_backfill`), with explicit unresolved semantics.
 - History backfill must be evidence-gated: inbound+missed-like is necessary but not sufficient; at least one normalized caller/line match should exist before enriching unresolved fields.
 - Missing or unparsable duration should remain unknown (`None`) rather than coerced to zero, otherwise answered/ambiguous rows can be misclassified as missed-like.
+- Inbound fan-out policy must be explicit and centrally computed (eligibility helper with reason code).
+- OTP/2FA and shortcode suppression are policy decisions, not channel-specific behaviors.
+- Observability should report policy outcomes (`eligible`, `filtered_sensitive`, `filtered_shortcode`, etc.) without leaking message secrets.
 - Preserving graceful behavior (webhook continuity) and increasing observability are compatible if failure semantics are structured.
 
 ## Open Questions
-- Should auth classification expand to explicit `403` handling when Dialpad scope/policy denials surface outside `401`?
-- Should enrichment degradation emit standardized counters/metrics beyond logs/response fields for fleet-level monitoring?
-- How far should the skill go toward multi-tenant line policy enforcement vs leaving policy to calling workflows?
-- Should release notes evolve into versioned migration guidance as wrapper behavior becomes more opinionated?
+- Should inbound policy reasons be exported as metrics counters for long-term drift detection?
+- Should policy become configurable per destination channel, or remain globally consistent for all notification sinks?
+- Should similar centralized policy gating be applied to missed-call and voicemail Telegram paths for uniform audit semantics?
 
 ## Scope Alignment with SKILL.md
-SKILL.md defines the user-facing contract: send SMS/calls, manage contacts, query history, and use safer wrappers with canonical auth/source-of-truth conventions. This theory document extends that contract into system intent:
-
-- **Why** those features exist together (communications control plane)
-- **How** reliability and safety are maintained under drift
-- **Where** current hardening work (like auth classification and missed-call context backfill) fits the larger architecture
-
-The intent is that individual fixes should always strengthen this broader control-plane model, not become isolated patches.
+SKILL.md promises safe operational workflows around Dialpad messaging and calls. This theory tightens that promise by treating inbound policy as a first-class invariant: every fan-out target must honor the same eligibility decision, and every decision must be explainable without exposing secrets.

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -522,6 +522,62 @@ def classify_inbound_notification(data):
     return "sms"
 
 
+def assess_inbound_sms_alert_eligibility(
+    data,
+    *,
+    from_number,
+    text,
+    sender="",
+    notification_type=None,
+):
+    """
+    Centralized eligibility decision for inbound SMS alert fan-out.
+    Returns a reason code safe for logs/response metadata.
+    """
+    resolved_type = notification_type or classify_inbound_notification(data)
+    if resolved_type == "missed_call":
+        return {
+            "eligible": False,
+            "reason_code": "filtered_missed_call",
+            "sensitive_filtered": False,
+            "notification_type": resolved_type,
+        }
+    if resolved_type == "blank_sms":
+        return {
+            "eligible": False,
+            "reason_code": "filtered_blank_sms",
+            "sensitive_filtered": False,
+            "notification_type": resolved_type,
+        }
+    if resolved_type != "sms":
+        return {
+            "eligible": False,
+            "reason_code": "not_inbound",
+            "sensitive_filtered": False,
+            "notification_type": resolved_type,
+        }
+    if is_short_code_sender(from_number):
+        return {
+            "eligible": False,
+            "reason_code": "filtered_shortcode",
+            "sensitive_filtered": True,
+            "notification_type": resolved_type,
+        }
+    if is_sensitive_message(text=text, sender=sender, contact_number=from_number):
+        return {
+            "eligible": False,
+            "reason_code": "filtered_sensitive",
+            "sensitive_filtered": True,
+            "notification_type": resolved_type,
+        }
+    return {
+        "eligible": True,
+        "reason_code": "eligible",
+        "sensitive_filtered": False,
+        "notification_type": resolved_type,
+    }
+
+
 def escape_telegram_markdown(text):
     """Escape Telegram MarkdownV1 control characters in dynamic content."""
     if text is None:
@@ -1204,6 +1260,12 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
         hook_sent = False
         hook_status = None
         sensitive_filtered = False
+        inbound_alert_decision = {
+            "eligible": False,
+            "reason_code": "not_inbound",
+            "sensitive_filtered": False,
+            "notification_type": notification_type,
+        }
         sender_enrichment = {
             "contact_name": None,
             "status": "not_applicable",
@@ -1220,28 +1282,34 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                     contact_info = cached
             sender_enrichment["contact_name"] = contact_info
 
-            if notification_type == "missed_call":
-                hook_status = "filtered_missed_call"
-            elif notification_type == "blank_sms":
-                hook_status = "filtered_blank_sms"
-            elif is_short_code_sender(from_num):
-                sensitive_filtered = True
-                hook_status = "filtered_shortcode"
-                print("   🔒 Short-code message filtered (not forwarding to OpenClaw hooks)")
-            elif is_sensitive_message(text=text, sender=contact_info or "", contact_number=from_num):
-                sensitive_filtered = True
-                hook_status = "filtered_sensitive"
-                print("   🔒 Sensitive message filtered (not forwarding to OpenClaw hooks)")
-            else:
+            inbound_alert_decision = assess_inbound_sms_alert_eligibility(
+                data,
+                from_number=from_num,
+                text=text,
+                sender=contact_info or "",
+                notification_type=notification_type,
+            )
+            hook_status = inbound_alert_decision["reason_code"]
+            sensitive_filtered = inbound_alert_decision["sensitive_filtered"]
+
+            if inbound_alert_decision["eligible"]:
                 line_display = get_line_name(to_num)
                 normalized_sms = normalize_sms_payload(data, contact_info=contact_info)
                 hook_sent, hook_status = send_sms_to_openclaw_hooks(
                     normalized_sms, line_display=line_display
                 )
+            elif hook_status == "filtered_shortcode":
+                print("   🔒 Short-code message filtered (not forwarding to OpenClaw hooks)")
+            elif hook_status == "filtered_sensitive":
+                print("   🔒 Sensitive message filtered (not forwarding to OpenClaw hooks)")
         # Optional immediate Telegram notification for inbound SMS
         telegram_sms_sent = None
+        telegram_status = TELEGRAM_STATUS_NOT_APPLICABLE
         if direction == "inbound":
-            if notification_type == "sms" and DIALPAD_SMS_TELEGRAM_NOTIFY and not sensitive_filtered:
+            if (
+                inbound_alert_decision["eligible"]
+                and DIALPAD_SMS_TELEGRAM_NOTIFY
+            ):
                 line_display = get_line_name(to_num)
                 to_display = line_display or str(first_value(to_num) or "Unknown")
                 contact_info = sender_enrichment.get("contact_name")
@@ -1255,6 +1323,11 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                     f"Message: {escape_telegram_markdown(text)}"
                 )
                 telegram_sms_sent = send_to_telegram(tg_text)
+                telegram_status = TELEGRAM_STATUS_SENT if telegram_sms_sent else TELEGRAM_STATUS_FAILED
+            elif not DIALPAD_SMS_TELEGRAM_NOTIFY:
+                telegram_status = "disabled"
+            else:
+                telegram_status = inbound_alert_decision["reason_code"]
 
         # Console logging
         print(f"[{timestamp}]")
@@ -1266,12 +1339,19 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
         if WEBHOOK_SECRET:
             print(f"   🔐 Auth: ✓ ({auth_source})")
         if direction == "inbound":
+            print(
+                "   🧭 Inbound Alert Eligibility: "
+                f"{'allow' if inbound_alert_decision['eligible'] else 'block'} "
+                f"({inbound_alert_decision['reason_code']})"
+            )
             if sensitive_filtered:
                 print(f"   🪝 OpenClaw Hook: ✗ ({hook_status} — filtered)")
             else:
                 print(f"   🪝 OpenClaw Hook: {'✓' if hook_sent else '✗'} ({hook_status})")
             if telegram_sms_sent is not None:
-                print(f"   📨 Telegram SMS Alert: {'✓' if telegram_sms_sent else '✗'}")
+                print(f"   📨 Telegram SMS Alert: {'✓' if telegram_sms_sent else '✗'} ({telegram_status})")
+            else:
+                print(f"   📨 Telegram SMS Alert: ✗ ({telegram_status})")
             if sender_enrichment.get("degraded"):
                 print(
                     "   ⚠️  Sender enrichment degraded "
@@ -1289,6 +1369,13 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
             "stored": True,
             "hook_forwarded": hook_sent if direction == "inbound" else None,
             "hook_status": hook_status if direction == "inbound" else None,
+            "inbound_alert_eligible": (
+                inbound_alert_decision.get("eligible") if direction == "inbound" else None
+            ),
+            "inbound_alert_reason": (
+                inbound_alert_decision.get("reason_code") if direction == "inbound" else None
+            ),
+            "telegram_status": telegram_status if direction == "inbound" else None,
             "sender_enrichment_degraded": (
                 sender_enrichment.get("degraded") if direction == "inbound" else None
             ),

--- a/tests/test_sender_enrichment.py
+++ b/tests/test_sender_enrichment.py
@@ -269,3 +269,160 @@ def test_inbound_telegram_escapes_markdown_content(monkeypatch):
     assert len(telegram_messages) == 1
     assert "Jane\\_Doe" in telegram_messages[0]
     assert "Need \\_bold\\_ \\*now\\* \\[check] \\`code\\`" in telegram_messages[0]
+
+
+def test_inbound_sensitive_sms_filtered_for_hook_and_telegram(monkeypatch):
+    monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
+    monkeypatch.setattr(
+        webhook_server,
+        "handle_sms_webhook",
+        lambda _data: {"stored": True, "message": {"contact_name": "Unknown"}},
+    )
+    monkeypatch.setattr(
+        webhook_server,
+        "lookup_contact_enrichment",
+        lambda _number: {
+            "contact_name": "Capital One",
+            "status": "resolved",
+            "degraded": False,
+            "degraded_reason": None,
+        },
+    )
+    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", True)
+
+    hook_calls = []
+
+    def _fake_hook(normalized_sms, line_display=None):
+        hook_calls.append({"normalized_sms": normalized_sms, "line_display": line_display})
+        return True, "http_200"
+
+    telegram_messages = []
+    monkeypatch.setattr(webhook_server, "send_sms_to_openclaw_hooks", _fake_hook)
+    monkeypatch.setattr(
+        webhook_server,
+        "send_to_telegram",
+        lambda text: telegram_messages.append(text) or True,
+    )
+
+    payload = {
+        "direction": "inbound",
+        "from_number": "+14155550123",
+        "to_number": ["+14155201316"],
+        "text": "Your OTP code is 773311 for login.",
+    }
+    handler, status = _build_handler(payload)
+    webhook_server.DialpadWebhookHandler.handle_webhook(handler)
+
+    response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    assert status["code"] == 200
+    assert hook_calls == []
+    assert telegram_messages == []
+    assert response["hook_status"] == "filtered_sensitive"
+    assert response["inbound_alert_eligible"] is False
+    assert response["inbound_alert_reason"] == "filtered_sensitive"
+    assert response["telegram_status"] == "filtered_sensitive"
+
+
+def test_inbound_shortcode_sms_filtered_for_hook_and_telegram(monkeypatch):
+    monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
+    monkeypatch.setattr(
+        webhook_server,
+        "handle_sms_webhook",
+        lambda _data: {"stored": True, "message": {"contact_name": "Unknown"}},
+    )
+    monkeypatch.setattr(
+        webhook_server,
+        "lookup_contact_enrichment",
+        lambda _number: {
+            "contact_name": "Unknown",
+            "status": "not_found",
+            "degraded": False,
+            "degraded_reason": None,
+        },
+    )
+    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", True)
+
+    hook_calls = []
+    telegram_messages = []
+    monkeypatch.setattr(
+        webhook_server,
+        "send_sms_to_openclaw_hooks",
+        lambda normalized_sms, line_display=None: hook_calls.append(
+            {"normalized_sms": normalized_sms, "line_display": line_display}
+        ) or (True, "http_200"),
+    )
+    monkeypatch.setattr(
+        webhook_server,
+        "send_to_telegram",
+        lambda text: telegram_messages.append(text) or True,
+    )
+
+    payload = {
+        "direction": "inbound",
+        "from_number": "12345",
+        "to_number": ["+14155201316"],
+        "text": "Code 009821 to verify.",
+    }
+    handler, status = _build_handler(payload)
+    webhook_server.DialpadWebhookHandler.handle_webhook(handler)
+
+    response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    assert status["code"] == 200
+    assert hook_calls == []
+    assert telegram_messages == []
+    assert response["hook_status"] == "filtered_shortcode"
+    assert response["inbound_alert_eligible"] is False
+    assert response["inbound_alert_reason"] == "filtered_shortcode"
+    assert response["telegram_status"] == "filtered_shortcode"
+
+
+def test_inbound_hook_and_telegram_paths_share_eligible_result(monkeypatch):
+    monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
+    monkeypatch.setattr(
+        webhook_server,
+        "handle_sms_webhook",
+        lambda _data: {"stored": True, "message": {"contact_name": "Unknown"}},
+    )
+    monkeypatch.setattr(
+        webhook_server,
+        "lookup_contact_enrichment",
+        lambda _number: {
+            "contact_name": "Jane Doe",
+            "status": "resolved",
+            "degraded": False,
+            "degraded_reason": None,
+        },
+    )
+    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", True)
+
+    hook_calls = []
+    telegram_messages = []
+
+    def _fake_hook(normalized_sms, line_display=None):
+        hook_calls.append({"normalized_sms": normalized_sms, "line_display": line_display})
+        return True, "http_200"
+
+    monkeypatch.setattr(webhook_server, "send_sms_to_openclaw_hooks", _fake_hook)
+    monkeypatch.setattr(
+        webhook_server,
+        "send_to_telegram",
+        lambda text: telegram_messages.append(text) or True,
+    )
+
+    payload = {
+        "direction": "inbound",
+        "from_number": "+14155550123",
+        "to_number": ["+14155201316"],
+        "text": "Inbound hello",
+    }
+    handler, status = _build_handler(payload)
+    webhook_server.DialpadWebhookHandler.handle_webhook(handler)
+
+    response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    assert status["code"] == 200
+    assert len(hook_calls) == 1
+    assert len(telegram_messages) == 1
+    assert response["hook_forwarded"] is True
+    assert response["inbound_alert_eligible"] is True
+    assert response["inbound_alert_reason"] == "eligible"
+    assert response["telegram_status"] == "sent"

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -7,6 +7,7 @@ sys.path.insert(0, str(ROOT / "scripts"))
 sys.path.insert(0, str(ROOT))
 
 from webhook_server import (
+    assess_inbound_sms_alert_eligibility,
     classify_inbound_notification,
     detect_reliable_missed_call_hint,
     extract_message_text,
@@ -69,6 +70,51 @@ class WebhookNotificationClassificationTests(unittest.TestCase):
     def test_non_sensitive_message_not_detected(self):
         text = "See you at 6pm for dinner."
         self.assertFalse(is_sensitive_message(text=text, sender="Friend"))
+
+    def test_inbound_alert_eligibility_filters_sensitive_sms(self):
+        payload = {
+            "direction": "inbound",
+            "from_number": "+14155551234",
+            "text": "Your OTP code is 773311 for login",
+        }
+        decision = assess_inbound_sms_alert_eligibility(
+            payload,
+            from_number="+14155551234",
+            text=payload["text"],
+            sender="Capital One",
+        )
+        self.assertFalse(decision["eligible"])
+        self.assertEqual(decision["reason_code"], "filtered_sensitive")
+
+    def test_inbound_alert_eligibility_filters_shortcode_sender(self):
+        payload = {
+            "direction": "inbound",
+            "from_number": "12345",
+            "text": "Use 998812 to continue",
+        }
+        decision = assess_inbound_sms_alert_eligibility(
+            payload,
+            from_number=payload["from_number"],
+            text=payload["text"],
+            sender="Unknown",
+        )
+        self.assertFalse(decision["eligible"])
+        self.assertEqual(decision["reason_code"], "filtered_shortcode")
+
+    def test_inbound_alert_eligibility_allows_benign_sms(self):
+        payload = {
+            "direction": "inbound",
+            "from_number": "+14155551234",
+            "text": "Can we meet tomorrow at 2?",
+        }
+        decision = assess_inbound_sms_alert_eligibility(
+            payload,
+            from_number=payload["from_number"],
+            text=payload["text"],
+            sender="Friend",
+        )
+        self.assertTrue(decision["eligible"])
+        self.assertEqual(decision["reason_code"], "eligible")
 
     def test_text_content_fallback_used_when_text_is_blank(self):
         payload = {


### PR DESCRIPTION
## Summary
Fixes issue #40 where inbound OTP/2FA SMS content could bypass sensitive filtering on the direct Telegram SMS alert path.

Closes #40.

## Root cause
Inbound webhook handling used partially duplicated decision paths for hook forwarding vs direct Telegram alerting. Under certain path combinations, sensitive/OTP-like content could still reach Telegram alerts even when it should be filtered.

## What changed
- Unified inbound SMS alert eligibility into a single shared decision path.
- Ensured hook-forwarding and direct Telegram SMS alerts consume the same sensitivity/shortcode filter outcome.
- Added explicit non-secret reason codes for allow/filter decisions.
- Preserved graceful webhook behavior (still returns 200; notifications remain non-blocking).

## Tests
- `pytest -q tests/test_sender_enrichment.py tests/test_webhook_server.py tests/test_webhook_hooks.py`
- Result: `38 passed`

## Risk notes
- Main tradeoff remains false-positive sensitivity filtering vs leakage risk; this change intentionally biases toward safety for OTP/2FA-like content.
- No credential/token logging added.
