### PR TITLE
fix(dialpad): add identity-state guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ If your gateway listens on a different port, change `OPENCLAW_GATEWAY_URL` accor
 The local gateway allows explicit `niemand-work` routing and `hook:dialpad:` session keys.
 For first-time or unknown inbound contacts, the payload also carries a `firstContact` hint that tells OpenClaw to enrich identity, look up business context, draft a reply, and suggest Dialpad contact sync when the match is clear.
 That pattern is CRM-agnostic: Attio is one example, but the same setup works with HubSpot, Pipedrive, Airtable, a spreadsheet, or a custom directory service downstream.
+Current-turn verification still applies: "Already sent" and "Already updated" are only valid after a fresh current-turn tool result, not from stale session memory.
 When `DIALPAD_AUTO_REPLY_ENABLED` is set, first-contact inbound events to the sales line `(415) 520-1316` get a short SMS acknowledgment automatically before the hook handoff continues. Missed calls get a "sorry we missed you" variant; SMS and voicemail get a "we'll be in touch shortly" variant.
 
 Create/list webhook subscriptions:

--- a/README.md
+++ b/README.md
@@ -79,9 +79,10 @@ export DIALPAD_AUTO_REPLY_ENABLED="1"
 When `OPENCLAW_HOOKS_TOKEN` is configured, inbound SMS and inbound missed-call events are forwarded to OpenClaw by default. Set `OPENCLAW_HOOKS_SMS_ENABLED=0` or `OPENCLAW_HOOKS_CALL_ENABLED=0` to disable one event class without changing the shared destination config.
 If your gateway listens on a different port, change `OPENCLAW_GATEWAY_URL` accordingly.
 The local gateway allows explicit `niemand-work` routing and `hook:dialpad:` session keys.
-For first-time or unknown inbound contacts, the payload also carries a `firstContact` hint that tells OpenClaw to enrich identity, look up business context, draft a reply, and suggest Dialpad contact sync when the match is clear.
+For first-time or unknown inbound contacts, the payload also carries a `firstContact` hint with an explicit `identityState` plus lookup details so OpenClaw can enrich identity, look up business context, draft a reply, and suggest Dialpad contact sync when the match is clear.
 That pattern is CRM-agnostic: Attio is one example, but the same setup works with HubSpot, Pipedrive, Airtable, a spreadsheet, or a custom directory service downstream.
 Current-turn verification still applies: "Already sent" and "Already updated" are only valid after a fresh current-turn tool result, not from stale session memory.
+For identity work, treat `resolved` as the only state that is safe to mutate automatically; `not_found`, `ambiguous`, and `degraded` stay draft-only until the CRM layer proves otherwise.
 When `DIALPAD_AUTO_REPLY_ENABLED` is set, first-contact inbound events to the sales line `(415) 520-1316` get a short SMS acknowledgment automatically before the hook handoff continues. Missed calls get a "sorry we missed you" variant; SMS and voicemail get a "we'll be in touch shortly" variant.
 
 Create/list webhook subscriptions:

--- a/SKILL.md
+++ b/SKILL.md
@@ -77,6 +77,7 @@ bin/update_contact.py --id "contact_123" --phone "+14155550123" --job-title "VP"
 9. **Call history:** `bin/list_calls.py` is the supported call-history command for agents. Use `--json` when downstream automation needs a deterministic response envelope.
 10. **Create/Update Contact Behavior:** `bin/create_contact.py` upserts shared/local contacts by phone/email match (or forces create with `--allow-duplicate`). `bin/update_contact.py` updates by `--id` with partial fields.
 11. **Current-turn verification:** "Already sent" and "Already updated" are only valid after a fresh current-turn tool result, not from stale session memory. If the current turn has not verified the action yet, say that plainly and run the tool now.
+12. **Identity guardrail:** For first-contact work, soft signals like first name, area code, industry, or job title are not enough to merge or update a contact. Keep uncertain identity `draft-only` and let the CRM layer prove the match before mutating anything.
 
 ## Reference Documentation
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -76,6 +76,7 @@ bin/update_contact.py --id "contact_123" --phone "+14155550123" --job-title "VP"
 8. **Group intro:** `bin/send_group_intro.py` mirrors intro messages as two one-to-one SMS sends (`mirrored_fallback`) because true group threads are unsupported via this wrapper.
 9. **Call history:** `bin/list_calls.py` is the supported call-history command for agents. Use `--json` when downstream automation needs a deterministic response envelope.
 10. **Create/Update Contact Behavior:** `bin/create_contact.py` upserts shared/local contacts by phone/email match (or forces create with `--allow-duplicate`). `bin/update_contact.py` updates by `--id` with partial fields.
+11. **Current-turn verification:** "Already sent" and "Already updated" are only valid after a fresh current-turn tool result, not from stale session memory. If the current turn has not verified the action yet, say that plainly and run the tool now.
 
 ## Reference Documentation
 

--- a/docs/plans/2026-03-26-003-bug-stale-already-sent-replies-plan.md
+++ b/docs/plans/2026-03-26-003-bug-stale-already-sent-replies-plan.md
@@ -1,0 +1,180 @@
+---
+title: bug: stale "Already sent" replies need current-turn verification
+type: bug
+status: completed
+date: 2026-03-26
+origin: https://github.com/kesslerio/dialpad-openclaw-skill/issues/64
+depth: standard
+---
+
+# bug: Stale "Already sent" Replies Need Current-Turn Verification
+
+## Overview
+
+Issue #64 is not the earlier SMS status-label bug. The Dialpad send wrappers can be working correctly while the OpenClaw operator still claims success from stale session context. The failure mode is behavioral: `niemand-work` answered "Already sent." without a fresh `send_sms.py` or `update_contact.py` call in the current turn, which makes the operator trust the wrong state.
+
+The fix belongs in the live OpenClaw operator contract, not in the Dialpad send wrapper. This repo should tighten the prompt boundary, document the freshness rule, and add a small regression around the written contract so the same failure is harder to reintroduce.
+
+## Problem Frame
+
+Operators need current-turn truth, not memory-shaped confidence. When a user asks to send a message or update a contact, the assistant must either:
+
+- perform the action in the current turn, or
+- explicitly state that it has not verified the current turn yet and proceed to verify it
+
+The current behavior shortcuts that requirement and answers "Already sent." from stale context. That hides real failures and makes the tool layer look trustworthy when it has not been exercised.
+
+## Requirements Trace
+
+- R1. A fresh current-turn tool call is required before any success claim about sending or updating.
+- R2. Prior turn context must not satisfy a new send/update request.
+- R3. "Already sent" is only valid after the current turn has actually verified the action.
+- R4. The rule applies equally to `send_sms.py` and `update_contact.py`.
+- R5. Repo docs must describe the freshness rule and separate draft generation from send authority.
+- R6. The repo must not conflate this bug with issue #58, which was only about SMS status wording.
+
+## Scope Boundaries
+
+In scope:
+
+- tighten the live `niemand-work` prompt in OpenClaw
+- update repo docs so the operator contract is explicit
+- add a lightweight regression around the written contract
+
+Out of scope:
+
+- changing Dialpad API semantics
+- changing `send_sms.py` delivery behavior
+- reworking first-contact enrichment
+- adding a general long-term memory system
+- broadening this into a new agent architecture
+
+## Context & Research
+
+### Relevant Code and Docs
+
+- `README.md` and `SKILL.md` already define `bin/*.py` as the supported Dialpad agent surface and point to `niemand-work` as the OpenClaw handoff target.
+- `references/openclaw-integration.md` already says to separate draft generation from send authority and default to `approval_required`.
+- `references/api-reference.md` already documents `firstContact`, `autoReply`, and explicit `niemand-work` routing.
+- The live OpenClaw config in `~/.openclaw/openclaw.json` contains the `Dialpad Operations` prompt for `telegram:group:-1003882776023`.
+- `tests/test_webhook_hooks.py` and `tests/test_sender_enrichment.py` already lock hook payload structure, but there is no repo test for stale success narration.
+- No relevant `docs/solutions/` learning exists in this repo for this specific workflow bug.
+
+### Source Evidence
+
+- The issue trace in `~/.openclaw/agents/niemand-work/sessions/8b39045a-630a-4cf6-a9e0-b1f1f6211615.jsonl` shows the later Reggie turn returned "Already sent." without a fresh send/update tool call.
+- The SMS database row for the actual outbound message exists separately and does not justify a stale follow-up success claim.
+
+## Key Technical Decisions
+
+1. Fix the live prompt first, not the wrapper.
+   Rationale: the bug is stale narration in the OpenClaw agent, not a broken Dialpad send path.
+
+2. Make verification current-turn explicit.
+   Rationale: the agent needs to distinguish "I drafted this earlier" from "I just executed this now."
+
+3. Treat "Already sent" as forbidden unless a current-turn tool result proves it.
+   Rationale: this is the exact false claim in issue #64.
+
+4. Document the freshness rule in the repo contract.
+   Rationale: operators and downstream maintainers need the same wording that the live prompt enforces.
+
+5. Add a small contract test for the docs.
+   Rationale: the prompt itself lives outside the repo, but the repo can still lock the contract language that keeps this behavior honest.
+
+## Open Questions
+
+Resolved during planning:
+
+- Is this the same bug as issue #58? No. #58 was about wrapper status wording; #64 is about stale success narration.
+- Should the fallback wording be "Already sent"? No. If the current turn has not verified the action, the agent should say it has not verified this turn yet.
+
+Deferred to implementation:
+
+- Whether the live prompt should also keep a compact last-tool-call fingerprint in session state.
+- Whether the docs should include a short example of the forbidden stale-success path versus the correct verification-first path.
+
+## Implementation Units
+
+- [ ] **Unit 1: Tighten the live `niemand-work` prompt**
+
+**Goal:** Make the `Dialpad Operations` prompt refuse stale success claims and require current-turn verification before saying a send or update is already done.
+
+**Requirements:** R1, R2, R3, R4, R6
+
+**Files:**
+- Modify: `~/.openclaw/openclaw.json`
+
+**Approach:**
+- Update the `Dialpad Operations` system prompt for `telegram:group:-1003882776023` so it explicitly requires a fresh tool call in the current turn before any success claim about `send_sms.py` or `update_contact.py`.
+- Add a hard rule that stale context cannot answer "Already sent." or "Already updated." unless the current turn has a matching tool result.
+- Define a fallback phrase such as "I have not verified this turn yet" for cases where the assistant is about to act but has not yet executed a tool call.
+- Keep the existing `attio`, `web_search`, `humanizer`, and Dialpad wrapper routing intact; this is a freshness guardrail, not a new workflow.
+
+**Patterns to follow:**
+- The current `Dialpad Operations thread` prompt in `~/.openclaw/openclaw.json`
+- The existing `OpenClaw` integration guidance in this repo
+
+**Test scenarios:**
+- A repeated request in the same session no longer short-circuits to "Already sent." without a fresh tool call.
+- A current-turn send request causes the agent to either run `send_sms.py` or clearly state that it has not verified the turn yet.
+- A current-turn contact-sync request behaves the same way for `update_contact.py`.
+
+**Verification:**
+- Live operator smoke test against `niemand-work` shows current-turn verification instead of stale success narration.
+
+- [ ] **Unit 2: Document the freshness contract in the repo**
+
+**Goal:** Make the repo docs say the same thing the live prompt will enforce, so the behavior is obvious to operators and future maintainers.
+
+**Requirements:** R3, R5, R6
+
+**Files:**
+- Modify: `README.md`
+- Modify: `SKILL.md`
+- Modify: `references/openclaw-integration.md`
+- Modify: `references/api-reference.md`
+- Test: `tests/test_openclaw_integration_docs.py`
+
+**Approach:**
+- Add a short "current-turn verification" note to the Dialpad Operations guidance.
+- Clarify that "Already sent" is only valid after a fresh tool call in the current turn, not from memory.
+- Keep the separation between draft generation, send authority, and verified execution explicit.
+- Keep issue #58 and issue #64 clearly distinct in the prose so future readers do not merge the bugs.
+
+**Patterns to follow:**
+- The current human-in-the-loop sections in `references/openclaw-integration.md`
+- The wrapper guidance in `README.md` and `SKILL.md`
+- The existing `firstContact` / `autoReply` contract language in `references/api-reference.md`
+
+**Test scenarios:**
+- The docs explicitly mention current-turn verification and stale-context prohibition.
+- The docs still preserve the "draft generation vs send authority" split.
+- The docs do not confuse this bug with the earlier SMS status-label fix.
+
+**Verification:**
+- The new doc contract test passes and the docs read as a single, consistent operator policy.
+
+## System-Wide Impact
+
+- The actual behavior change lives in the OpenClaw operator config, so the repo plan needs a live config reload after the prompt update.
+- The repo docs should keep future operators from reintroducing stale success language in other instructions or handoff notes.
+
+## Risks & Dependencies
+
+- The main risk is prompt drift: if the live `niemand-work` prompt and the repo docs diverge, the stale-success bug can return.
+- Another risk is over-correction: the agent still needs to act, not just disclaim. The fallback wording must not become a dead end.
+- A third risk is scope creep into memory systems or new agent architecture. This issue only needs a freshness gate and clearer operator wording.
+
+## Verification
+
+- Confirm that a current-turn send/update request no longer produces "Already sent." from stale context alone.
+- Confirm that the docs and live prompt both describe the same freshness rule.
+- Confirm that issue #58 remains separate and unchanged by this work.
+
+## Sources & References
+
+- **Origin issue:** [#64](https://github.com/kesslerio/dialpad-openclaw-skill/issues/64)
+- Related repo docs: [README.md](/home/art/projects/skills/work/dialpad-openclaw-skill/README.md), [SKILL.md](/home/art/projects/skills/work/dialpad-openclaw-skill/SKILL.md), [references/openclaw-integration.md](/home/art/projects/skills/work/dialpad-openclaw-skill/references/openclaw-integration.md), [references/api-reference.md](/home/art/projects/skills/work/dialpad-openclaw-skill/references/api-reference.md)
+- Related live config: `/home/art/.openclaw/openclaw.json`
+- Related trace: `/home/art/.openclaw/agents/niemand-work/sessions/8b39045a-630a-4cf6-a9e0-b1f1f6211615.jsonl`

--- a/references/api-reference.md
+++ b/references/api-reference.md
@@ -192,6 +192,7 @@ Behavior notes:
 - For unknown inbound contacts, the hook may include a `firstContact` hint with lookup and reply-drafting signals; downstream users can map that to Attio, HubSpot, Airtable, or any other source of truth
 - The webhook server also adds `autoReply` metadata when it sends the sales-line acknowledgment directly, so downstream automation can avoid double-sending the same reply
 - The repo preserves the current top-level OpenClaw hook envelope and does not claim end-to-end validation of downstream proactive enrichment behavior
+- Current-turn verification still applies to `niemand-work`: stale context must not produce "Already sent" or "Already updated"; only a fresh tool result in the same turn can justify those claims.
 - If your gateway listens on a different port, change `OPENCLAW_GATEWAY_URL` accordingly.
 
 ### Advanced Webhooks (CLI)

--- a/references/api-reference.md
+++ b/references/api-reference.md
@@ -40,6 +40,7 @@ The OpenAPI-generated CLI (`generated/dialpad`) exposes 241 endpoints. It is the
 - `--dry-run` shows resolved sender and the exact message payload without sending.
 - `bin/send_group_intro.py` performs a mirrored fallback (`mode: mirrored_fallback`) by sending two separate one-to-one SMS messages because the wrapper does not guarantee a true group thread.
 - `bin/list_calls.py` provides agent-safe recent call history with `--hours` or `--today`, optional missed-call filtering, and `--json` for a machine-readable envelope.
+- `firstContact` includes an explicit `identityState` and raw lookup status so downstream agents can keep weak matches draft-only instead of mutating a contact record too early.
 
 ```bash
 bin/send_sms.py --to "+14155550111" --message 'Hello' --profile work
@@ -190,6 +191,7 @@ Behavior notes:
 - Voicemail notifications remain Telegram-only for OpenClaw fan-out, but first-contact sales-line voicemails also get the SMS acknowledgment when auto-replies are enabled
 - The local OpenClaw gateway allows explicit `niemand-work` routing and the `hook:dialpad:` session-key namespace
 - For unknown inbound contacts, the hook may include a `firstContact` hint with lookup and reply-drafting signals; downstream users can map that to Attio, HubSpot, Airtable, or any other source of truth
+- Identity states are preserved as data, not implied behavior: `resolved` is safe to mutate, while `ambiguous`, `not_found`, and `degraded` should stay non-mutating until the CRM/agent layer proves the identity
 - The webhook server also adds `autoReply` metadata when it sends the sales-line acknowledgment directly, so downstream automation can avoid double-sending the same reply
 - The repo preserves the current top-level OpenClaw hook envelope and does not claim end-to-end validation of downstream proactive enrichment behavior
 - Current-turn verification still applies to `niemand-work`: stale context must not produce "Already sent" or "Already updated"; only a fresh tool result in the same turn can justify those claims.

--- a/references/openclaw-integration.md
+++ b/references/openclaw-integration.md
@@ -124,6 +124,7 @@ The webhook may include a `firstContact` object for first-time or otherwise unkn
 
 ```json
 {
+  "identityState": "not_found",
   "knownContact": false,
   "needsIdentityLookup": true,
   "needsBusinessContext": true,
@@ -145,10 +146,12 @@ The webhook may include a `firstContact` object for first-time or otherwise unkn
 
 Interpretation:
 
+- `identityState` is the normalized identity result carried through the hook; only `resolved` is safe to treat as auto-mutable
 - when `knownContact` is `false`, do the identity/business lookup first
 - use Attio if that is your source of truth, or plug in a different CRM/directory if you do not use Attio
 - if lookup is still ambiguous, use web research as fallback and keep the output concise
 - if the match is clear, suggest Dialpad contact normalization or update
+- if the evidence is only first name, area code, industry, or job title, keep the lead ambiguous and draft-only until stronger proof appears
 - if `keepBrief` is `true`, skip the long background pass and stay short
 - if `autoReply` is present, the webhook server already sent the sales-line acknowledgment and downstream automation should not send the same reply again
 
@@ -268,6 +271,7 @@ SMS:
   "body": "Need a callback",
   "callId": null,
   "firstContact": {
+    "identityState": "not_found",
     "knownContact": false,
     "needsIdentityLookup": true,
     "needsBusinessContext": true,
@@ -307,6 +311,7 @@ Missed call:
   "body": null,
   "callId": "call-123",
   "firstContact": {
+    "identityState": "resolved",
     "knownContact": true,
     "needsIdentityLookup": false,
     "needsBusinessContext": false,
@@ -363,6 +368,13 @@ Current-turn verification applies here too:
 - Stale session memory is not proof of a send or contact update.
 - If the current turn has not verified the action yet, say so plainly and continue with the send/update step.
 
+Suggested identity states:
+
+- `resolved` when the payload already carries a strong contact match or the downstream CRM proves identity with strong evidence
+- `ambiguous` when the downstream CRM can narrow to a candidate but not prove it, or the evidence is too soft to mutate
+- `not_found` when no strong match exists yet and the lead should stay draft-only until more evidence appears
+- `degraded` when lookup failed or is partially unavailable
+
 Suggested state fields:
 
 ```json
@@ -403,6 +415,7 @@ OpenClaw should:
 - dedupe using `sessionKey`
 - never assume duplicate delivery means duplicate user intent
 - separate "draft generation" from "send authority"
+- require `identityState == "resolved"` before any contact mutation; `ambiguous`, `not_found`, and `degraded` stay draft-only
 - require current-turn verification before any success claim about sending or updating
 - treat stale context as non-evidence for "Already sent" or "Already updated"
 

--- a/references/openclaw-integration.md
+++ b/references/openclaw-integration.md
@@ -357,6 +357,12 @@ The safe default is:
    - reject
    - mark for callback
 
+Current-turn verification applies here too:
+
+- "Already sent" and "Already updated" are only valid after a fresh tool result in the same turn.
+- Stale session memory is not proof of a send or contact update.
+- If the current turn has not verified the action yet, say so plainly and continue with the send/update step.
+
 Suggested state fields:
 
 ```json
@@ -397,6 +403,8 @@ OpenClaw should:
 - dedupe using `sessionKey`
 - never assume duplicate delivery means duplicate user intent
 - separate "draft generation" from "send authority"
+- require current-turn verification before any success claim about sending or updating
+- treat stale context as non-evidence for "Already sent" or "Already updated"
 
 Outbound send must always enforce `sendMode`.
 

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -1125,6 +1125,13 @@ def build_first_contact_context(normalized_event, sender_enrichment=None, line_d
     contact_name_text = str(contact_name or "").strip()
     known_contact = bool(contact_name_text) and contact_name_text.lower() != "unknown"
     first_contact_candidate = not known_contact
+    lookup_status = str(sender_enrichment.get("status") or "not_applicable")
+    if sender_enrichment.get("degraded") or lookup_status in {"disabled", "not_applicable"}:
+        identity_state = "degraded"
+    elif known_contact:
+        identity_state = "resolved"
+    else:
+        identity_state = lookup_status
 
     return {
         "knownContact": known_contact,
@@ -1133,13 +1140,14 @@ def build_first_contact_context(normalized_event, sender_enrichment=None, line_d
         "needsDraftReply": first_contact_candidate,
         "needsDialpadContactSync": first_contact_candidate,
         "keepBrief": not first_contact_candidate,
+        "identityState": identity_state,
         "contactName": contact_name,
         "senderNumber": normalized_event.get("sender_number"),
         "recipientNumber": normalized_event.get("recipient_number"),
         "lineDisplay": line_display or normalized_event.get("line_display"),
         "eventType": event_type,
         "lookup": {
-            "status": sender_enrichment.get("status", "not_applicable"),
+            "status": lookup_status,
             "degraded": bool(sender_enrichment.get("degraded")),
             "degradedReason": sender_enrichment.get("degraded_reason"),
         },

--- a/tests/test_openclaw_integration_docs.py
+++ b/tests/test_openclaw_integration_docs.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_openclaw_docs_require_current_turn_verification():
+    readme = (ROOT / "README.md").read_text().lower()
+    skill = (ROOT / "SKILL.md").read_text().lower()
+    api_reference = (ROOT / "references/api-reference.md").read_text().lower()
+    integration = (ROOT / "references/openclaw-integration.md").read_text().lower()
+
+    assert "current-turn verification" in readme
+    assert "current-turn verification" in skill
+    assert "current-turn verification" in api_reference
+    assert "current-turn verification" in integration
+
+    assert "stale session memory" in readme
+    assert "stale session memory" in skill
+    assert "fresh tool result in the same turn" in api_reference
+    assert "fresh tool result in the same turn" in integration

--- a/tests/test_openclaw_integration_docs.py
+++ b/tests/test_openclaw_integration_docs.py
@@ -19,3 +19,9 @@ def test_openclaw_docs_require_current_turn_verification():
     assert "stale session memory" in skill
     assert "fresh tool result in the same turn" in api_reference
     assert "fresh tool result in the same turn" in integration
+    assert "identitystate" in readme
+    assert "identitystate" in api_reference
+    assert "identitystate" in integration
+    assert "ambiguous" in integration
+    assert "first name" in integration
+    assert "area code" in integration

--- a/tests/test_sender_enrichment.py
+++ b/tests/test_sender_enrichment.py
@@ -143,6 +143,7 @@ def test_lookup_contact_enrichment_401_degraded_and_cached_fallback(monkeypatch)
     assert hook_calls[0]["normalized_sms"]["sender"] == "Cached Person"
     assert hook_calls[0]["normalized_sms"]["first_contact"]["knownContact"] is True
     assert hook_calls[0]["normalized_sms"]["first_contact"]["keepBrief"] is True
+    assert hook_calls[0]["normalized_sms"]["first_contact"]["identityState"] == "degraded"
 
 
 def test_inbound_telegram_uses_enriched_sender(monkeypatch):
@@ -228,6 +229,7 @@ def test_inbound_webhook_hook_uses_enriched_sender(monkeypatch):
     assert hook_calls[0]["normalized_sms"]["sender"] == "Jane Doe"
     assert hook_calls[0]["normalized_sms"]["first_contact"]["knownContact"] is True
     assert hook_calls[0]["normalized_sms"]["first_contact"]["keepBrief"] is True
+    assert hook_calls[0]["normalized_sms"]["first_contact"]["identityState"] == "resolved"
     assert response["hook_forwarded"] is True
     assert response["sender_enrichment_status"] == "resolved"
     assert response["sender_enrichment_degraded"] is False
@@ -275,6 +277,7 @@ def test_inbound_webhook_hook_marks_unknown_sender_first_contact_candidate(monke
     assert hook_calls[0]["normalized_sms"]["first_contact"]["needsIdentityLookup"] is True
     assert hook_calls[0]["normalized_sms"]["first_contact"]["needsDraftReply"] is True
     assert hook_calls[0]["normalized_sms"]["first_contact"]["keepBrief"] is False
+    assert hook_calls[0]["normalized_sms"]["first_contact"]["identityState"] == "not_found"
 
 
 def test_inbound_sales_sms_auto_replies_on_first_contact(monkeypatch):
@@ -339,6 +342,7 @@ def test_inbound_sales_sms_auto_replies_on_first_contact(monkeypatch):
     assert sms_calls[0]["to_numbers"] == ["+14155550123"]
     assert sms_calls[0]["from_number"] == "+14155201316"
     assert "ShapeScale for Business Sales" in sms_calls[0]["message"]
+    assert hook_calls[0]["normalized_sms"]["first_contact"]["identityState"] == "not_found"
     assert response["auto_reply_sent"] is True
     assert response["auto_reply_status"] == "accepted/queued"
 

--- a/tests/test_webhook_hooks.py
+++ b/tests/test_webhook_hooks.py
@@ -145,6 +145,7 @@ def test_hook_payload_includes_optional_agent_channel_and_to(monkeypatch):
             "needsDraftReply": True,
             "needsDialpadContactSync": True,
             "keepBrief": False,
+            "identityState": "not_found",
             "contactName": None,
             "senderNumber": "+14155550123",
             "recipientNumber": "+14155559876",
@@ -171,6 +172,7 @@ def test_hook_payload_includes_optional_agent_channel_and_to(monkeypatch):
     assert payload["agentId"] == "niemand-work"
     assert payload["sessionKey"] == "hook:dialpad:sms:conv-123"
     assert payload["firstContact"]["needsDraftReply"] is True
+    assert payload["firstContact"]["identityState"] == "not_found"
     assert payload["autoReply"]["sent"] is True
 
 
@@ -226,6 +228,7 @@ def test_call_hook_payload_uses_shared_envelope(monkeypatch):
         "timestamp": 1760000000000,
         "call_id": "call-123",
         "first_contact": {
+            "identityState": "resolved",
             "knownContact": True,
             "needsIdentityLookup": False,
             "needsBusinessContext": False,
@@ -256,5 +259,6 @@ def test_call_hook_payload_uses_shared_envelope(monkeypatch):
     assert payload["deliver"] is True
     assert payload["sessionKey"] == "hook:dialpad:call:call-123"
     assert "📞 Dialpad Missed Call" in payload["message"]
+    assert payload["firstContact"]["identityState"] == "resolved"
     assert payload["firstContact"]["keepBrief"] is True
     assert payload["autoReply"]["eligible"] is False

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -416,6 +416,7 @@ class CallWebhookHandlerTests(unittest.TestCase):
         self.assertEqual(hook_calls[0]["normalized_event"]["call_id"], "call-123")
         self.assertEqual(hook_calls[0]["normalized_event"]["first_contact"]["knownContact"], False)
         self.assertEqual(hook_calls[0]["normalized_event"]["first_contact"]["keepBrief"], False)
+        self.assertEqual(hook_calls[0]["normalized_event"]["first_contact"]["identityState"], "not_found")
         self.assertIn("ShapeScale for Business Sales", sms_calls[0]["message"])
         self.assertEqual(len(telegram_messages), 1)
         self.assertTrue(response["missed_call"])


### PR DESCRIPTION
What
- Add `firstContact.identityState` to the webhook payload so first-contact ambiguity stays explicit.
- Preserve sender lookup state for SMS and missed-call paths instead of collapsing weak signals into a single authoritative identity.
- Harden the live OpenClaw prompt and repo docs so ambiguous contacts stay draft-only until the CRM layer proves a strong match.

Why
- The current flow can overcommit on first name, area code, or job-title similarity and mutate the wrong contact.
- Keeping the ambiguity state visible lets `niemand-work` draft replies without turning soft evidence into a merge/update.

Tests
- `pytest -q tests/test_sender_enrichment.py tests/test_webhook_hooks.py tests/test_webhook_server.py tests/test_openclaw_integration_docs.py`
- `python3 -m py_compile scripts/webhook_server.py`

AI Assistance
- Used: yes.
- Testing: automated local tests were run.
- Prompt/session log: [plan](https://github.com/kesslerio/dialpad-openclaw-skill/blob/main/docs/plans/2026-03-26-001-fix-contact-ambiguity-guard-plan.md) and [brainstorm](https://github.com/kesslerio/dialpad-openclaw-skill/blob/main/docs/brainstorms/2026-03-26-dialpad-contact-ambiguity-guard-requirements.md).
- I understand this code.
