### PR TITLE
docs: clarify agent-safe command surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Dialpad OpenClaw Skill
 
-Dialpad messaging and calling skill for OpenClaw with lightweight wrappers, webhook handling, and local SMS history storage.
+Dialpad messaging and calling skill for OpenClaw with task-focused wrappers, webhook handling, and local SMS history storage.
 
 ## What This Repo Contains
 
-- `SKILL.md` for skill loading and usage guidance.
-- `bin/` wrappers for stable task-focused commands.
-- `generated/` OpenAPI-generated Dialpad CLI surface.
-- `scripts/` operational Python scripts (legacy entrypoints + webhook/storage tooling).
+- `SKILL.md` for skill loading and agent-safe usage guidance.
+- `bin/` wrappers for the supported agent-facing command surface.
+- `generated/` internal OpenAPI-generated backend CLI used by wrappers and manual troubleshooting.
+- `scripts/` operational Python scripts for webhook, storage, and maintenance workflows.
 - `references/` deeper API/architecture/storage/voice docs.
 
 ## Quick Start
@@ -20,21 +20,15 @@ cd dialpad-openclaw-skill
 # Required auth (canonical)
 export DIALPAD_API_KEY="your-api-key"
 
-# Optional/derived auth bridge for direct generated CLI usage
-export DIALPAD_TOKEN="${DIALPAD_TOKEN:-$DIALPAD_API_KEY}"
-
 # Optional premium TTS
 export ELEVENLABS_API_KEY="your-elevenlabs-key"
 ```
 
 ## Common Commands
 
-Prefer wrappers in `bin/` for day-to-day usage.
+Use `bin/` wrappers for all normal agent work. They are the stable, supported command contract.
 
 ```bash
-# Auth preflight for direct generated CLI usage
-generated/dialpad --api-key "$DIALPAD_API_KEY" company company.get >/dev/null
-
 # Send SMS (recommended: explicit sender)
 bin/send_sms.py --to "+14155551234" --from "+14155201316" --message 'Hello from OpenClaw'
 
@@ -54,9 +48,6 @@ bin/send_group_intro.py --prospect "+14155550111" --reference "+14155550999" --c
 # Create/update contacts
 bin/create_contact.py --first-name "Jane" --last-name "Doe" --phone "+14155550123" --email "jane@example.com"
 bin/update_contact.py --id "contact_123" --job-title "Director"
-
-# SMS SQLite history (script moved under scripts/)
-python3 scripts/sms_sqlite.py list
 ```
 
 ## Webhooks to OpenClaw
@@ -75,8 +66,30 @@ export OPENCLAW_HOOKS_NAME="Dialpad SMS"
 Create/list webhook subscriptions:
 
 ```bash
-python3 scripts/create_sms_webhook.py create --url "https://your-server.com/webhook/dialpad" --direction "all"
-python3 scripts/create_sms_webhook.py list
+bin/create_sms_webhook.py create --url "https://your-server.com/webhook/dialpad" --direction "all"
+bin/create_sms_webhook.py list
+```
+
+## Operational Tools
+
+These commands are for manual operator workflows, storage inspection, and maintenance. They are not the supported agent-facing interface.
+
+```bash
+# SMS SQLite history
+python3 scripts/sms_sqlite.py list
+
+# Deep webhook/storage operations
+python3 scripts/webhook_server.py
+python3 scripts/sms_storage.py list
+```
+
+## Manual Troubleshooting
+
+`generated/dialpad` is an internal backend surface for the wrappers. Use it directly only for manual operator troubleshooting, API inspection, or regeneration work.
+
+```bash
+export DIALPAD_TOKEN="${DIALPAD_TOKEN:-$DIALPAD_API_KEY}"
+generated/dialpad --api-key "$DIALPAD_API_KEY" company company.get >/dev/null
 ```
 
 ## Repository Layout
@@ -104,6 +117,6 @@ dialpad-openclaw-skill/
 
 - Root Python entrypoints were consolidated into `scripts/`.
 - If you previously used `python3 <root-script>.py`, switch to `python3 scripts/<script>.py`.
-- For direct generated CLI calls, pass `--api-key "$DIALPAD_API_KEY"` (or ensure `DIALPAD_TOKEN` is exported). Wrappers in `bin/` handle auth bridging automatically.
+- Agents should use `bin/*` wrappers for normal work. Treat `generated/dialpad` as operator-only troubleshooting infrastructure.
 - For messages containing `$` or other shell-sensitive text, prefer `--message-file` or `--message-stdin`. If you use inline `--message`, single-quote it.
 - `bin/send_sms.py --dry-run` now prints the exact message preview so pricing/shell corruption is visible before send.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dialpad
-description: Send SMS and make voice calls via Dialpad API using an OpenAPI-generated CLI with compatibility wrappers.
+description: Send SMS and make voice calls via Dialpad API using task-focused wrappers backed by an OpenAPI-generated CLI.
 homepage: https://developers.dialpad.com/
 ---
 
@@ -14,7 +14,7 @@ Use this skill to:
 - Send SMS messages (individual or batch)
 - Make voice calls (with TTS or custom voices)
 - Manage contacts and organization settings
-- Query SMS history from local SQLite database
+- Inspect SMS history through operator tooling when needed
 
 ## Available Phone Numbers
 
@@ -25,11 +25,6 @@ Use this skill to:
 | (415) 991-7155 | Support SMS Only | SMS only (no voice) |
 
 ## Quick Start
-
-**Auth preflight (run first):**
-```bash
-generated/dialpad --api-key "$DIALPAD_API_KEY" company company.get >/dev/null
-```
 
 **Send SMS (explicit sender recommended):**
 ```bash
@@ -56,37 +51,40 @@ bin/create_contact.py --first-name "Jane" --last-name "Doe" --phone "+1415555012
 bin/update_contact.py --id "contact_123" --phone "+14155550123" --job-title "VP"
 ```
 
-**Check SMS History:**
-```bash
-python3 scripts/sms_sqlite.py list
-```
-
 ## Key Rules
 
 1. **Format:** Always use E.164 format for numbers (e.g., `+14155551234`).
 2. **Escaping:** Use single quotes for inline `--message` values containing `$` to prevent shell expansion (e.g., `'Price is $10'`).
 3. **Safer message input:** Prefer `--message-file` or `--message-stdin` for pricing text, multi-line copy, or anything shell-sensitive.
-4. **Auth canonical source:** `DIALPAD_API_KEY` is canonical. `DIALPAD_TOKEN` is optional/derived.
-   - Recommended: `export DIALPAD_TOKEN="${DIALPAD_TOKEN:-$DIALPAD_API_KEY}"`
-5. **Execution modes:**
-   - `bin/*.py` wrappers: preferred for routine operations (auto auth bridging + safer UX)
-   - `generated/dialpad`: advanced/direct API control; always pass `--api-key` (or set `DIALPAD_TOKEN`)
-6. **SMS sender safety:** `--from` and `--profile work|sales` are supported. Prefer explicit `--from` for deterministic routing.
+4. **Supported agent interface:** use `bin/*.py` wrappers for normal work. They are the stable command contract for agents.
+5. **Operator-only surfaces:** `generated/dialpad` and `scripts/*` are for manual troubleshooting, storage inspection, or operational maintenance, not normal agent task execution.
+6. **Auth canonical source:** `DIALPAD_API_KEY` is canonical. `DIALPAD_TOKEN` is only needed for manual generated CLI troubleshooting.
+   - Operator example: `export DIALPAD_TOKEN="${DIALPAD_TOKEN:-$DIALPAD_API_KEY}"`
+7. **SMS sender safety:** `--from` and `--profile work|sales` are supported. Prefer explicit `--from` for deterministic routing.
    - `--profile` maps to configured env vars:
      - work: `DIALPAD_PROFILE_WORK_FROM`
      - sales: `DIALPAD_PROFILE_SALES_FROM`
    - default fallback order: `DIALPAD_DEFAULT_FROM_NUMBER`, then `DIALPAD_DEFAULT_PROFILE`
    - `--allow-profile-mismatch` permits explicit/profile mismatches when intentional
    - `--dry-run` prints sender resolution and the exact message/request preview without an API call
-7. **Group intro:** `bin/send_group_intro.py` mirrors intro messages as two one-to-one SMS sends (`mirrored_fallback`) because true group threads are unsupported via this wrapper.
-8. **Create/Update Contact Behavior:** `bin/create_contact.py` upserts shared/local contacts by phone/email match (or forces create with `--allow-duplicate`). `bin/update_contact.py` updates by `--id` with partial fields.
+8. **Group intro:** `bin/send_group_intro.py` mirrors intro messages as two one-to-one SMS sends (`mirrored_fallback`) because true group threads are unsupported via this wrapper.
+9. **Create/Update Contact Behavior:** `bin/create_contact.py` upserts shared/local contacts by phone/email match (or forces create with `--allow-duplicate`). `bin/update_contact.py` updates by `--id` with partial fields.
 
 ## Reference Documentation
 
-- **`references/api-reference.md`** — API endpoints, Generated CLI usage, Webhooks
+- **`references/api-reference.md`** — Wrapper behavior, operator CLI reference, Webhooks
 - **`references/sms-storage.md`** — SQLite commands, FTS5 search, legacy storage
 - **`references/voice-options.md`** — List of available TTS voices (Budget & Premium)
 - **`references/architecture.md`** — System architecture, wrappers, and CLI generation
+
+## Operational Tools
+
+Use these only for manual operator workflows, storage inspection, and maintenance:
+
+```bash
+python3 scripts/sms_sqlite.py list
+python3 scripts/webhook_server.py
+```
 
 ## Setup
 
@@ -95,7 +93,7 @@ python3 scripts/sms_sqlite.py list
 export DIALPAD_API_KEY="your_key"
 ```
 
-**Recommended auth bridge for direct generated CLI usage:**
+**Operator auth bridge for manual generated CLI troubleshooting:**
 ```bash
 export DIALPAD_TOKEN="${DIALPAD_TOKEN:-$DIALPAD_API_KEY}"
 ```

--- a/docs/plans/2026-03-25-agent-interface-doc-boundaries.md
+++ b/docs/plans/2026-03-25-agent-interface-doc-boundaries.md
@@ -1,0 +1,142 @@
+# Plan: Agent Interface Documentation Boundaries
+
+Date: 2026-03-25
+Issues: #33, #36
+Depth: Lightweight
+
+## Problem Frame
+
+The repository still presents three different surfaces as if they were equally valid for agent use:
+
+- `bin/*` wrappers as the preferred interface
+- `generated/dialpad` as a normal direct interface
+- `scripts/*` commands mixed into general usage examples
+
+That contradicts the intended safety model. Agents need one deterministic contract. The generated CLI is too broad and noisy to be a supported agent entrypoint, and operational scripts should remain available without being framed as first-class agent commands.
+
+## Scope
+
+In scope:
+
+- Reposition `bin/*` wrappers as the only supported agent-facing interface
+- Reframe `generated/dialpad` as an internal backend surface for wrappers and manual operator troubleshooting
+- Separate operator-only `scripts/*` usage from agent usage in top-level docs
+- Align README, SKILL, and reference docs so they stop drifting on this point
+
+Out of scope:
+
+- Changing wrapper behavior or generated CLI implementation
+- Removing scripts or generated assets from the repository
+- Adding new wrappers for missing capabilities
+- Changing webhook or storage runtime behavior
+
+## Requirements Trace
+
+### Issue #33
+
+- `README.md` and `SKILL.md` must state that `bin/*` is the supported agent interface
+- `scripts/*` examples must not be presented as equivalent to core agent commands
+- Architecture docs must describe `bin/*` as the stable contract
+
+### Issue #36
+
+- `generated/dialpad` must be framed as an internal implementation detail for agent usage
+- Direct generated CLI usage must be limited to advanced/manual operator troubleshooting
+- Wrapper-to-generated flow must be explicit in architecture/docs
+
+## Current Evidence
+
+- `README.md` includes direct `generated/dialpad` auth preflight and direct CLI guidance in notes
+- `SKILL.md` quick start begins with direct generated CLI auth preflight and lists `generated/dialpad` as an execution mode
+- `references/api-reference.md` documents generated CLI capabilities without clearly separating operator/manual use from agent-safe use
+- `references/architecture.md` correctly shows wrappers calling the generated CLI, but does not explicitly define the generated CLI as internal-only for agent workflows
+
+## Decisions
+
+1. `bin/*` will be documented as the only supported agent-facing command surface.
+   Rationale: This directly satisfies both issues and keeps LLM invocation deterministic.
+
+2. `generated/dialpad` will remain documented, but only in an explicit operator/manual troubleshooting context.
+   Rationale: The repo still needs to support human debugging and regeneration workflows without advertising the raw CLI to agents.
+
+3. `scripts/*` will remain documented only as operational tooling.
+   Rationale: Webhook, SQLite, and storage flows are legitimate operator tasks, but they should not compete with wrapper guidance.
+
+4. The implementation will stay documentation-only unless a contradiction requires a tiny metadata cleanup.
+   Rationale: The issues are about positioning and supported surfaces, not runtime behavior.
+
+## Files
+
+- `README.md`
+- `SKILL.md`
+- `references/api-reference.md`
+- `references/architecture.md`
+
+## Implementation Units
+
+### Unit 1: Top-Level Contract Alignment
+
+Goal:
+- Make the wrapper-first contract explicit in the top-level docs
+
+Files:
+- `README.md`
+- `SKILL.md`
+
+Approach:
+- Replace direct generated CLI quick-start framing with wrapper-first setup and usage
+- Add a short operator/troubleshooting section that explains when `generated/dialpad` is acceptable
+- Move `scripts/*` examples into clearly labeled operational sections
+
+Patterns to follow:
+- Keep README concise and navigational
+- Keep SKILL focused on agent-safe usage
+
+Verification:
+- No README or SKILL section implies that agents should call `generated/dialpad` directly for normal tasks
+- `scripts/*` examples are labeled operator/operational rather than agent-facing
+
+### Unit 2: Reference Doc Consistency
+
+Goal:
+- Align deeper docs with the same interface boundary
+
+Files:
+- `references/api-reference.md`
+- `references/architecture.md`
+
+Approach:
+- Reframe generated CLI sections as internal backend surface plus manual operator tooling
+- State wrapper-to-generated flow plainly in architecture
+- Preserve useful advanced reference material, but relocate its audience to operators/manual troubleshooting
+
+Patterns to follow:
+- Keep reference docs descriptive rather than marketing-heavy
+- Avoid deleting valid operational knowledge
+
+Verification:
+- Reference docs consistently describe wrappers as the stable agent contract
+- Generated CLI references are explicitly manual/operator-facing
+
+## Risks
+
+- Overcorrecting and hiding legitimate operator workflows
+- Leaving one stray example that reintroduces ambiguity
+- Repeating the same guidance differently across docs and creating new drift
+
+## Test Scenarios
+
+1. Scan `README.md`, `SKILL.md`, `references/api-reference.md`, and `references/architecture.md` for `generated/dialpad` mentions and verify each mention is either internal/backend or manual/operator-facing.
+2. Scan for `scripts/` examples and verify they are labeled operational, not core agent commands.
+3. Confirm top-level command examples for SMS, calls, contacts, and webhooks use `bin/*` wrappers where wrappers exist.
+
+## Verification
+
+- Text search for interface-surface phrasing across the edited docs
+- Manual review of doc flow for contradiction removal
+
+## Alternative Considered
+
+Close #33 and #36 as already satisfied.
+
+Rejected because the current docs still explicitly advertise direct generated CLI use and therefore do not actually meet the acceptance criteria.

--- a/references/api-reference.md
+++ b/references/api-reference.md
@@ -1,5 +1,7 @@
 # Dialpad API & CLI Reference
 
+Agent-facing usage should go through `bin/*` wrappers. This document also keeps the underlying CLI and API details available for manual operator troubleshooting.
+
 ## API Capabilities
 
 ### SMS
@@ -14,9 +16,13 @@
 - **Features:** Outbound calling, Text-to-Speech
 - **Caller ID:** Must be assigned to your Dialpad account
 
-## Generated CLI (241 Endpoints)
+## Supported Agent Surface
 
-The OpenAPI-generated CLI (`generated/dialpad`) exposes 241 endpoints.
+For agent workflows, `bin/*` wrappers are the supported contract. They provide task-focused arguments, auth bridging, and safer output behavior than the raw generated CLI.
+
+## Generated CLI Backend (Operator Use Only)
+
+The OpenAPI-generated CLI (`generated/dialpad`) exposes 241 endpoints. It is the backend surface used by wrappers and a manual operator troubleshooting tool, not a normal agent entrypoint.
 
 ### Wrapper Behavior Notes
 
@@ -39,6 +45,10 @@ bin/send_sms.py --to "+14155550111" --message 'Hello' --profile work
 printf '%s' 'The premium hardshell travel case is $499.' | bin/send_sms.py --to "+14155550111" --from "+14155201316" --message-stdin --dry-run
 bin/send_group_intro.py --prospect "+14155550111" --reference "+14155559999" --confirm-share --from "+14153602954"
 ```
+
+### Manual Operator CLI Examples
+
+These examples are for human operators doing deep inspection or advanced troubleshooting.
 
 ### Campaign & Automation
 ```bash
@@ -99,7 +109,7 @@ dialpad accesscontrolpolicies accesscontrolpolicies.assign --id "policy_123" --u
 
 ### Contact & CRM
 ```bash
-# Full contact CRUD (beyond just lookup)
+# Full contact CRUD (manual operator use)
 dialpad contacts contacts.create --first-name "John" --last-name "Doe" --phones '["+14155551234"]'
 dialpad contacts contacts.update --id "contact_123" --first-name "John" --job-title "VP"
 dialpad contacts contacts.delete --id "contact_123"

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -4,7 +4,7 @@
 Dialpad OpenClaw Skill
 ├── SKILL.md                      # Skill trigger/instruction entrypoint
 ├── README.md                     # Concise setup + navigation
-├── bin/                          # Preferred user-facing wrappers
+├── bin/                          # Supported agent-facing wrappers
 │   ├── send_sms.py
 │   ├── send_group_intro.py
 │   ├── make_call.py
@@ -14,10 +14,10 @@ Dialpad OpenClaw Skill
 │   ├── export_sms.py
 │   ├── create_sms_webhook.py
 │   └── _dialpad_compat.py
-├── generated/                    # OpenAPI-generated CLI
+├── generated/                    # Internal backend CLI used by wrappers
 │   ├── dialpad
 │   └── dialpad.openapi
-├── scripts/                      # Operational/legacy Python tooling
+├── scripts/                      # Operator-only operational Python tooling
 │   ├── send_sms.py
 │   ├── make_call.py
 │   ├── list_calls.py
@@ -41,6 +41,8 @@ Dialpad OpenClaw Skill
 
 ## Wrapper to Generated CLI Flow
 
+`bin/*` is the stable agent contract. `generated/dialpad` sits behind that contract and should only be used directly by human operators for troubleshooting or regeneration work.
+
 1. Wrapper receives task-oriented arguments.
 2. Wrapper transforms arguments to Dialpad CLI payloads.
 3. Wrapper executes `generated/dialpad` with auth from env.
@@ -48,7 +50,7 @@ Dialpad OpenClaw Skill
 
 ## Script Layer
 
-Scripts in `scripts/` are retained for compatibility and operational workflows (webhooks, storage, exports, and call lookup utilities). They are no longer placed in repository root.
+Scripts in `scripts/` are retained for compatibility and operational workflows (webhooks, storage, exports, and call lookup utilities). They are no longer placed in repository root and are not the supported agent-facing interface.
 
 ## Regeneration
 


### PR DESCRIPTION
## What
- make `bin/*` wrappers the explicitly supported agent-facing command surface
- reframe `generated/dialpad` as internal backend and manual operator troubleshooting infrastructure
- move `scripts/*` usage out of normal examples and into operational/manual sections
- add a written plan artifact in `docs/plans/2026-03-25-agent-interface-doc-boundaries.md`

## Why
The repo docs still drifted between wrapper-first guidance and direct raw CLI usage. That ambiguity is exactly what issues #33 and #36 were trying to eliminate.

Closes #33
Closes #36

## Risk
Low. This is documentation-only and does not change runtime behavior.

## How Verified
- `python3 -m pytest`
- `git diff --check`
- manual contradiction sweep across `README.md`, `SKILL.md`, `references/api-reference.md`, and `references/architecture.md`

## Post-Deploy Monitoring & Validation
- Log queries/search terms: not applicable for this docs-only change
- Metrics or dashboards to watch: not applicable for this docs-only change
- Expected healthy signals: top-level docs consistently route agents to `bin/*`; direct generated CLI usage is framed as manual/operator-only
- Failure signals and rollback/mitigation trigger: if contributors keep opening issues or PRs that treat `generated/dialpad` or `scripts/*` as normal agent entrypoints, reopen the docs pass and tighten wording
