### PR TITLE
Fix: poller conflates Dialpad timeout with zero-result scan (#68)

### DIFF
--- a/scripts/poll_voicemails.py
+++ b/scripts/poll_voicemails.py
@@ -194,23 +194,33 @@ def fetch_inbound_calls(api_key, lookback_ms=None, now_ms=None):
 
         req = urllib.request.Request(url, headers=headers)
         with urllib.request.urlopen(req, timeout=20) as response:
-            data = json.loads(response.read().decode("utf-8"))
+            raw_response = response.read().decode("utf-8")
+            try:
+                data = json.loads(raw_response)
+            except json.JSONDecodeError as exc:
+                print(f"❌ Failed to parse Dialpad JSON response: {exc}\nResponse: {raw_response[:200]}...", file=sys.stderr)
+                raise RuntimeError(f"Invalid JSON response from Dialpad API")
 
         if isinstance(data, list):
             all_calls.extend(data)
             break
 
         if not isinstance(data, dict):
-            break
+            print(f"❌ Unexpected Dialpad API response structure (not dict/list): {type(data)}", file=sys.stderr)
+            raise RuntimeError(f"Unexpected API response structure")
 
         items = []
+        found_key = False
         for key in ("items", "calls", "data", "results"):
             value = data.get(key)
             if isinstance(value, list):
                 items = value
+                found_key = True
                 break
 
-        all_calls.extend(items)
+        if not found_key:
+            print(f"❌ Could not find items/calls/data key in Dialpad response: {data.keys()}", file=sys.stderr)
+            raise RuntimeError(f"Missing items in API response")
 
         # Stop paginating if all items on this page are older than lookback
         if lookback_ms and now_ms and items:

--- a/scripts/poll_voicemails.py
+++ b/scripts/poll_voicemails.py
@@ -340,12 +340,10 @@ def main():
                 calls = fetch_inbound_calls(DIALPAD_API_KEY, lookback_ms=lookback_ms, now_ms=now_ms)
             except urllib.error.HTTPError as exc:
                 print(f"❌ Dialpad API HTTP error: {exc.code} {exc.reason}", file=sys.stderr)
-                print("found 0 voicemail(s), notified 0 new")
-                return 0
+                return 1
             except Exception as exc:
                 print(f"❌ Dialpad API request failed: {exc}", file=sys.stderr)
-                print("found 0 voicemail(s), notified 0 new")
-                return 0
+                return 1
             voicemails = [
                 call
                 for call in calls

--- a/tests/test_voicemail_poller_error_handling.py
+++ b/tests/test_voicemail_poller_error_handling.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import json
+import sys
+import unittest
+import urllib.error
+from unittest.mock import patch, MagicMock
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import poll_voicemails
+
+class _FakeResponse:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status = status
+
+    def read(self):
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+class VoicemailPollerErrorTests(unittest.TestCase):
+    def test_main_exits_with_error_on_http_failure(self):
+        with patch("poll_voicemails.urllib.request.urlopen", side_effect=urllib.error.HTTPError("url", 500, "Internal Server Error", {}, None)):
+            with patch.dict("poll_voicemails.os.environ", {"DIALPAD_API_KEY": "fake-key"}):
+                with patch("poll_voicemails.sqlite3.connect"):
+                    exit_code = poll_voicemails.main()
+                    self.assertEqual(exit_code, 1)
+
+    def test_main_exits_with_error_on_network_timeout(self):
+        # urllib.request.urlopen can raise TimeoutError or socket.timeout which is often wrapped in URLError
+        with patch("poll_voicemails.urllib.request.urlopen", side_effect=RuntimeError("The read operation timed out")):
+            with patch.dict("poll_voicemails.os.environ", {"DIALPAD_API_KEY": "fake-key"}):
+                with patch("poll_voicemails.sqlite3.connect"):
+                    exit_code = poll_voicemails.main()
+                    self.assertEqual(exit_code, 1)
+
+    def test_main_exits_with_zero_on_success_with_no_calls(self):
+        response = _FakeResponse({"items": []})
+        with patch("poll_voicemails.urllib.request.urlopen", return_value=response):
+            with patch.dict("poll_voicemails.os.environ", {"DIALPAD_API_KEY": "fake-key"}):
+                with patch("poll_voicemails.sqlite3.connect"):
+                    # We need to mock the cursor and return value for the SELECT 1 FROM voicemails_seen
+                    exit_code = poll_voicemails.main()
+                    self.assertEqual(exit_code, 0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ensures that the poller script returns a non-zero exit code when the Dialpad API request fails (e.g., due to a timeout or HTTP error). This allows the cron runner/watchdog to distinguish between a failed scan and a genuine zero-result scan, preventing the 'found 0 voicemail(s)' message from being treated as a successful scan in error scenarios.

Related to #68