### PR TITLE
fix(create-contact): forward required flags

### DIFF
--- a/bin/create_contact.py
+++ b/bin/create_contact.py
@@ -224,49 +224,31 @@ def find_matching_contact(
 
 
 def create_contact(payload: dict[str, Any]) -> dict[str, Any]:
-    return run_generated_json(build_contact_command_args(payload, owner_id=payload.get("owner_id")))
+    return run_generated_json(build_create_contact_command_args(payload))
 
 
 def update_contact(contact_id: str, payload: dict[str, Any]) -> dict[str, Any]:
-    return run_generated_json(build_contact_command_args(payload, contact_id=contact_id))
+    return run_generated_json(
+        ["contacts", "contacts.update", "--id", contact_id, "--data", json.dumps(payload)]
+    )
 
 
-def build_contact_command_args(
-    payload: dict[str, Any],
-    *,
-    contact_id: str | None = None,
-    owner_id: Any | None = None,
-) -> list[str]:
-    if contact_id:
-        command = ["contacts", "contacts.update", "--id", contact_id]
-    else:
-        command = ["contacts", "contacts.create"]
+def build_create_contact_command_args(payload: dict[str, Any]) -> list[str]:
+    first_name = str(payload.get("first_name") or "").strip()
+    last_name = str(payload.get("last_name") or "").strip()
+    if not first_name or not last_name:
+        raise WrapperError("Create contact payload requires first_name and last_name.")
 
-    option_map = [
-        ("company_name", "--company-name", False),
-        ("emails", "--emails", True),
-        ("extension", "--extension", False),
-        ("first_name", "--first-name", False),
-        ("job_title", "--job-title", False),
-        ("last_name", "--last-name", False),
-        ("phones", "--phones", True),
-        ("urls", "--urls", True),
+    return [
+        "contacts",
+        "contacts.create",
+        "--first-name",
+        first_name,
+        "--last-name",
+        last_name,
+        "--data",
+        json.dumps(payload),
     ]
-
-    for key, flag, expects_list in option_map:
-        value = payload.get(key)
-        if value in (None, ""):
-            continue
-        if expects_list:
-            command.extend([flag, json.dumps(value)])
-        else:
-            command.extend([flag, str(value)])
-
-    resolved_owner_id = owner_id if owner_id is not None else payload.get("owner_id")
-    if resolved_owner_id:
-        command.extend(["--owner-id", str(resolved_owner_id)])
-
-    return command
 
 
 def is_owner_not_found_error(message: str) -> bool:

--- a/tests/test_create_contact.py
+++ b/tests/test_create_contact.py
@@ -65,11 +65,12 @@ class CreateContactTests(unittest.TestCase):
         self.assertEqual(calls[1][:2], ["contacts", "contacts.create"])
         self.assertEqual(self._get_option(calls[1], "--first-name"), "Alice")
         self.assertEqual(self._get_option(calls[1], "--last-name"), "Miller")
-        self.assertEqual(self._get_json_option(calls[1], "--phones"), ["+14155550123"])
-        self.assertEqual(self._get_json_option(calls[1], "--emails"), ["alice@example.com"])
-        self.assertNotIn("--data", calls[1])
+        payload = self._get_json_option(calls[1], "--data")
+        self.assertEqual(payload["phones"], ["+14155550123"])
+        self.assertEqual(payload["emails"], ["alice@example.com"])
+        self.assertEqual(payload["company_name"], "Acme")
 
-    def test_build_contact_command_args_uses_required_create_flags(self):
+    def test_build_create_contact_command_args_uses_required_flags_and_data_payload(self):
         payload = create_contact.build_payload(
             first_name="Phil",
             last_name="Stockton",
@@ -82,16 +83,16 @@ class CreateContactTests(unittest.TestCase):
             owner_id=None,
         )
 
-        cmd = create_contact.build_contact_command_args(payload)
+        cmd = create_contact.build_create_contact_command_args(payload)
 
         self.assertEqual(cmd[:2], ["contacts", "contacts.create"])
         self.assertEqual(self._get_option(cmd, "--first-name"), "Phil")
         self.assertEqual(self._get_option(cmd, "--last-name"), "Stockton")
-        self.assertEqual(self._get_option(cmd, "--company-name"), "Stockton Training Grounds")
-        self.assertEqual(self._get_json_option(cmd, "--phones"), ["+13174411610"])
-        self.assertEqual(self._get_json_option(cmd, "--emails"), ["phil@example.com"])
-        self.assertEqual(self._get_json_option(cmd, "--urls"), ["https://stockton.training/"])
-        self.assertNotIn("--data", cmd)
+        payload_arg = self._get_json_option(cmd, "--data")
+        self.assertEqual(payload_arg["company_name"], "Stockton Training Grounds")
+        self.assertEqual(payload_arg["phones"], ["+13174411610"])
+        self.assertEqual(payload_arg["emails"], ["phil@example.com"])
+        self.assertEqual(payload_arg["urls"], ["https://stockton.training/"])
 
     def test_create_contact_api_error_propagates(self):
         with patch("create_contact.require_generated_cli"), \
@@ -140,9 +141,9 @@ class CreateContactTests(unittest.TestCase):
         self.assertIn("Updated shared contact:", out)
         self.assertEqual(calls[0][:2], ["contacts", "contacts.list"])
         self.assertEqual(calls[1][:2], ["contacts", "contacts.update"])
-        self.assertEqual(self._get_option(calls[1], "--first-name"), "New")
-        self.assertEqual(self._get_option(calls[1], "--last-name"), "Contact")
-        self.assertNotIn("--data", calls[1])
+        payload = self._get_json_option(calls[1], "--data")
+        self.assertEqual(payload["first_name"], "New")
+        self.assertEqual(payload["last_name"], "Contact")
 
     def test_create_contact_auto_scope_with_owner_targets_shared_and_local(self):
         calls: list[list[str]] = []
@@ -152,7 +153,8 @@ class CreateContactTests(unittest.TestCase):
             if cmd[:2] == ["contacts", "contacts.list"]:
                 return {"items": []}
             if cmd[:2] == ["contacts", "contacts.create"]:
-                if self._get_option(cmd, "--owner-id") == "owner-9":
+                payload = self._get_json_option(cmd, "--data")
+                if payload.get("owner_id") == "owner-9":
                     return {"id": "local-1"}
                 return {"id": "shared-1"}
             raise AssertionError(f"Unexpected command: {cmd}")
@@ -223,7 +225,8 @@ class CreateContactTests(unittest.TestCase):
             if cmd[:2] == ["contacts", "contacts.list"]:
                 return {"items": []}
             if cmd[:2] == ["contacts", "contacts.create"]:
-                if self._get_option(cmd, "--owner-id") == "missing-owner":
+                payload = self._get_json_option(cmd, "--data")
+                if payload.get("owner_id") == "missing-owner":
                     raise WrapperError("Request failed: 404 owner not found")
                 return {"id": "shared-1"}
             raise AssertionError(f"Unexpected command: {cmd}")


### PR DESCRIPTION
## What
Fixes issue #47 by making `bin/create_contact.py` satisfy the generated Dialpad CLI parser contract **without** breaking structured payload fields.

Closes #47.

## Why
The wrapper's create path was broken for normal usage. It built a JSON payload and invoked:

- `contacts contacts.create --data ...`

That is wrong for this generated CLI. `contacts.create` validates Click-required flags like `--first-name` and `--last-name` before it applies `--data`, so the wrapper failed locally with `Missing option '--first-name'` even though direct CLI calls worked.

The follow-up review caught a second problem in my first fix: pushing `phones` / `emails` / `urls` through CLI options turned array fields into strings. The correct behavior is hybrid:

- `contacts.create` passes `--first-name` and `--last-name` to satisfy Click parse-time validation
- the full request body still goes through `--data` so array fields remain arrays
- `contacts.update` stays on the `--data` path for the same reason

## Tests
- `python3 -m pytest tests/test_create_contact.py -q`
- `python3 -m pytest -q`
- Result: `95 passed`

## AI Assistance
- Used: yes, Codex CLI
- Testing level: full local pytest suite (`95 passed`)
- Prompt/session log link: unavailable; this was a local Codex CLI session with no shareable public log
- I understand this code.
