### PR TITLE
fix(dialpad): gate SMS replies behind approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ bin/send_sms.py --to "+14155551234" --message 'Hello' --profile work
 printf '%s' 'The premium hardshell travel case is $499.' | \
   bin/send_sms.py --to "+14155551234" --from "+14155201316" --message-stdin --dry-run
 
+# Create and approve an exact-text SMS draft
+bin/create_sms_draft.py --thread-key "hook:dialpad:sms:conv-123" --to "+14155551234" --from "+14155201316" --message 'Draft text' --json
+bin/approve_sms_draft.py smsdraft_abc123 --actor-id "telegram-user-123" --actor-username "operator" --approval-token "$DIALPAD_SMS_APPROVAL_TOKEN" --json
+
 # Make a call with TTS
 bin/make_call.py --to "+14155551234" --text "This is a test call."
 
@@ -68,22 +72,25 @@ export OPENCLAW_HOOKS_NAME="Dialpad SMS"
 export OPENCLAW_HOOKS_CALL_NAME="Dialpad Missed Call"
 export OPENCLAW_HOOKS_AGENT_ID="niemand-work"
 
-# Optional per-event hook controls (enabled by default)
+# Optional per-event hook controls (disabled by default)
 export OPENCLAW_HOOKS_SMS_ENABLED="1"
 export OPENCLAW_HOOKS_CALL_ENABLED="1"
 
-# Optional sales-line first-contact auto-replies (enabled by default)
+# Optional sales-line first-contact auto-replies (disabled by default)
 export DIALPAD_AUTO_REPLY_ENABLED="1"
+export DIALPAD_SMS_APPROVAL_DB="/home/art/clawd/logs/sms_approvals.db"
+export DIALPAD_SMS_APPROVAL_TOKEN="operator-only-random-token"
 ```
 
-When `OPENCLAW_HOOKS_TOKEN` is configured, inbound SMS and inbound missed-call events are forwarded to OpenClaw by default. Set `OPENCLAW_HOOKS_SMS_ENABLED=0` or `OPENCLAW_HOOKS_CALL_ENABLED=0` to disable one event class without changing the shared destination config.
+When `OPENCLAW_HOOKS_TOKEN` is configured, inbound SMS and inbound missed-call events are only forwarded to OpenClaw when the matching event flag is explicitly enabled. Leave `OPENCLAW_HOOKS_SMS_ENABLED=0` and `OPENCLAW_HOOKS_CALL_ENABLED=0` for notification-only mode.
 If your gateway listens on a different port, change `OPENCLAW_GATEWAY_URL` accordingly.
 The local gateway allows explicit `niemand-work` routing and `hook:dialpad:` session keys.
 For first-time or unknown inbound contacts, the payload also carries a `firstContact` hint with an explicit `identityState` plus lookup details so OpenClaw can enrich identity, look up business context, draft a reply, and suggest Dialpad contact sync when the match is clear.
 That pattern is CRM-agnostic: Attio is one example, but the same setup works with HubSpot, Pipedrive, Airtable, a spreadsheet, or a custom directory service downstream.
 Current-turn verification still applies: "Already sent" and "Already updated" are only valid after a fresh current-turn tool result, not from stale session memory.
 For identity work, treat `resolved` as the only state that is safe to mutate automatically; `not_found`, `ambiguous`, and `degraded` stay draft-only until the CRM layer proves otherwise.
-When `DIALPAD_AUTO_REPLY_ENABLED` is set, first-contact inbound events to the sales line `(415) 520-1316` get a short SMS acknowledgment automatically before the hook handoff continues. Missed calls get a "sorry we missed you" variant; SMS and voicemail get a "we'll be in touch shortly" variant.
+When `DIALPAD_AUTO_REPLY_ENABLED` is set, first-contact inbound events to the sales line `(415) 520-1316` create a short exact-text approval draft instead of sending SMS directly. Missed calls get a "sorry we missed you" draft variant; SMS and voicemail get a "we'll be in touch shortly" draft variant. Explicit opt-out language creates no draft, invalidates pending drafts for that customer, and sends only a human-only Telegram notice.
+CLI approval is disabled unless `DIALPAD_SMS_APPROVAL_TOKEN` is configured and supplied to `bin/approve_sms_draft.py`; keep that token out of agent runtime environments.
 
 Create/list webhook subscriptions:
 
@@ -96,7 +103,7 @@ Notes:
 
 - `/webhook/dialpad` handles SMS storage plus optional OpenClaw/Telegram fan-out
 - `/webhook/dialpad-call` handles missed-call Telegram alerts using the event timestamp when available, with dynamic Markdown escaping, plus optional OpenClaw hook forwarding
-- `/webhook/dialpad-voicemail` remains Telegram-only for OpenClaw fan-out, but first-contact sales-line voicemails also get the SMS acknowledgment when auto-replies are enabled
+- `/webhook/dialpad-voicemail` sends Telegram alerts and can create first-contact sales-line SMS approval drafts, but does not send SMS directly
 - This repo validates hook request shape, gating, and graceful degradation only. It does not validate downstream OpenClaw proactive enrichment behavior
 
 ## Operational Tools
@@ -106,6 +113,10 @@ These commands are for manual operator workflows, storage inspection, and mainte
 ```bash
 # SMS SQLite history
 python3 scripts/sms_sqlite.py list
+
+# SMS approval drafts
+python3 scripts/create_sms_draft.py --thread-key "manual:test" --to "+14155551234" --from "+14155201316" --message 'Draft text' --json
+python3 scripts/approve_sms_draft.py smsdraft_abc123 --actor-id "telegram-user-123" --approval-token "$DIALPAD_SMS_APPROVAL_TOKEN" --json
 
 # Deep webhook/storage operations
 python3 scripts/webhook_server.py

--- a/SKILL.md
+++ b/SKILL.md
@@ -31,6 +31,12 @@ Use this skill to:
 bin/send_sms.py --to "+14155551234" --from "+14155201316" --message 'Hello from OpenClaw!'
 ```
 
+**Create/approve an SMS draft (human approval path):**
+```bash
+bin/create_sms_draft.py --thread-key "manual:thread" --to "+14155551234" --from "+14155201316" --message 'Exact draft text' --json
+bin/approve_sms_draft.py smsdraft_abc123 --actor-id "telegram-user-123" --actor-username "operator" --approval-token "$DIALPAD_SMS_APPROVAL_TOKEN" --json
+```
+
 **Group Intro (mirrored fallback):**
 ```bash
 bin/send_group_intro.py --prospect "+14155550111" --reference "+14155559999" --confirm-share --from "+14153602954"
@@ -78,6 +84,8 @@ bin/update_contact.py --id "contact_123" --phone "+14155550123" --job-title "VP"
 10. **Create/Update Contact Behavior:** `bin/create_contact.py` upserts shared/local contacts by phone/email match (or forces create with `--allow-duplicate`). `bin/update_contact.py` updates by `--id` with partial fields.
 11. **Current-turn verification:** "Already sent" and "Already updated" are only valid after a fresh current-turn tool result, not from stale session memory. If the current turn has not verified the action yet, say that plainly and run the tool now.
 12. **Identity guardrail:** For first-contact work, soft signals like first name, area code, industry, or job title are not enough to merge or update a contact. Keep uncertain identity `draft-only` and let the CRM layer prove the match before mutating anything.
+13. **Inbound automation guardrail:** Dialpad inbound hooks may create SMS approval drafts, but they must not send customer SMS directly. Use `bin/approve_sms_draft.py` only with a real human actor id and an operator-only `DIALPAD_SMS_APPROVAL_TOKEN`; agent/bot actors are rejected by the approval ledger.
+14. **Opt-out guardrail:** Explicit opt-out language is a hard stop. Do not create override drafts or send follow-ups on those threads unless a human operator handles the conversation outside automation.
 
 ## Reference Documentation
 

--- a/bin/_dialpad_compat.py
+++ b/bin/_dialpad_compat.py
@@ -33,6 +33,8 @@ COMMAND_IDS = {
     "create_contact.upsert": "create_contact.upsert",
     "update_contact.update": "update_contact.update",
     "send_group_intro.send": "send_group_intro.send",
+    "create_sms_draft.create": "create_sms_draft.create",
+    "approve_sms_draft.approve": "approve_sms_draft.approve",
     "create_sms_webhook.create": "create_sms_webhook.create",
     "create_sms_webhook.list": "create_sms_webhook.list",
     "create_sms_webhook.delete": "create_sms_webhook.delete",

--- a/bin/approve_sms_draft.py
+++ b/bin/approve_sms_draft.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Stable wrapper for approving Dialpad SMS drafts."""
+
+from __future__ import annotations
+
+import argparse
+import hmac
+import os
+import sys
+from pathlib import Path
+
+from _dialpad_compat import (
+    COMMAND_IDS,
+    WrapperArgumentParser,
+    WrapperError,
+    emit_success,
+    handle_wrapper_exception,
+    print_wrapper_error,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from sms_approval import ACTION_APPROVE, ACTION_CONFIRM_RISK, approve_draft, init_db
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = WrapperArgumentParser(description="Approve a Dialpad SMS draft")
+    parser.add_argument("draft_id")
+    parser.add_argument("--action", choices=(ACTION_APPROVE, ACTION_CONFIRM_RISK), default=ACTION_APPROVE)
+    parser.add_argument("--actor-id", required=True)
+    parser.add_argument("--actor-username")
+    parser.add_argument("--actor-is-bot", action="store_true")
+    parser.add_argument("--approval-token")
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def require_approval_token(provided_token: str | None) -> None:
+    expected_token = os.environ.get("DIALPAD_SMS_APPROVAL_TOKEN")
+    if not expected_token:
+        raise WrapperError(
+            "DIALPAD_SMS_APPROVAL_TOKEN is not configured; CLI approval is disabled.",
+            code="validation_failed",
+            retryable=False,
+        )
+    if not provided_token or not hmac.compare_digest(provided_token, expected_token):
+        raise WrapperError("Invalid or missing approval token.", code="validation_failed", retryable=False)
+
+
+def main() -> int:
+    json_mode = "--json" in sys.argv
+    command = COMMAND_IDS["approve_sms_draft.approve"]
+    wrapper = "approve_sms_draft.py"
+
+    try:
+        args = build_parser().parse_args()
+        json_mode = args.json
+        require_approval_token(args.approval_token)
+        conn = init_db()
+        try:
+            result = approve_draft(
+                conn,
+                draft_id=args.draft_id,
+                actor_id=args.actor_id,
+                actor_username=args.actor_username,
+                action=args.action,
+                actor_is_bot=args.actor_is_bot,
+            )
+        finally:
+            conn.close()
+
+        if not result.get("ok"):
+            raise WrapperError(str(result.get("status") or "approval_failed"), code="validation_failed", retryable=False, meta={"result": result})
+        if json_mode:
+            emit_success(command, wrapper, result)
+        elif result.get("sent"):
+            print(f"SMS sent: {result.get('dialpad_sms_id') or 'unknown id'}")
+        else:
+            print(f"SMS not sent: {result.get('status')}")
+        return 0 if result.get("ok") else 2
+    except WrapperError as err:
+        if json_mode:
+            return handle_wrapper_exception(command, wrapper, err, True)
+        print_wrapper_error(err)
+        return 2
+    except Exception as err:  # noqa: BLE001 - wrapper boundary
+        if json_mode:
+            return handle_wrapper_exception(command, wrapper, err, True)
+        print_wrapper_error(err)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/create_sms_draft.py
+++ b/bin/create_sms_draft.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Stable wrapper for creating Dialpad SMS approval drafts."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from _dialpad_compat import (
+    COMMAND_IDS,
+    WrapperArgumentParser,
+    WrapperError,
+    emit_success,
+    handle_wrapper_exception,
+    print_wrapper_error,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from sms_approval import RISK_NORMAL, RISK_RISKY, create_draft, init_db, invalidate_pending
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = WrapperArgumentParser(description="Create a Dialpad SMS approval draft")
+    parser.add_argument("--thread-key", required=True)
+    parser.add_argument("--to", required=True, dest="customer_number")
+    parser.add_argument("--from", required=True, dest="sender_number")
+    message_group = parser.add_mutually_exclusive_group(required=True)
+    message_group.add_argument("--message")
+    message_group.add_argument("--message-file")
+    message_group.add_argument("--message-stdin", action="store_true")
+    parser.add_argument("--source-inbound-id")
+    parser.add_argument("--risk-state", choices=(RISK_NORMAL, RISK_RISKY), default=RISK_NORMAL)
+    parser.add_argument("--risk-reason")
+    parser.add_argument("--context-fingerprint")
+    parser.add_argument("--keep-pending", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def resolve_message_text(args: argparse.Namespace) -> tuple[str, str]:
+    if args.message is not None:
+        return args.message, "--message"
+    if args.message_file:
+        try:
+            return Path(args.message_file).read_text(encoding="utf-8"), "--message-file"
+        except (OSError, UnicodeDecodeError) as exc:
+            raise WrapperError(
+                f"Failed to read --message-file '{args.message_file}': {exc}",
+                code="invalid_argument",
+                retryable=False,
+            ) from exc
+    message = sys.stdin.read()
+    if not message:
+        raise WrapperError("Message text from --message-stdin is empty.", code="invalid_argument", retryable=False)
+    return message, "--message-stdin"
+
+
+def main() -> int:
+    json_mode = "--json" in sys.argv
+    command = COMMAND_IDS["create_sms_draft.create"]
+    wrapper = "create_sms_draft.py"
+
+    try:
+        args = build_parser().parse_args()
+        json_mode = args.json
+        message, message_source = resolve_message_text(args)
+        conn = init_db()
+        try:
+            if not args.keep_pending:
+                invalidate_pending(conn, thread_key=args.thread_key, reason="superseded_by_new_draft")
+            draft = create_draft(
+                conn,
+                thread_key=args.thread_key,
+                customer_number=args.customer_number,
+                sender_number=args.sender_number,
+                draft_text=message,
+                source_inbound_id=args.source_inbound_id,
+                risk_state=args.risk_state,
+                risk_reason=args.risk_reason,
+                context_fingerprint=args.context_fingerprint,
+                metadata={"message_source": message_source},
+            )
+        finally:
+            conn.close()
+
+        if json_mode:
+            emit_success(command, wrapper, {"draft": draft, "message_source": message_source})
+        else:
+            print(f"Draft created: {draft['draft_id']}")
+        return 0
+    except WrapperError as err:
+        if json_mode:
+            return handle_wrapper_exception(command, wrapper, err, True)
+        print_wrapper_error(err)
+        return 2
+    except Exception as err:  # noqa: BLE001 - wrapper boundary
+        if json_mode:
+            return handle_wrapper_exception(command, wrapper, err, True)
+        print_wrapper_error(err)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/create_sms_draft.py
+++ b/bin/create_sms_draft.py
@@ -19,7 +19,7 @@ from _dialpad_compat import (
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
-from sms_approval import RISK_NORMAL, RISK_RISKY, create_draft, init_db, invalidate_pending
+from sms_approval import RISK_NORMAL, RISK_RISKY, create_draft, create_replacement_draft, init_db
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -69,20 +69,26 @@ def main() -> int:
         message, message_source = resolve_message_text(args)
         conn = init_db()
         try:
-            if not args.keep_pending:
-                invalidate_pending(conn, thread_key=args.thread_key, reason="superseded_by_new_draft")
-            draft = create_draft(
-                conn,
-                thread_key=args.thread_key,
-                customer_number=args.customer_number,
-                sender_number=args.sender_number,
-                draft_text=message,
-                source_inbound_id=args.source_inbound_id,
-                risk_state=args.risk_state,
-                risk_reason=args.risk_reason,
-                context_fingerprint=args.context_fingerprint,
-                metadata={"message_source": message_source},
-            )
+            draft_args = {
+                "thread_key": args.thread_key,
+                "customer_number": args.customer_number,
+                "sender_number": args.sender_number,
+                "draft_text": message,
+                "source_inbound_id": args.source_inbound_id,
+                "risk_state": args.risk_state,
+                "risk_reason": args.risk_reason,
+                "context_fingerprint": args.context_fingerprint,
+                "metadata": {"message_source": message_source},
+            }
+            if args.keep_pending:
+                draft = create_draft(conn, **draft_args)
+            else:
+                draft = create_replacement_draft(
+                    conn,
+                    invalidate_thread_key=args.thread_key,
+                    invalidate_customer_number=args.customer_number,
+                    **draft_args,
+                )
         finally:
             conn.close()
 

--- a/docs/brainstorms/2026-04-24-dialpad-one-click-sms-approval-requirements.md
+++ b/docs/brainstorms/2026-04-24-dialpad-one-click-sms-approval-requirements.md
@@ -1,0 +1,88 @@
+---
+date: 2026-04-24
+topic: dialpad-one-click-sms-approval
+---
+
+# Dialpad One-Click SMS Approval
+
+## Problem Frame
+Dialpad inbound SMS automation can currently cross the line from helpful drafting into unsafe outbound messaging. The immediate failure mode is an agent sending or preparing customer replies without a fresh human approval, including after the customer asked for a real person or wanted outreach to stop.
+
+The desired capability is not autonomous SMS. The desired capability is fast human approval: the agent may enrich context and propose an exact reply, but a real operator must authorize any outbound SMS from the review surface.
+
+## Requirements
+
+**Send Authority**
+- R1. Inbound Dialpad SMS must never cause an outbound SMS without an explicit human approval action.
+- R2. The default behavior for inbound SMS is notification plus draft generation, not sending.
+- R3. The preferred approval UX is a Telegram inline button when callback support exists; if not, the fallback must be a command-based approval such as `/send <draft-id>` with the same safety rules.
+- R4. Approval must send the exact draft text shown to the operator. Editing the text creates a new draft and resets approval.
+- R5. A pending approval is invalidated by any newer inbound customer message, any manual outbound message in the same thread, or any material CRM/calendar state change used by the draft.
+
+**Risk and Escalation**
+- R6. Messages that express anger, confusion, request for a real person, legal/compliance concern, or similar elevated risk must require two-step confirmation before sending.
+- R7. The first step for a risky message may select the draft, but the second step must explicitly show the risk reason before the SMS is sent.
+- R8. Any real Telegram group member may perform the second confirmation, but the agent or bot must never be able to confirm its own draft.
+- R9. The system must log the approving actor, timestamp, draft id, risk reason when present, and resulting SMS delivery id when a send succeeds.
+- R10. Explicit opt-out language such as "stop", "do not contact me", "don't bother me", or "remove me" must hard-stop automation: no draft, no send button, no two-step override.
+
+**Operator Experience**
+- R11. The review message must clearly distinguish draft text from sent text.
+- R12. The review message must show whether the draft is normal approval, risky two-step approval, or blocked opt-out/human-only.
+- R13. Blocked opt-out/human-only cases should notify the group that automation is not allowed to send on that thread.
+- R14. A stale approval attempt must fail closed with a clear reason instead of sending the old draft.
+- R15. A failed Dialpad send attempt must remain visibly unsent and must not be described as sent without a fresh Dialpad success result.
+
+## Success Criteria
+- A Dialpad SMS can no longer be sent solely because an agent decided it was appropriate.
+- Operators can still approve low-risk replies quickly from Telegram when the draft is current.
+- Risky replies require an explicit second confirmation that displays the reason for risk.
+- Opt-out messages produce no automated outbound SMS path.
+- The audit trail can answer who approved which exact draft, when, and what Dialpad SMS id resulted.
+- Failed sends are surfaced as failures, not success claims.
+
+## Scope Boundaries
+- This does not re-enable fully autonomous SMS sending.
+- This does not require solving all CRM identity or contact ambiguity problems; those remain governed by the contact ambiguity guard.
+- This does not require Telegram inline buttons if the current OpenClaw/Telegram surface cannot support callbacks yet. Command approval is an acceptable first implementation with the same policy semantics.
+- This does not define the final storage schema, endpoint layout, or implementation details. Those belong in planning.
+
+## Key Decisions
+- Notification plus one-click approval over auto-send: fast human approval preserves speed while keeping send authority outside the agent.
+- Exact-draft approval only: the audit trail must match what the operator saw and approved.
+- Approval valid until superseded: approvals remain usable only while no newer customer, outbound, or context-changing event has changed the basis for the draft.
+- Two-step approval for risky messages: risky sends are not forbidden by default, but the second confirmation must surface the risk reason.
+- Group-member confirmation allowed: operational speed matters, so any real group member may confirm, with audit logging as the compensating control.
+- Opt-out hard stop: explicit opt-out language is a compliance and trust boundary, not a workflow inconvenience.
+
+## Dependencies / Assumptions
+- Existing Dialpad/OpenClaw integration guidance already treats `approval_required` as the safe default and separates draft generation from send authority.
+- Telegram inline callback support has not been confirmed in the current repo scan. Planning must verify whether the target UX is natively supported or should start with command approval.
+- The review surface has enough stable thread context to detect newer inbound messages, manual outbound messages, and context-changing updates before sending.
+
+## Approval Flow
+```text
+Inbound SMS
+  -> classify risk
+  -> opt-out? block automation and notify human-only
+  -> draft reply if allowed
+  -> operator approval
+  -> stale? fail closed
+  -> risky? require second confirmation with risk reason
+  -> send exact draft
+  -> log actor, draft, risk reason, timestamp, and SMS id
+```
+
+## Outstanding Questions
+
+### Resolve Before Planning
+- None.
+
+### Deferred to Planning
+- [R3][Technical] Does the current OpenClaw Telegram integration support inline buttons and callback handling, or should the first implementation use `/send <draft-id>`?
+- [R5][Technical] What is the smallest reliable event set needed to invalidate approvals across Dialpad, manual sends, CRM changes, and calendar changes?
+- [R6][Technical] Where should risk classification live so SMS, missed-call follow-up, and future channels share the same policy?
+- [R10][Technical] Which opt-out phrases should be exact hard-stop triggers at launch, and which should be treated as risky but not opt-out?
+
+## Next Steps
+-> /ce:plan for structured implementation planning

--- a/docs/plans/2026-04-24-001-fix-dialpad-sms-approval-gate-plan.md
+++ b/docs/plans/2026-04-24-001-fix-dialpad-sms-approval-gate-plan.md
@@ -1,0 +1,358 @@
+---
+title: fix: Gate Dialpad SMS sends behind human approval
+type: fix
+status: active
+date: 2026-04-24
+origin: docs/brainstorms/2026-04-24-dialpad-one-click-sms-approval-requirements.md
+---
+
+# fix: Gate Dialpad SMS Sends Behind Human Approval
+
+## Overview
+
+Dialpad inbound SMS handling must stay useful without allowing an agent turn to send customer SMS on its own. This plan adds a deterministic approval layer around outbound SMS: inbound events can create reviewable exact-text drafts, Telegram operators can approve or reject them, and the send path checks freshness, risk, opt-out, and audit state before calling Dialpad.
+
+The core design is to keep send authority outside the LLM. OpenClaw may draft and enrich, but the only live send path is a deterministic approval command or Telegram inline callback handled by plugin/runtime code.
+
+## Problem Frame
+
+The incident captured in the origin document showed the unsafe failure mode: an OpenClaw hook-delivered inbound SMS became an agent session that issued a Dialpad `send_sms.py` command without a fresh human send approval. Existing docs already say `approval_required` should be the safe default, and the current hotfix disabled hooks and auto-replies by default. The permanent fix should make that default enforceable in code instead of relying on prompt discipline.
+
+## Requirements Trace
+
+- R1. Inbound Dialpad SMS must never cause outbound SMS without explicit human approval.
+- R2. Inbound SMS defaults to notification plus draft generation, not sending.
+- R3. Telegram inline approval is preferred when supported; deterministic command approval is the fallback.
+- R4. Approval sends the exact draft text shown to the operator; edits create a new draft.
+- R5. Pending approvals are invalidated by newer inbound messages, manual outbound messages, or material context changes.
+- R6. Risky messages require two-step confirmation before sending.
+- R7. The second confirmation must show the risk reason before send.
+- R8. Any real Telegram group member may confirm; the agent or bot may not confirm itself.
+- R9. Approval logging must record actor, timestamp, draft id, risk reason when present, and resulting Dialpad SMS id.
+- R10. Explicit opt-out language hard-stops automation with no draft, button, or override.
+- R11. Review messages distinguish draft text from sent text.
+- R12. Review messages show normal, risky two-step, or blocked opt-out state.
+- R13. Blocked opt-out/human-only cases notify the group that automation cannot send.
+- R14. Stale approval attempts fail closed with a clear reason.
+- R15. Failed Dialpad sends remain visibly unsent and cannot be described as sent without a fresh Dialpad success result.
+
+## Scope Boundaries
+
+- This does not re-enable autonomous SMS.
+- This does not depend on prompt obedience for send authority.
+- This does not solve all CRM identity ambiguity; `docs/brainstorms/2026-03-26-dialpad-contact-ambiguity-guard-requirements.md` remains the identity contract.
+- This does not require rebuilding the OpenClaw hook receiver. The Dialpad skill can keep hook forwarding disabled until this approval path is deployed and verified.
+- This does not require a second Telegram bot poller or a separate Telegram webhook. Callback handling must go through OpenClaw's existing Telegram plugin runtime.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/webhook_server.py` owns inbound Dialpad webhook handling, Telegram notifications, OpenClaw hook forwarding, and the current disabled-by-default `DIALPAD_AUTO_REPLY_ENABLED` path.
+- `scripts/send_sms.py` is the deterministic Dialpad API wrapper that should remain the only low-level SMS send primitive.
+- `scripts/sms_sqlite.py` and `scripts/webhook_sqlite.py` already provide SQLite persistence for Dialpad SMS events and are the natural place to share connection/path conventions.
+- `tests/test_webhook_hooks.py`, `tests/test_webhook_server.py`, and `tests/test_sender_enrichment.py` already cover webhook classification, hook payloads, and degraded forwarding behavior.
+- `tests/test_openclaw_integration_docs.py` already locks current-turn verification and draft/send authority documentation.
+- `references/openclaw-integration.md` already documents `approval_required`, human review, current-turn verification, and separation of draft generation from send authority.
+- OpenClaw's Telegram runtime supports inline buttons and callback dispatch through plugin interactive handlers. The relevant pattern is a plugin registering `api.registerInteractiveHandler({ channel: "telegram", namespace: ... })`, with callback data shaped as `<namespace>:<payload>`.
+- The Dialpad skill is currently a Python skill, not a native OpenClaw plugin. Inline buttons therefore need a small plugin bridge or the first version must use a deterministic plugin command fallback.
+
+### Institutional Learnings
+
+- `docs/plans/2026-03-26-003-bug-stale-already-sent-replies-plan.md` shows that stale success claims are a known class of bug; this plan must require fresh Dialpad success evidence before any "sent" state.
+- `docs/plans/2026-03-26-002-feat-first-contact-enrichment-replies-beta-plan.md` already covers enrichment and draft generation. This plan should not duplicate enrichment logic; it gates the send action after a draft exists.
+
+### External References
+
+- None used. Local OpenClaw runtime artifacts were sufficient to verify inline callback support.
+
+## Key Technical Decisions
+
+- Deterministic approval ledger: SMS drafts, approval state, invalidation state, and send results live in persistent storage, not in agent memory or Telegram message text.
+- Same send primitive, stricter caller: keep `scripts/send_sms.py` as the low-level Dialpad sender, but only call it from an approval-confirmed deterministic path.
+- Plugin-mediated Telegram actions: use OpenClaw plugin interactive handlers and plugin commands for Telegram actor identity. Do not add an independent Telegram poller to `scripts/webhook_server.py`.
+- Exact draft snapshot: the approval ledger stores the exact draft text, from number, to number, line display, source inbound id, and context fingerprint used for approval.
+- Fail closed on freshness: if any invalidating event occurred after draft creation, approval returns stale/blocked and does not send.
+- Two-step risky confirmation: risky messages can be sent only after the second action confirms the risk reason. Opt-out is not risky; it is blocked.
+- Keep emergency defaults: `OPENCLAW_HOOKS_SMS_ENABLED`, `OPENCLAW_HOOKS_CALL_ENABLED`, and `DIALPAD_AUTO_REPLY_ENABLED` remain default-off until the approval workflow is deployed and verified.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Does OpenClaw support Telegram inline callbacks? Yes. The installed Telegram runtime includes inline button construction, `callback_query` handling, and plugin interactive dispatch.
+- Should raw buttons be sent directly from `webhook_server.py`? No. Without a callback handler registered in OpenClaw, raw button callbacks would not provide a safe deterministic send path.
+- Should command fallback be LLM-mediated? No. The fallback command must be a plugin command so it receives Telegram sender identity and bypasses agent reasoning.
+- Where should the native plugin live? In a `plugin/` package directory inside this repo so the existing Python skill root does not become an ambiguous mixed-runtime package root.
+
+### Deferred to Implementation
+
+- Exact approval DB placement: reuse `sms.db` if migration risk is low, otherwise use a sibling `sms_approvals.db` under the same log root.
+- Exact initial risk phrase list: start from origin requirements and tests, then adjust based on fixtures discovered during implementation.
+- Material CRM/calendar state change detection: implement the local event hooks available in this repo first, and leave deeper CRM/calendar invalidation behind explicit integration seams.
+
+## High-Level Technical Design
+
+> This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.
+
+```mermaid
+flowchart TB
+  inbound[Dialpad inbound SMS] --> classify[Classify opt-out and risk]
+  classify -->|opt-out| blocked[Notify human-only, no draft]
+  classify -->|allowed| draft[Persist exact draft and context fingerprint]
+  draft --> review[Telegram review message]
+  review -->|inline callback| plugin[OpenClaw Dialpad approval plugin]
+  review -->|/dialpad_send fallback| plugin
+  plugin --> stale{Draft still current?}
+  stale -->|no| fail[Fail closed and explain stale reason]
+  stale -->|yes| risky{Risky draft?}
+  risky -->|yes, first action| confirm[Show risk reason and require second confirmation]
+  confirm --> plugin
+  risky -->|no or confirmed| send[Deterministic Dialpad send]
+  send --> audit[Record actor, result, SMS id, and visible status]
+```
+
+## Implementation Units
+
+- [x] **Unit 1: Approval Ledger and Deterministic Send Core**
+
+**Goal:** Add persistent approval state and a deterministic exact-draft send function that can be called by webhook code, plugin code, or tests without involving an LLM.
+
+**Requirements:** R1, R4, R5, R9, R14, R15
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `scripts/sms_approval.py`
+- Create: `scripts/create_sms_draft.py`
+- Create: `scripts/approve_sms_draft.py`
+- Create: `bin/create_sms_draft.py`
+- Create: `bin/approve_sms_draft.py`
+- Test: `tests/test_sms_approval.py`
+
+**Approach:**
+- Store approval drafts with draft id, conversation/thread key, inbound Dialpad id, customer number, sender line, exact text, status, risk state, risk reason, context fingerprint, created timestamp, invalidated timestamp/reason, approving actor, and Dialpad send result.
+- Add helpers for creating a draft, invalidating current drafts for a thread/customer, confirming a normal draft, recording the first risky approval step, confirming the second risky step, marking send success, and marking send failure.
+- Make `scripts/create_sms_draft.py` the deterministic write path for both webhook-created boilerplate drafts and future agent-created AI drafts. It creates reviewable drafts but never sends.
+- Make `scripts/approve_sms_draft.py` return a JSON envelope for every outcome: sent, blocked_opt_out, stale, risky_confirmation_required, failed, not_found, or already_resolved.
+- Call the existing `scripts/send_sms.py` send function only after the approval state machine permits sending.
+- Preserve exact-draft behavior by sending only the stored text, not caller-supplied replacement text.
+
+**Execution note:** Implement the approval state machine test-first because it is the safety boundary.
+
+**Patterns to follow:**
+- SQLite connection/path style in `scripts/sms_sqlite.py`
+- JSON success/error envelope expectations from existing CLI tests in `tests/test_json_contract.py`
+- Fresh success wording from `docs/plans/2026-03-26-003-bug-stale-already-sent-replies-plan.md`
+
+**Test scenarios:**
+- Happy path: pending normal draft plus real actor confirmation calls the mocked Dialpad sender with the stored exact text and records the SMS id.
+- Edge case: caller supplies edited text or mismatched draft id; stored draft text is still the only sendable text.
+- Edge case: newer inbound invalidates the draft; confirmation returns stale and does not call the sender.
+- Error path: Dialpad sender raises; draft remains unsent with failed status and no success claim.
+- Error path: bot/agent actor id is rejected before send.
+- Integration: create-draft CLI persists exact text and returns draft id without calling Dialpad send.
+- Integration: CLI returns machine-readable JSON for sent, stale, failed, and risky-confirmation-required outcomes.
+
+**Verification:**
+- Approval state transitions are deterministic and covered without needing Telegram or Dialpad network access.
+
+- [x] **Unit 2: Inbound Policy Classification and Draft Creation**
+
+**Goal:** Convert inbound SMS handling from "possibly send" to "classify, draft or block, notify, and invalidate old approvals."
+
+**Requirements:** R1, R2, R5, R6, R10, R12, R13, R14
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `scripts/webhook_server.py`
+- Test: `tests/test_webhook_server.py`
+- Test: `tests/test_sender_enrichment.py`
+- Test: `tests/test_webhook_hooks.py`
+
+**Approach:**
+- Add opt-out detection before draft creation. Explicit opt-out phrases create a human-only notification and no draft record.
+- Add risk classification for anger, confusion, real-person request, legal/compliance concern, and similar elevated-risk phrases.
+- Invalidate prior pending drafts for the same customer/thread when a newer inbound SMS arrives.
+- Treat outbound webhook events from Dialpad as invalidation events for pending drafts in that same thread/customer.
+- Replace the direct `send_proactive_reply()` behavior for inbound events with draft creation when a proactive reply would otherwise have been eligible.
+- When OpenClaw/agent-generated text is introduced later, require it to enter through `scripts/create_sms_draft.py` so AI drafts and deterministic boilerplate drafts share one approval ledger.
+- Keep `DIALPAD_AUTO_REPLY_ENABLED` default-off and do not let it bypass approval.
+- Preserve sensitive-message and short-code filtering before any draft or hook forwarding.
+
+**Execution note:** Add characterization tests around current inbound filtering before changing the send/draft behavior.
+
+**Patterns to follow:**
+- `assess_inbound_sms_alert_eligibility()` for centralized fan-out decisions
+- `should_send_proactive_reply()` for eligibility rules that can become draft-eligibility rules
+- Existing response metadata style in `handle_webhook()`
+
+**Test scenarios:**
+- Happy path: low-risk inbound SMS creates a pending draft and Telegram review notification but does not call Dialpad send.
+- Edge case: explicit "don't bother me" creates no draft and returns/prints human-only state.
+- Edge case: "I need a real person" creates a risky draft requiring two-step approval.
+- Edge case: short-code or OTP-like SMS creates no draft and no approval controls.
+- Integration: second inbound from the same customer invalidates the earlier pending draft.
+- Integration: outbound Dialpad webhook event invalidates pending drafts for the same customer/thread.
+
+**Verification:**
+- Inbound webhook responses expose draft/review state, but no inbound path sends an SMS directly.
+
+- [ ] **Unit 3: Telegram Review Surface and Plugin Approval Bridge**
+
+**Status:** Deferred after the hotfix. The webhook now adds Telegram review text with the draft id, exact text, and deterministic shell approval command, but native OpenClaw inline callbacks/commands are not implemented in this patch.
+
+**Goal:** Add the operator approval UX with inline buttons when available and a deterministic command fallback when not.
+
+**Requirements:** R3, R7, R8, R9, R11, R12, R14
+
+**Dependencies:** Units 1 and 2.
+
+**Files:**
+- Create: `plugin/openclaw.plugin.json`
+- Create: `plugin/package.json`
+- Create: `plugin/tsconfig.json`
+- Create: `plugin/index.ts`
+- Create: `plugin/src/approval-client.ts`
+- Create: `plugin/src/approval-plugin.ts`
+- Test: `plugin/src/approval-plugin.test.ts`
+- Modify: `scripts/webhook_server.py`
+- Test: `tests/test_webhook_server.py`
+
+**Approach:**
+- Add a minimal OpenClaw native plugin that registers a Telegram interactive handler under a short namespace such as `dialpadsms`.
+- Use callback data shaped like `dialpadsms:<draft-id>:approve` and `dialpadsms:<draft-id>:confirm-risk` so it fits Telegram's callback data limit.
+- Register plugin commands such as `/dialpad_send <draft-id>` and `/dialpad_confirm <draft-id>` as the non-inline fallback. These commands must be handled by plugin command handlers, not by the agent.
+- Have the plugin pass Telegram `senderId`, username when available, account id, chat/thread context, draft id, and action to the deterministic approval core.
+- Use OpenClaw's existing Telegram outbound runtime to edit buttons, clear resolved buttons, and reply with sent/stale/blocked/failure status.
+- Require the webhook sender and OpenClaw Telegram runtime to use the same Telegram bot account for callback delivery; otherwise render command fallback only.
+- Keep `scripts/webhook_server.py` responsible for the review message content; it can include inline buttons only when plugin support is configured, otherwise it includes deterministic command instructions.
+
+**Patterns to follow:**
+- `openclaw-codex-app-server/index.ts` for `api.registerInteractiveHandler(...)` and `api.registerCommand(...)`
+- OpenClaw Telegram callback namespace behavior where callback data before the first colon selects the plugin namespace
+- Existing Telegram send helper shape in `scripts/webhook_server.py`
+
+**Test scenarios:**
+- Happy path: inline approve callback from a Telegram user sends a normal pending draft and clears buttons.
+- Happy path: `/dialpad_send <draft-id>` command from a Telegram user reaches the same approval path.
+- Edge case: risky draft first action edits/replies with risk reason and does not send.
+- Edge case: risky draft second confirmation sends only after the risk reason was presented.
+- Error path: callback from bot/agent actor is rejected.
+- Error path: stale draft callback replies with stale reason and does not call the sender.
+- Integration: review message clearly labels draft text, current state, and available action.
+
+**Verification:**
+- Telegram actions can approve sends without invoking an LLM turn, and the audit record contains the real Telegram actor.
+
+- [ ] **Unit 4: OpenClaw Runtime Policy and Hook Re-Enable Guardrails**
+
+**Goal:** Align runtime config and docs so hooks can be re-enabled only with approval-required behavior and no direct auto-send path.
+
+**Requirements:** R1, R2, R8, R10, R15
+
+**Dependencies:** Units 1-3.
+
+**Files:**
+- Modify: `README.md`
+- Modify: `SKILL.md`
+- Modify: `references/openclaw-integration.md`
+- Modify: `references/api-reference.md`
+- Test: `tests/test_openclaw_integration_docs.py`
+
+**Approach:**
+- Document that `OPENCLAW_HOOKS_SMS_ENABLED` and `OPENCLAW_HOOKS_CALL_ENABLED` are default-off until the approval plugin is installed and verified.
+- Remove or clearly deprecate any guidance that suggests enabling `DIALPAD_AUTO_REPLY_ENABLED=1` as a live send path.
+- Document the approval states, opt-out hard stop, stale invalidation, risky two-step confirmation, and failed-send visibility.
+- Update the `niemand-work` runtime prompt guidance so it may draft but must not call `send_sms.py` directly for Dialpad SMS replies.
+- Point AI-generated reply drafting at the create-draft path instead of the send path, so the prompt can improve draft quality without acquiring send authority.
+- Require OpenClaw exec approvals to remain on for any residual manual `send_sms.py` use.
+
+**Patterns to follow:**
+- Current-turn verification assertions in `tests/test_openclaw_integration_docs.py`
+- Human-in-the-loop workflow in `references/openclaw-integration.md`
+- Existing README env-var documentation
+
+**Test scenarios:**
+- Docs state that inbound SMS defaults to draft/review, not send.
+- Docs state that opt-out language creates no automation send path.
+- Docs state that failed sends remain unsent without a fresh Dialpad success result.
+- Docs no longer present auto-reply as a safe live-send toggle.
+
+**Verification:**
+- Repo docs and runtime policy describe one consistent approval-required contract.
+
+- [ ] **Unit 5: Rollout and Regression Verification**
+
+**Goal:** Re-enable only the safe pieces in a controlled order and prove the incident path cannot recur.
+
+**Requirements:** R1-R15
+
+**Dependencies:** Units 1-4.
+
+**Files:**
+- Modify: `systemd/dialpad-webhook.service` if environment wiring needs durable service-level flags
+- Modify: `README.md`
+- Test: `tests/test_sms_approval.py`
+- Test: `tests/test_webhook_server.py`
+- Test: `plugin/src/approval-plugin.test.ts`
+
+**Approach:**
+- Keep Dialpad hook forwarding disabled until approval tests and a manual Telegram approval smoke test pass.
+- Add a fixture for the Clelia-style sequence: time confusion, real-person request, opt-out-like anger, then another scheduling clarification. The expected result is no auto-send and risky/human-only handling where appropriate.
+- Add a smoke checklist for service state, port state, OpenClaw config, Telegram callback delivery, and Dialpad mocked send result.
+- Make rollout reversible by documenting the disable levers for webhook service, hooks, approval plugin, and auto-reply.
+
+**Patterns to follow:**
+- Existing webhook tests with mocked network calls
+- Existing service file in `systemd/dialpad-webhook.service`
+- Incident evidence summarized in the origin requirements doc
+
+**Test scenarios:**
+- Regression: the incident sequence never calls Dialpad send without approval.
+- Regression: an opt-out phrase suppresses draft/buttons even if an agent would have drafted a reply.
+- Regression: a risky real-person request requires two separate human actions.
+- Integration: Telegram callback approval records actor id and SMS id on success.
+- Integration: approval after a newer inbound fails stale.
+
+**Verification:**
+- The full approval path is test-covered with mocked Dialpad/Telegram dependencies before any production re-enable.
+
+## System-Wide Impact
+
+- **Interaction graph:** Dialpad webhook -> approval ledger -> Telegram review -> OpenClaw plugin callback/command -> deterministic Dialpad send.
+- **Error propagation:** Webhooks still return 200 after local storage succeeds; approval/send failures are surfaced in review state and audit logs, not hidden as webhook failures.
+- **State lifecycle risks:** Drafts must handle duplicate inbound webhooks, repeated callback clicks, stale context, failed sends, and already-resolved approvals idempotently.
+- **API surface parity:** Inline buttons and command fallback must call the same approval core so behavior does not drift.
+- **Integration coverage:** Unit tests must mock Telegram and Dialpad, and one manual smoke test should verify callback delivery through the installed OpenClaw Telegram runtime.
+- **Unchanged invariants:** Sensitive/short-code filtering, current-turn verification, contact ambiguity rules, and default-off hook/auto-reply posture remain in force.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Inline callbacks require plugin infrastructure that the Dialpad skill does not currently have | Build a minimal OpenClaw plugin bridge and keep command fallback deterministic through the same plugin |
+| A second Telegram poller would conflict with OpenClaw's bot runtime | Do not add one; route callbacks through OpenClaw interactive handlers |
+| Approval state can go stale after thread context changes | Store context fingerprints and invalidate on inbound/outbound events; defer deeper CRM/calendar invalidation behind explicit seams |
+| Operators may treat risky two-step approval as routine | Show the risk reason on the second confirmation and audit the actor |
+| Auto-reply code could become a bypass | Keep default-off, convert eligible auto-replies into drafts, and document deprecation of direct live auto-reply |
+| Failed Dialpad sends could be misreported | Store sent only after a fresh Dialpad success result with SMS id; otherwise keep failed/unsent |
+
+## Documentation / Operational Notes
+
+- The emergency containment changes should remain until this plan is implemented and smoke-tested: disabled Dialpad webhook service, hooks default-off, group mention requirement, exec approvals on, and empty `niemand-work` exec allowlist.
+- Re-enabling should be staged: plugin installed, approval tests passing, webhook service running, hook forwarding still off, Telegram callback smoke test, then selective hook forwarding.
+- If inline callbacks are blocked in the live OpenClaw version, ship the plugin command fallback first and keep inline buttons disabled until callback support is verified in that runtime.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-24-dialpad-one-click-sms-approval-requirements.md](docs/brainstorms/2026-04-24-dialpad-one-click-sms-approval-requirements.md)
+- Related requirements: [docs/brainstorms/2026-03-26-dialpad-contact-ambiguity-guard-requirements.md](docs/brainstorms/2026-03-26-dialpad-contact-ambiguity-guard-requirements.md)
+- Related plan: [docs/plans/2026-03-26-003-bug-stale-already-sent-replies-plan.md](docs/plans/2026-03-26-003-bug-stale-already-sent-replies-plan.md)
+- Related code: [scripts/webhook_server.py](scripts/webhook_server.py)
+- Related code: [scripts/send_sms.py](scripts/send_sms.py)
+- Related code: [scripts/sms_sqlite.py](scripts/sms_sqlite.py)
+- Related docs: [references/openclaw-integration.md](references/openclaw-integration.md)
+- Related tests: [tests/test_webhook_server.py](tests/test_webhook_server.py)
+- Related tests: [tests/test_webhook_hooks.py](tests/test_webhook_hooks.py)

--- a/references/api-reference.md
+++ b/references/api-reference.md
@@ -177,22 +177,26 @@ export OPENCLAW_HOOKS_PATH="/hooks/agent"
 export OPENCLAW_HOOKS_NAME="Dialpad SMS"
 export OPENCLAW_HOOKS_CALL_NAME="Dialpad Missed Call"
 export OPENCLAW_HOOKS_AGENT_ID="niemand-work"
-export OPENCLAW_HOOKS_SMS_ENABLED="1"
-export OPENCLAW_HOOKS_CALL_ENABLED="1"
-export DIALPAD_AUTO_REPLY_ENABLED="1"
+export OPENCLAW_HOOKS_SMS_ENABLED="0"
+export OPENCLAW_HOOKS_CALL_ENABLED="0"
+export DIALPAD_AUTO_REPLY_ENABLED="0"
+export DIALPAD_SMS_APPROVAL_DB="/home/art/clawd/logs/sms_approvals.db"
+export DIALPAD_SMS_APPROVAL_TOKEN="operator-only-random-token"
 ```
 
 Behavior notes:
 
-- Inbound SMS forwarding is enabled by default when `OPENCLAW_HOOKS_TOKEN` is configured
-- Inbound missed-call forwarding is enabled by default when `OPENCLAW_HOOKS_TOKEN` is configured
-- Set `OPENCLAW_HOOKS_SMS_ENABLED=0` or `OPENCLAW_HOOKS_CALL_ENABLED=0` to disable one event class
-- First-contact auto-replies are only sent on the sales line `(415) 520-1316` when `DIALPAD_AUTO_REPLY_ENABLED` is truthy
-- Voicemail notifications remain Telegram-only for OpenClaw fan-out, but first-contact sales-line voicemails also get the SMS acknowledgment when auto-replies are enabled
+- Inbound SMS forwarding requires `OPENCLAW_HOOKS_TOKEN` and `OPENCLAW_HOOKS_SMS_ENABLED=1`
+- Inbound missed-call forwarding requires `OPENCLAW_HOOKS_TOKEN` and `OPENCLAW_HOOKS_CALL_ENABLED=1`
+- Leave `OPENCLAW_HOOKS_SMS_ENABLED=0` and `OPENCLAW_HOOKS_CALL_ENABLED=0` for notification-only mode
+- First-contact sales-line replies create approval drafts when `DIALPAD_AUTO_REPLY_ENABLED` is truthy; they do not send SMS directly
+- Voicemail notifications remain Telegram-only for OpenClaw fan-out, but first-contact sales-line voicemails can create SMS approval drafts when draft creation is enabled
 - The local OpenClaw gateway allows explicit `niemand-work` routing and the `hook:dialpad:` session-key namespace
 - For unknown inbound contacts, the hook may include a `firstContact` hint with lookup and reply-drafting signals; downstream users can map that to Attio, HubSpot, Airtable, or any other source of truth
 - Identity states are preserved as data, not implied behavior: `resolved` is safe to mutate, while `ambiguous`, `not_found`, and `degraded` should stay non-mutating until the CRM/agent layer proves the identity
-- The webhook server also adds `autoReply` metadata when it sends the sales-line acknowledgment directly, so downstream automation can avoid double-sending the same reply
+- The webhook server adds `autoReply` metadata for approval drafts. `sent: false` is expected until a deterministic approval command records a Dialpad success result
+- CLI approval requires `DIALPAD_SMS_APPROVAL_TOKEN`; keep that token in the trusted operator surface, not in agent runtime environments
+- Explicit opt-out language creates no draft, invalidates pending drafts for that customer, and emits only a human-only Telegram notice
 - The repo preserves the current top-level OpenClaw hook envelope and does not claim end-to-end validation of downstream proactive enrichment behavior
 - Current-turn verification still applies to `niemand-work`: stale context must not produce "Already sent" or "Already updated"; only a fresh tool result in the same turn can justify those claims.
 - If your gateway listens on a different port, change `OPENCLAW_GATEWAY_URL` accordingly.

--- a/references/openclaw-integration.md
+++ b/references/openclaw-integration.md
@@ -20,7 +20,7 @@ This repo does not validate:
 - downstream OpenClaw prompt quality
 - autonomous enrichment quality
 - session semantics or dedupe behavior inside OpenClaw
-- whether OpenClaw should auto-send without approval
+- autonomous outbound sending; SMS send authority stays in the deterministic approval ledger
 
 ## Default Operating Model
 
@@ -28,7 +28,7 @@ Recommended OpenClaw policy:
 - proactively enrich inbound events
 - generate a summary and recommended next action
 - draft a response
-- require human approval before any outbound send
+- require deterministic human approval before any outbound send
 
 Recommended default:
 
@@ -45,9 +45,8 @@ Recommended default:
 Suggested `sendMode` values:
 - `draft_only`
 - `approval_required`
-- `auto_send`
 
-`approval_required` should be the default.
+`approval_required` should be the default. `auto_send` is intentionally unsupported for inbound Dialpad-triggered SMS.
 
 ## Dialpad-Side Environment
 
@@ -63,16 +62,20 @@ export OPENCLAW_HOOKS_PATH="/hooks/agent"
 export OPENCLAW_HOOKS_NAME="Dialpad SMS"
 export OPENCLAW_HOOKS_CALL_NAME="Dialpad Missed Call"
 export OPENCLAW_HOOKS_AGENT_ID="niemand-work"
-export OPENCLAW_HOOKS_SMS_ENABLED="1"
-export OPENCLAW_HOOKS_CALL_ENABLED="1"
-export DIALPAD_AUTO_REPLY_ENABLED="1"
+export OPENCLAW_HOOKS_SMS_ENABLED="0"
+export OPENCLAW_HOOKS_CALL_ENABLED="0"
+export DIALPAD_AUTO_REPLY_ENABLED="0"
+export DIALPAD_SMS_APPROVAL_DB="/home/art/clawd/logs/sms_approvals.db"
+export DIALPAD_SMS_APPROVAL_TOKEN="operator-only-random-token"
 ```
 
 Behavior:
-- when `OPENCLAW_HOOKS_TOKEN` is configured, inbound SMS forwarding is enabled by default unless `OPENCLAW_HOOKS_SMS_ENABLED=0`
-- when `OPENCLAW_HOOKS_TOKEN` is configured, inbound missed-call forwarding is enabled by default unless `OPENCLAW_HOOKS_CALL_ENABLED=0`
-- when `DIALPAD_AUTO_REPLY_ENABLED` is truthy, first-contact messages on the sales line `(415) 520-1316` get an automatic SMS acknowledgment before the hook handoff continues
-- voicemail remains Telegram-only for OpenClaw fan-out, but first-contact sales-line voicemails also get the SMS acknowledgment when auto-replies are enabled
+- when `OPENCLAW_HOOKS_TOKEN` is configured, inbound SMS forwarding still requires `OPENCLAW_HOOKS_SMS_ENABLED=1`
+- when `OPENCLAW_HOOKS_TOKEN` is configured, inbound missed-call forwarding still requires `OPENCLAW_HOOKS_CALL_ENABLED=1`
+- when `DIALPAD_AUTO_REPLY_ENABLED` is truthy, first-contact messages on the sales line `(415) 520-1316` create exact-text approval drafts instead of sending SMS directly
+- voicemail remains Telegram-only for OpenClaw fan-out, but first-contact sales-line voicemails can create SMS approval drafts when draft creation is enabled
+- explicit opt-out language creates no draft, invalidates pending drafts for that customer, and emits only a human-only Telegram notice
+- CLI approval is disabled unless `DIALPAD_SMS_APPROVAL_TOKEN` is configured and supplied by the operator approval surface
 - if your gateway listens on a different port, change `OPENCLAW_GATEWAY_URL` accordingly
 - the local gateway allows explicit `niemand-work` routing and the `hook:dialpad:` session-key namespace
 
@@ -84,13 +87,15 @@ Relevant endpoints in `scripts/webhook_server.py`:
   - stores SMS
   - optionally forwards eligible inbound SMS to OpenClaw
   - optionally sends Telegram SMS alerts
+  - creates approval drafts for eligible first-contact sales-line replies, but does not send SMS directly
 - `POST /webhook/dialpad-call`
   - detects inbound missed calls
   - optionally forwards missed calls to OpenClaw
   - optionally sends Telegram missed-call alerts using the event timestamp when available
   - escapes dynamic Telegram fields before sending
+  - creates approval drafts for eligible first-contact sales-line missed-call acknowledgments, but does not send SMS directly
 - `POST /webhook/dialpad-voicemail`
-  - Telegram-only in this repo
+  - Telegram notification plus optional approval-draft creation for eligible first-contact sales-line voicemails
 
 ## OpenClaw Receiver Contract
 
@@ -117,6 +122,7 @@ The token should match `OPENCLAW_HOOKS_TOKEN`.
 - `to`
 - `agentId`
 - `firstContact`
+- `autoReply`
 
 ### First-Contact Assist Hint
 
@@ -153,7 +159,9 @@ Interpretation:
 - if the match is clear, suggest Dialpad contact normalization or update
 - if the evidence is only first name, area code, industry, or job title, keep the lead ambiguous and draft-only until stronger proof appears
 - if `keepBrief` is `true`, skip the long background pass and stay short
-- if `autoReply` is present, the webhook server already sent the sales-line acknowledgment and downstream automation should not send the same reply again
+- if `autoReply` is present, treat it as approval-draft metadata. `sent: false` means the webhook created or attempted a draft and downstream automation must not send the same reply directly.
+- if `autoReply.replyPolicy.state` is `risky`, the approval path must require a second confirmation.
+- if opt-out language is detected, the event is not forwarded as a normal hook payload; automation must remain human-only.
 
 ### SMS Example
 
@@ -186,8 +194,15 @@ Interpretation:
   },
   "autoReply": {
     "eligible": true,
-    "sent": true,
-    "status": "accepted/queued",
+    "sent": false,
+    "draftCreated": true,
+    "draftId": "smsdraft_abc123",
+    "status": "draft_created",
+    "replyPolicy": {
+      "state": "normal",
+      "reason_code": "eligible",
+      "risk_reason": null
+    },
     "message": "Hi there, thanks for reaching ShapeScale for Business Sales. We got your message and will be in touch shortly."
   }
 }
@@ -221,8 +236,15 @@ Interpretation:
   },
   "autoReply": {
     "eligible": true,
-    "sent": true,
-    "status": "accepted/queued",
+    "sent": false,
+    "draftCreated": true,
+    "draftId": "smsdraft_def456",
+    "status": "draft_created",
+    "replyPolicy": {
+      "state": "normal",
+      "reason_code": "eligible",
+      "risk_reason": null
+    },
     "message": "Hi there, you've reached ShapeScale for Business Sales. Sorry we missed your call. How can we help?"
   }
 }
@@ -291,8 +313,15 @@ SMS:
   },
   "autoReply": {
     "eligible": true,
-    "sent": true,
-    "status": "accepted/queued",
+    "sent": false,
+    "draftCreated": true,
+    "draftId": "smsdraft_abc123",
+    "status": "draft_created",
+    "replyPolicy": {
+      "state": "normal",
+      "reason_code": "eligible",
+      "risk_reason": null
+    },
     "message": "Hi there, thanks for reaching ShapeScale for Business Sales. We got your message and will be in touch shortly."
   }
 }
@@ -419,7 +448,7 @@ OpenClaw should:
 - require current-turn verification before any success claim about sending or updating
 - treat stale context as non-evidence for "Already sent" or "Already updated"
 
-Outbound send must always enforce `sendMode`.
+Outbound send must always go through `scripts/approve_sms_draft.py` or an equivalent deterministic approval handler with a real human actor id plus a trusted approval token/callback. The agent or bot must not approve its own draft.
 
 ## Rollout Plan
 
@@ -430,7 +459,7 @@ Recommended rollout:
 3. verify real SMS and missed-call payloads
 4. add normalization and proactive enrichment
 5. ship `approval_required` mode first
-6. only enable `auto_send` if explicitly desired later
+6. re-enable hook classes only after approval drafts and stale/opt-out behavior are verified
 
 ## Validation Checklist
 
@@ -445,7 +474,7 @@ OpenClaw-side:
 - payloads are logged with secret redaction
 - `sessionKey` is persisted for dedupe
 - review items are created for inbound SMS and missed calls
-- outbound replies require approval by default
+- outbound replies require approval; autonomous SMS send is not supported for inbound Dialpad-triggered events
 
 ## Monitoring
 

--- a/scripts/approve_sms_draft.py
+++ b/scripts/approve_sms_draft.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Approve a previously created Dialpad SMS draft."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import hmac
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from sms_approval import ACTION_APPROVE, ACTION_CONFIRM_RISK, approve_draft, init_db
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Approve a Dialpad SMS draft")
+    parser.add_argument("draft_id")
+    parser.add_argument("--action", choices=(ACTION_APPROVE, ACTION_CONFIRM_RISK), default=ACTION_APPROVE)
+    parser.add_argument("--actor-id", required=True)
+    parser.add_argument("--actor-username")
+    parser.add_argument("--actor-is-bot", action="store_true")
+    parser.add_argument("--approval-token")
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def validate_approval_token(provided_token: str | None) -> dict[str, object] | None:
+    expected_token = os.environ.get("DIALPAD_SMS_APPROVAL_TOKEN")
+    if not expected_token:
+        return {
+            "ok": False,
+            "status": "approval_token_required",
+            "sent": False,
+            "reason": "DIALPAD_SMS_APPROVAL_TOKEN_not_configured",
+        }
+    if not provided_token or not hmac.compare_digest(provided_token, expected_token):
+        return {
+            "ok": False,
+            "status": "approval_token_invalid",
+            "sent": False,
+            "reason": "approval_token_missing_or_invalid",
+        }
+    return None
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    token_error = validate_approval_token(args.approval_token)
+    if token_error is not None:
+        if args.json:
+            print(json.dumps(token_error, sort_keys=True))
+        else:
+            print(f"SMS not sent: {token_error['status']}")
+        return 2
+
+    conn = init_db()
+    try:
+        result = approve_draft(
+            conn,
+            draft_id=args.draft_id,
+            actor_id=args.actor_id,
+            actor_username=args.actor_username,
+            action=args.action,
+            actor_is_bot=args.actor_is_bot,
+        )
+    finally:
+        conn.close()
+
+    if args.json:
+        print(json.dumps(result, sort_keys=True))
+    elif result.get("sent"):
+        print(f"SMS sent: {result.get('dialpad_sms_id') or 'unknown id'}")
+    else:
+        print(f"SMS not sent: {result.get('status')}")
+    return 0 if result.get("ok") else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/create_sms_draft.py
+++ b/scripts/create_sms_draft.py
@@ -11,7 +11,7 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
-from sms_approval import RISK_NORMAL, RISK_RISKY, create_draft, init_db, invalidate_pending
+from sms_approval import RISK_NORMAL, RISK_RISKY, create_draft, create_replacement_draft, init_db
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -45,23 +45,25 @@ def main() -> int:
     message = resolve_message_text(args)
     conn = init_db()
     try:
-        if not args.keep_pending:
-            invalidate_pending(
+        draft_args = {
+            "thread_key": args.thread_key,
+            "customer_number": args.customer_number,
+            "sender_number": args.sender_number,
+            "draft_text": message,
+            "source_inbound_id": args.source_inbound_id,
+            "risk_state": args.risk_state,
+            "risk_reason": args.risk_reason,
+            "context_fingerprint": args.context_fingerprint,
+        }
+        if args.keep_pending:
+            draft = create_draft(conn, **draft_args)
+        else:
+            draft = create_replacement_draft(
                 conn,
-                thread_key=args.thread_key,
-                reason="superseded_by_new_draft",
+                invalidate_thread_key=args.thread_key,
+                invalidate_customer_number=args.customer_number,
+                **draft_args,
             )
-        draft = create_draft(
-            conn,
-            thread_key=args.thread_key,
-            customer_number=args.customer_number,
-            sender_number=args.sender_number,
-            draft_text=message,
-            source_inbound_id=args.source_inbound_id,
-            risk_state=args.risk_state,
-            risk_reason=args.risk_reason,
-            context_fingerprint=args.context_fingerprint,
-        )
     finally:
         conn.close()
 

--- a/scripts/create_sms_draft.py
+++ b/scripts/create_sms_draft.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Create a reviewable Dialpad SMS draft without sending it."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from sms_approval import RISK_NORMAL, RISK_RISKY, create_draft, init_db, invalidate_pending
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Create a Dialpad SMS approval draft")
+    parser.add_argument("--thread-key", required=True)
+    parser.add_argument("--to", required=True, dest="customer_number")
+    parser.add_argument("--from", required=True, dest="sender_number")
+    message_group = parser.add_mutually_exclusive_group(required=True)
+    message_group.add_argument("--message")
+    message_group.add_argument("--message-file")
+    message_group.add_argument("--message-stdin", action="store_true")
+    parser.add_argument("--source-inbound-id")
+    parser.add_argument("--risk-state", choices=(RISK_NORMAL, RISK_RISKY), default=RISK_NORMAL)
+    parser.add_argument("--risk-reason")
+    parser.add_argument("--context-fingerprint")
+    parser.add_argument("--keep-pending", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def resolve_message_text(args: argparse.Namespace) -> str:
+    if args.message is not None:
+        return args.message
+    if args.message_file:
+        return Path(args.message_file).read_text(encoding="utf-8")
+    return sys.stdin.read()
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    message = resolve_message_text(args)
+    conn = init_db()
+    try:
+        if not args.keep_pending:
+            invalidate_pending(
+                conn,
+                thread_key=args.thread_key,
+                reason="superseded_by_new_draft",
+            )
+        draft = create_draft(
+            conn,
+            thread_key=args.thread_key,
+            customer_number=args.customer_number,
+            sender_number=args.sender_number,
+            draft_text=message,
+            source_inbound_id=args.source_inbound_id,
+            risk_state=args.risk_state,
+            risk_reason=args.risk_reason,
+            context_fingerprint=args.context_fingerprint,
+        )
+    finally:
+        conn.close()
+
+    if args.json:
+        print(json.dumps({"ok": True, "draft": draft}, sort_keys=True))
+    else:
+        print(f"Draft created: {draft['draft_id']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sms_approval.py
+++ b/scripts/sms_approval.py
@@ -144,6 +144,7 @@ def create_draft(
     metadata: dict[str, Any] | None = None,
     draft_id: str | None = None,
     created_at_ms: int | None = None,
+    commit: bool = True,
 ) -> dict[str, Any]:
     if risk_state not in {RISK_NORMAL, RISK_RISKY}:
         raise ValueError(f"invalid risk_state: {risk_state}")
@@ -179,7 +180,8 @@ def create_draft(
             json.dumps(metadata or {}, sort_keys=True),
         ),
     )
-    conn.commit()
+    if commit:
+        conn.commit()
     return get_draft(conn, resolved_draft_id) or {}
 
 
@@ -238,6 +240,7 @@ def invalidate_pending(
     reason: str,
     invalidated_at_ms: int | None = None,
     exclude_draft_id: str | None = None,
+    commit: bool = True,
 ) -> int:
     clauses = ["status IN (?, ?)"]
     params: list[Any] = [STATUS_PENDING, STATUS_RISK_PENDING]
@@ -262,8 +265,45 @@ def invalidate_pending(
         """,
         params,
     )
-    conn.commit()
+    if commit:
+        conn.commit()
     return cursor.rowcount
+
+
+def create_replacement_draft(
+    conn: sqlite3.Connection,
+    *,
+    invalidate_thread_key: str | None = None,
+    invalidate_customer_number: str | None = None,
+    invalidated_reason: str = "superseded_by_new_draft",
+    **draft_kwargs: Any,
+) -> dict[str, Any]:
+    """Atomically stale prior pending drafts and insert the replacement draft."""
+    if not invalidate_thread_key and not invalidate_customer_number:
+        raise ValueError("invalidate_thread_key or invalidate_customer_number is required")
+
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        if invalidate_thread_key:
+            invalidate_pending(
+                conn,
+                thread_key=invalidate_thread_key,
+                reason=invalidated_reason,
+                commit=False,
+            )
+        if invalidate_customer_number:
+            invalidate_pending(
+                conn,
+                customer_number=invalidate_customer_number,
+                reason=invalidated_reason,
+                commit=False,
+            )
+        draft = create_draft(conn, commit=False, **draft_kwargs)
+        conn.commit()
+        return draft
+    except Exception:
+        conn.rollback()
+        raise
 
 
 def _is_bot_actor(actor_id: str | None, actor_is_bot: bool = False) -> bool:

--- a/scripts/sms_approval.py
+++ b/scripts/sms_approval.py
@@ -14,6 +14,7 @@ from typing import Any, Callable
 
 
 DB_PATH = Path(os.environ.get("DIALPAD_SMS_APPROVAL_DB", "/home/art/clawd/logs/sms_approvals.db"))
+DEFAULT_EMERGENCY_OPT_OUT_PATH = Path("/tmp/dialpad_sms_approval_emergency_opt_outs.jsonl")
 
 STATUS_PENDING = "pending"
 STATUS_RISK_PENDING = "risk_pending"
@@ -52,6 +53,71 @@ def normalize_phone_number(phone_number: str | None) -> str | None:
     if len(digits) == 11 and digits.startswith("1"):
         digits = digits[1:]
     return digits[-10:] if len(digits) >= 10 else digits or None
+
+
+def emergency_opt_out_paths() -> list[Path]:
+    configured = os.environ.get("DIALPAD_SMS_APPROVAL_EMERGENCY_PATH")
+    if configured:
+        return [Path(configured)]
+    return [
+        DB_PATH.with_name("sms_approval_emergency_opt_outs.jsonl"),
+        DEFAULT_EMERGENCY_OPT_OUT_PATH,
+    ]
+
+
+def record_emergency_opt_out(
+    *,
+    customer_number: str,
+    reason: str = "customer_opt_out",
+    source: str | None = None,
+    created_at_ms: int | None = None,
+) -> Path:
+    """Append a fail-closed opt-out marker outside the approval database."""
+    normalized = normalize_phone_number(customer_number)
+    if not normalized:
+        raise ValueError("customer_number is required")
+
+    payload = {
+        "customer_number_normalized": normalized,
+        "customer_number": customer_number,
+        "reason": reason,
+        "source": source,
+        "created_at_ms": created_at_ms or now_ms(),
+    }
+    last_error: Exception | None = None
+    for path in emergency_opt_out_paths():
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(payload, sort_keys=True) + "\n")
+            return path
+        except OSError as exc:
+            last_error = exc
+    if last_error:
+        raise last_error
+    raise OSError("no emergency opt-out path configured")
+
+
+def is_emergency_opted_out(customer_number: str | None) -> bool:
+    normalized = normalize_phone_number(customer_number)
+    if not normalized:
+        return False
+
+    for path in emergency_opt_out_paths():
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                for line in handle:
+                    try:
+                        payload = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if payload.get("customer_number_normalized") == normalized:
+                        return True
+        except FileNotFoundError:
+            continue
+        except OSError:
+            continue
+    return False
 
 
 def build_context_fingerprint(parts: dict[str, Any]) -> str:
@@ -189,6 +255,8 @@ def is_opted_out(conn: sqlite3.Connection, customer_number: str | None) -> bool:
     normalized = normalize_phone_number(customer_number)
     if not normalized:
         return False
+    if is_emergency_opted_out(customer_number):
+        return True
     row = conn.execute(
         "SELECT 1 FROM sms_approval_opt_outs WHERE customer_number_normalized = ?",
         (normalized,),

--- a/scripts/sms_approval.py
+++ b/scripts/sms_approval.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Persistent approval gate for Dialpad SMS drafts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Callable
+
+
+DB_PATH = Path(os.environ.get("DIALPAD_SMS_APPROVAL_DB", "/home/art/clawd/logs/sms_approvals.db"))
+
+STATUS_PENDING = "pending"
+STATUS_RISK_PENDING = "risk_pending"
+STATUS_SENDING = "sending"
+STATUS_SENT = "sent"
+STATUS_FAILED = "failed"
+STATUS_STALE = "stale"
+
+RISK_NORMAL = "normal"
+RISK_RISKY = "risky"
+
+ACTION_APPROVE = "approve"
+ACTION_CONFIRM_RISK = "confirm-risk"
+
+BOT_ACTOR_IDS = {"", "agent", "bot", "openclaw", "niemand", "niemand-work"}
+
+
+def now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def normalize_phone_number(phone_number: str | None) -> str | None:
+    if not phone_number:
+        return None
+    digits = "".join(ch for ch in str(phone_number) if ch.isdigit())
+    if len(digits) == 11 and digits.startswith("1"):
+        digits = digits[1:]
+    return digits[-10:] if len(digits) >= 10 else digits or None
+
+
+def build_context_fingerprint(parts: dict[str, Any]) -> str:
+    canonical = json.dumps(parts, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def init_db(path: Path | None = None) -> sqlite3.Connection:
+    db_path = path or DB_PATH
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS sms_approval_drafts (
+            draft_id TEXT PRIMARY KEY,
+            thread_key TEXT NOT NULL,
+            source_inbound_id TEXT,
+            customer_number TEXT NOT NULL,
+            customer_number_normalized TEXT,
+            sender_number TEXT NOT NULL,
+            draft_text TEXT NOT NULL,
+            risk_state TEXT NOT NULL,
+            risk_reason TEXT,
+            context_fingerprint TEXT,
+            status TEXT NOT NULL,
+            created_at_ms INTEGER NOT NULL,
+            invalidated_at_ms INTEGER,
+            invalidated_reason TEXT,
+            first_confirmed_by TEXT,
+            first_confirmed_username TEXT,
+            first_confirmed_at_ms INTEGER,
+            approved_by TEXT,
+            approved_username TEXT,
+            approved_at_ms INTEGER,
+            dialpad_sms_id TEXT,
+            delivery_status TEXT,
+            send_error TEXT,
+            metadata_json TEXT
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sms_approval_thread_status "
+        "ON sms_approval_drafts(thread_key, status)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sms_approval_customer_status "
+        "ON sms_approval_drafts(customer_number_normalized, status)"
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS sms_approval_opt_outs (
+            customer_number_normalized TEXT PRIMARY KEY,
+            customer_number TEXT NOT NULL,
+            reason TEXT NOT NULL,
+            source TEXT,
+            created_at_ms INTEGER NOT NULL
+        )
+        """
+    )
+    conn.commit()
+    return conn
+
+
+def row_to_dict(row: sqlite3.Row | None) -> dict[str, Any] | None:
+    if row is None:
+        return None
+    result = dict(row)
+    if result.get("metadata_json"):
+        try:
+            result["metadata"] = json.loads(result["metadata_json"])
+        except json.JSONDecodeError:
+            result["metadata"] = None
+    result.pop("metadata_json", None)
+    return result
+
+
+def create_draft(
+    conn: sqlite3.Connection,
+    *,
+    thread_key: str,
+    customer_number: str,
+    sender_number: str,
+    draft_text: str,
+    source_inbound_id: str | None = None,
+    risk_state: str = RISK_NORMAL,
+    risk_reason: str | None = None,
+    context_fingerprint: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    draft_id: str | None = None,
+    created_at_ms: int | None = None,
+) -> dict[str, Any]:
+    if risk_state not in {RISK_NORMAL, RISK_RISKY}:
+        raise ValueError(f"invalid risk_state: {risk_state}")
+    text = draft_text.strip()
+    if not text:
+        raise ValueError("draft_text cannot be empty")
+    if is_opted_out(conn, customer_number):
+        raise ValueError("customer has opted out")
+
+    resolved_draft_id = draft_id or f"smsdraft_{uuid.uuid4().hex[:16]}"
+    conn.execute(
+        """
+        INSERT INTO sms_approval_drafts (
+            draft_id, thread_key, source_inbound_id, customer_number,
+            customer_number_normalized, sender_number, draft_text, risk_state,
+            risk_reason, context_fingerprint, status, created_at_ms, metadata_json
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            resolved_draft_id,
+            thread_key,
+            source_inbound_id,
+            customer_number,
+            normalize_phone_number(customer_number),
+            sender_number,
+            text,
+            risk_state,
+            risk_reason,
+            context_fingerprint,
+            STATUS_PENDING,
+            created_at_ms or now_ms(),
+            json.dumps(metadata or {}, sort_keys=True),
+        ),
+    )
+    conn.commit()
+    return get_draft(conn, resolved_draft_id) or {}
+
+
+def is_opted_out(conn: sqlite3.Connection, customer_number: str | None) -> bool:
+    normalized = normalize_phone_number(customer_number)
+    if not normalized:
+        return False
+    row = conn.execute(
+        "SELECT 1 FROM sms_approval_opt_outs WHERE customer_number_normalized = ?",
+        (normalized,),
+    ).fetchone()
+    return row is not None
+
+
+def mark_opt_out(
+    conn: sqlite3.Connection,
+    *,
+    customer_number: str,
+    reason: str = "customer_opt_out",
+    source: str | None = None,
+    created_at_ms: int | None = None,
+) -> None:
+    normalized = normalize_phone_number(customer_number)
+    if not normalized:
+        raise ValueError("customer_number is required")
+    conn.execute(
+        """
+        INSERT INTO sms_approval_opt_outs (
+            customer_number_normalized, customer_number, reason, source, created_at_ms
+        )
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(customer_number_normalized) DO UPDATE SET
+            customer_number = excluded.customer_number,
+            reason = excluded.reason,
+            source = excluded.source,
+            created_at_ms = excluded.created_at_ms
+        """,
+        (normalized, customer_number, reason, source, created_at_ms or now_ms()),
+    )
+    invalidate_pending(conn, customer_number=customer_number, reason=reason)
+
+
+def get_draft(conn: sqlite3.Connection, draft_id: str) -> dict[str, Any] | None:
+    row = conn.execute(
+        "SELECT * FROM sms_approval_drafts WHERE draft_id = ?",
+        (draft_id,),
+    ).fetchone()
+    return row_to_dict(row)
+
+
+def invalidate_pending(
+    conn: sqlite3.Connection,
+    *,
+    thread_key: str | None = None,
+    customer_number: str | None = None,
+    reason: str,
+    invalidated_at_ms: int | None = None,
+    exclude_draft_id: str | None = None,
+) -> int:
+    clauses = ["status IN (?, ?)"]
+    params: list[Any] = [STATUS_PENDING, STATUS_RISK_PENDING]
+    if thread_key:
+        clauses.append("thread_key = ?")
+        params.append(thread_key)
+    elif customer_number:
+        clauses.append("customer_number_normalized = ?")
+        params.append(normalize_phone_number(customer_number))
+    else:
+        raise ValueError("thread_key or customer_number is required")
+    if exclude_draft_id:
+        clauses.append("draft_id != ?")
+        params.append(exclude_draft_id)
+
+    params = [STATUS_STALE, invalidated_at_ms or now_ms(), reason, *params]
+    cursor = conn.execute(
+        f"""
+        UPDATE sms_approval_drafts
+        SET status = ?, invalidated_at_ms = ?, invalidated_reason = ?
+        WHERE {" AND ".join(clauses)}
+        """,
+        params,
+    )
+    conn.commit()
+    return cursor.rowcount
+
+
+def _is_bot_actor(actor_id: str | None, actor_is_bot: bool = False) -> bool:
+    if actor_is_bot:
+        return True
+    normalized = str(actor_id or "").strip().lower()
+    return normalized in BOT_ACTOR_IDS
+
+
+def _actor_is_allowed(actor_id: str | None) -> bool:
+    raw_allowlist = os.environ.get("DIALPAD_SMS_APPROVAL_ALLOWED_ACTORS", "")
+    allowed = {item.strip() for item in raw_allowlist.split(",") if item.strip()}
+    if not allowed:
+        return True
+    return str(actor_id or "").strip() in allowed
+
+
+def _extract_send_result(result: Any) -> tuple[str | None, str | None]:
+    if not isinstance(result, dict):
+        return None, "unknown"
+    sms_id = result.get("id") or result.get("message_id")
+    status = result.get("delivery_status") or result.get("message_status") or result.get("status")
+    return (str(sms_id) if sms_id is not None else None, str(status) if status is not None else None)
+
+
+def approve_draft(
+    conn: sqlite3.Connection,
+    *,
+    draft_id: str,
+    actor_id: str,
+    actor_username: str | None = None,
+    action: str = ACTION_APPROVE,
+    actor_is_bot: bool = False,
+    send_func: Callable[..., Any] | None = None,
+    approved_at_ms: int | None = None,
+) -> dict[str, Any]:
+    if _is_bot_actor(actor_id, actor_is_bot=actor_is_bot):
+        return {"ok": False, "status": "blocked_actor", "sent": False, "reason": "agent_or_bot_cannot_approve"}
+    if not _actor_is_allowed(actor_id):
+        return {"ok": False, "status": "actor_not_allowed", "sent": False, "reason": "actor_not_in_allowlist"}
+    if action not in {ACTION_APPROVE, ACTION_CONFIRM_RISK}:
+        return {"ok": False, "status": "invalid_action", "sent": False, "reason": action}
+
+    draft = get_draft(conn, draft_id)
+    if not draft:
+        return {"ok": False, "status": "not_found", "sent": False}
+    if draft.get("status") == STATUS_SENT:
+        return {"ok": True, "status": "already_resolved", "sent": False, "draft": draft}
+    if draft.get("status") not in {STATUS_PENDING, STATUS_RISK_PENDING}:
+        return {
+            "ok": False,
+            "status": "stale",
+            "sent": False,
+            "reason": draft.get("invalidated_reason") or draft.get("status"),
+            "draft": draft,
+        }
+    if draft.get("invalidated_at_ms"):
+        return {
+            "ok": False,
+            "status": "stale",
+            "sent": False,
+            "reason": draft.get("invalidated_reason") or "invalidated",
+            "draft": draft,
+        }
+    if is_opted_out(conn, draft.get("customer_number")):
+        return {
+            "ok": False,
+            "status": "blocked_opt_out",
+            "sent": False,
+            "reason": "customer_opt_out",
+            "draft": draft,
+        }
+
+    ts = approved_at_ms or now_ms()
+    if draft.get("risk_state") == RISK_RISKY:
+        if action == ACTION_CONFIRM_RISK:
+            if draft.get("status") != STATUS_RISK_PENDING or not draft.get("first_confirmed_at_ms"):
+                return {
+                    "ok": True,
+                    "status": "risky_confirmation_required",
+                    "sent": False,
+                    "risk_reason": draft.get("risk_reason"),
+                    "draft": draft,
+                }
+        else:
+            conn.execute(
+                """
+                UPDATE sms_approval_drafts
+                SET status = ?, first_confirmed_by = ?, first_confirmed_username = ?,
+                    first_confirmed_at_ms = ?
+                WHERE draft_id = ?
+                """,
+                (STATUS_RISK_PENDING, actor_id, actor_username, ts, draft_id),
+            )
+            conn.commit()
+            return {
+                "ok": True,
+                "status": "risky_confirmation_required",
+                "sent": False,
+                "risk_reason": draft.get("risk_reason"),
+                "draft": get_draft(conn, draft_id),
+            }
+
+    expected_status = STATUS_RISK_PENDING if draft.get("risk_state") == RISK_RISKY else STATUS_PENDING
+    cursor = conn.execute(
+        """
+        UPDATE sms_approval_drafts
+        SET status = ?, approved_by = ?, approved_username = ?, approved_at_ms = ?,
+            send_error = NULL
+        WHERE draft_id = ?
+          AND status = ?
+          AND invalidated_at_ms IS NULL
+        """,
+        (STATUS_SENDING, actor_id, actor_username, ts, draft_id, expected_status),
+    )
+    conn.commit()
+    if cursor.rowcount != 1:
+        current = get_draft(conn, draft_id)
+        return {
+            "ok": False,
+            "status": "stale",
+            "sent": False,
+            "reason": (current or {}).get("invalidated_reason") or (current or {}).get("status") or "not_claimed",
+            "draft": current,
+        }
+
+    if send_func is None:
+        from send_sms import send_sms as send_func
+
+    try:
+        result = send_func(
+            [draft["customer_number"]],
+            draft["draft_text"],
+            from_number=draft["sender_number"],
+        )
+        sms_id, delivery_status = _extract_send_result(result)
+        conn.execute(
+            """
+            UPDATE sms_approval_drafts
+            SET status = ?, dialpad_sms_id = ?, delivery_status = ?, send_error = NULL
+            WHERE draft_id = ? AND status = ?
+            """,
+            (STATUS_SENT, sms_id, delivery_status, draft_id, STATUS_SENDING),
+        )
+        conn.commit()
+        return {
+            "ok": True,
+            "status": STATUS_SENT,
+            "sent": True,
+            "dialpad_sms_id": sms_id,
+            "delivery_status": delivery_status,
+            "draft": get_draft(conn, draft_id),
+        }
+    except Exception as exc:  # noqa: BLE001 - persisted error boundary for external send.
+        conn.execute(
+            """
+            UPDATE sms_approval_drafts
+            SET status = ?, send_error = ?
+            WHERE draft_id = ? AND status = ?
+            """,
+            (STATUS_FAILED, str(exc), draft_id, STATUS_SENDING),
+        )
+        conn.commit()
+        return {
+            "ok": False,
+            "status": STATUS_FAILED,
+            "sent": False,
+            "error": str(exc),
+            "draft": get_draft(conn, draft_id),
+        }

--- a/scripts/sms_approval.py
+++ b/scripts/sms_approval.py
@@ -339,14 +339,14 @@ def approve_draft(
                     "draft": draft,
                 }
         else:
-            conn.execute(
+            cursor = conn.execute(
                 """
                 UPDATE sms_approval_drafts
                 SET status = ?, first_confirmed_by = ?, first_confirmed_username = ?,
                     first_confirmed_at_ms = ?
-                WHERE draft_id = ?
+                WHERE draft_id = ? AND status = ? AND first_confirmed_at_ms IS NULL
                 """,
-                (STATUS_RISK_PENDING, actor_id, actor_username, ts, draft_id),
+                (STATUS_RISK_PENDING, actor_id, actor_username, ts, draft_id, STATUS_PENDING),
             )
             conn.commit()
             return {
@@ -354,7 +354,7 @@ def approve_draft(
                 "status": "risky_confirmation_required",
                 "sent": False,
                 "risk_reason": draft.get("risk_reason"),
-                "draft": get_draft(conn, draft_id),
+                "draft": get_draft(conn, draft_id) if cursor.rowcount == 1 else draft,
             }
 
     expected_status = STATUS_RISK_PENDING if draft.get("risk_state") == RISK_RISKY else STATUS_PENDING

--- a/scripts/sms_approval.py
+++ b/scripts/sms_approval.py
@@ -15,6 +15,7 @@ from typing import Any, Callable
 
 DB_PATH = Path(os.environ.get("DIALPAD_SMS_APPROVAL_DB", "/home/art/clawd/logs/sms_approvals.db"))
 DEFAULT_EMERGENCY_OPT_OUT_PATH = Path("/tmp/dialpad_sms_approval_emergency_opt_outs.jsonl")
+_EMERGENCY_OPT_OUT_MEMORY: set[str] = set()
 
 STATUS_PENDING = "pending"
 STATUS_RISK_PENDING = "risk_pending"
@@ -76,6 +77,7 @@ def record_emergency_opt_out(
     normalized = normalize_phone_number(customer_number)
     if not normalized:
         raise ValueError("customer_number is required")
+    _EMERGENCY_OPT_OUT_MEMORY.add(normalized)
 
     payload = {
         "customer_number_normalized": normalized,
@@ -102,6 +104,8 @@ def is_emergency_opted_out(customer_number: str | None) -> bool:
     normalized = normalize_phone_number(customer_number)
     if not normalized:
         return False
+    if normalized in _EMERGENCY_OPT_OUT_MEMORY:
+        return True
 
     for path in emergency_opt_out_paths():
         try:

--- a/scripts/sms_approval.py
+++ b/scripts/sms_approval.py
@@ -29,6 +29,16 @@ ACTION_APPROVE = "approve"
 ACTION_CONFIRM_RISK = "confirm-risk"
 
 BOT_ACTOR_IDS = {"", "agent", "bot", "openclaw", "niemand", "niemand-work"}
+FAILED_DELIVERY_STATUSES = {
+    "failed",
+    "failure",
+    "undelivered",
+    "rejected",
+    "error",
+    "errored",
+    "cancelled",
+    "canceled",
+}
 
 
 def now_ms() -> int:
@@ -279,6 +289,15 @@ def _extract_send_result(result: Any) -> tuple[str | None, str | None]:
     return (str(sms_id) if sms_id is not None else None, str(status) if status is not None else None)
 
 
+def _send_result_failure_reason(sms_id: str | None, delivery_status: str | None) -> str | None:
+    if not sms_id:
+        return "missing_dialpad_sms_id"
+    normalized_status = str(delivery_status or "").strip().lower()
+    if normalized_status in FAILED_DELIVERY_STATUSES:
+        return f"delivery_status_{normalized_status}"
+    return None
+
+
 def approve_draft(
     conn: sqlite3.Connection,
     *,
@@ -390,6 +409,26 @@ def approve_draft(
             from_number=draft["sender_number"],
         )
         sms_id, delivery_status = _extract_send_result(result)
+        failure_reason = _send_result_failure_reason(sms_id, delivery_status)
+        if failure_reason:
+            conn.execute(
+                """
+                UPDATE sms_approval_drafts
+                SET status = ?, dialpad_sms_id = ?, delivery_status = ?, send_error = ?
+                WHERE draft_id = ? AND status = ?
+                """,
+                (STATUS_FAILED, sms_id, delivery_status, failure_reason, draft_id, STATUS_SENDING),
+            )
+            conn.commit()
+            return {
+                "ok": False,
+                "status": STATUS_FAILED,
+                "sent": False,
+                "error": failure_reason,
+                "dialpad_sms_id": sms_id,
+                "delivery_status": delivery_status,
+                "draft": get_draft(conn, draft_id),
+            }
         conn.execute(
             """
             UPDATE sms_approval_drafts

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -1844,6 +1844,7 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                     auto_reply_message,
                     reply_policy,
                 )
+                tg_text += build_human_only_blocked_suffix(reply_policy)
                 telegram_sms_sent = send_to_telegram(tg_text)
                 telegram_status = TELEGRAM_STATUS_SENT if telegram_sms_sent else TELEGRAM_STATUS_FAILED
             elif hook_status == "filtered_opt_out":

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -155,7 +155,8 @@ CALLS_ENDPOINT = "https://dialpad.com/api/v2/call"
 
 OPT_OUT_PATTERNS = (
     re.compile(r"^\s*(stop|stopall|unsubscribe|cancel|end|quit)\s*[.!]?\s*$", re.IGNORECASE),
-    re.compile(r"\b(stop|unsubscribe|remove me|do not contact|don't contact)\b", re.IGNORECASE),
+    re.compile(r"\bstop\s+(texting|messaging|calling|contacting|reaching out|sending)\b", re.IGNORECASE),
+    re.compile(r"\b(unsubscribe|remove me|do not contact|don't contact)\b", re.IGNORECASE),
     re.compile(r"\b(do not|don't|please don't)\s+bother me\b", re.IGNORECASE),
     re.compile(r"\bleave me alone\b", re.IGNORECASE),
 )
@@ -1783,16 +1784,18 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                     except Exception as exc:  # noqa: BLE001 - webhook must degrade safely.
                         print(f"⚠️  Failed to persist opt-out ({type(exc).__name__})")
         elif direction == "outbound" and sms_approval is not None:
-            outbound_customer = first_value(to_num)
-            if outbound_customer:
+            outbound_customers = to_num if isinstance(to_num, list) else [to_num]
+            outbound_customers = [customer for customer in outbound_customers if customer]
+            if outbound_customers:
                 try:
                     conn = sms_approval.init_db()
                     try:
-                        sms_approval.invalidate_pending(
-                            conn,
-                            customer_number=outbound_customer,
-                            reason="manual_outbound",
-                        )
+                        for outbound_customer in outbound_customers:
+                            sms_approval.invalidate_pending(
+                                conn,
+                                customer_number=outbound_customer,
+                                reason="manual_outbound",
+                            )
                     finally:
                         conn.close()
                 except Exception as exc:  # noqa: BLE001 - webhook must degrade safely.

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -1303,7 +1303,7 @@ def build_approval_review_suffix(draft_id, draft_message, reply_policy=None):
         f"*Draft ID:* `{escape_telegram_markdown(draft_id)}`",
         f"*Exact text:*\n{escape_telegram_markdown(draft_message)}",
         "",
-        f"Approve from an operator shell: `bin/approve_sms_draft.py {escape_telegram_markdown(draft_id)} --actor-id <human-id> --json`",
+        f"Approve from an operator shell: `bin/approve_sms_draft.py {escape_telegram_markdown(draft_id)} --actor-id <human-id> --approval-token \"$DIALPAD_SMS_APPROVAL_TOKEN\" --json`",
     ]
     if risk_state == "risky":
         reason = reply_policy.get("risk_reason") or "risk policy matched"
@@ -1311,7 +1311,7 @@ def build_approval_review_suffix(draft_id, draft_message, reply_policy=None):
             [
                 "",
                 f"⚠️ *Risk:* {escape_telegram_markdown(reason)}",
-                f"Second confirmation required: `bin/approve_sms_draft.py {escape_telegram_markdown(draft_id)} --action confirm-risk --actor-id <human-id> --json`",
+                f"Second confirmation required: `bin/approve_sms_draft.py {escape_telegram_markdown(draft_id)} --action confirm-risk --actor-id <human-id> --approval-token \"$DIALPAD_SMS_APPROVAL_TOKEN\" --json`",
             ]
         )
     return "\n".join(lines)
@@ -1370,6 +1370,12 @@ def create_proactive_reply_draft(normalized_event, sender_enrichment=None, line_
     try:
         conn = sms_approval.init_db()
         try:
+            if sms_approval.is_opted_out(conn, recipient_number):
+                return False, "blocked_opt_out", message, None, {
+                    "state": "blocked_opt_out",
+                    "reason_code": "filtered_opt_out",
+                    "risk_reason": "customer previously opted out",
+                }
             sms_approval.invalidate_pending(
                 conn,
                 thread_key=thread_key,

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -1840,7 +1840,13 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                 print("   🔒 Sensitive message filtered (not forwarding to OpenClaw hooks)")
             elif hook_status == "filtered_opt_out":
                 print("   🛑 Opt-out message filtered (automation send path blocked)")
-                mark_opt_out_fail_closed(from_num, reason="customer_opt_out", source="sms")
+                opt_out_blocked = mark_opt_out_fail_closed(
+                    from_num,
+                    reason="customer_opt_out",
+                    source="sms",
+                )
+                if not opt_out_blocked:
+                    hook_status = "opt_out_persistence_failed"
         elif direction == "outbound" and sms_approval is not None:
             outbound_customers = to_num if isinstance(to_num, list) else [to_num]
             outbound_customers = [customer for customer in outbound_customers if customer]
@@ -1894,6 +1900,14 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                 )
                 telegram_sms_sent = send_to_telegram(tg_text)
                 telegram_status = "human_only_notified" if telegram_sms_sent else TELEGRAM_STATUS_FAILED
+            elif hook_status == "opt_out_persistence_failed":
+                tg_text = (
+                    "🛑 Dialpad SMS opt-out persistence failed / human-only\n"
+                    f"From: {escape_telegram_markdown(str(from_num))}\n"
+                    "Automation did not create a draft, but the opt-out could not be confirmed durable."
+                )
+                telegram_sms_sent = send_to_telegram(tg_text)
+                telegram_status = "opt_out_persistence_failed" if telegram_sms_sent else TELEGRAM_STATUS_FAILED
             elif not DIALPAD_SMS_TELEGRAM_NOTIFY:
                 telegram_status = "disabled"
             else:

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -1376,7 +1376,7 @@ def mark_opt_out_fail_closed(customer_number, *, reason="customer_opt_out", sour
     except Exception as exc:  # noqa: BLE001 - explicit opt-outs must fail closed.
         print(f"⚠️  Failed to persist opt-out ({type(exc).__name__})")
 
-    invalidated = invalidate_pending_sms_drafts(customer_number=customer_number, reason=reason)
+    invalidate_pending_sms_drafts(customer_number=customer_number, reason=reason)
     try:
         sms_approval.record_emergency_opt_out(
             customer_number=customer_number,
@@ -1386,7 +1386,7 @@ def mark_opt_out_fail_closed(customer_number, *, reason="customer_opt_out", sour
         return True
     except Exception as exc:  # noqa: BLE001 - webhook must degrade safely.
         print(f"⚠️  Failed to record emergency opt-out ({type(exc).__name__})")
-        return invalidated
+        return False
 
 
 def create_proactive_reply_draft(normalized_event, sender_enrichment=None, line_display=None):
@@ -1396,11 +1396,16 @@ def create_proactive_reply_draft(normalized_event, sender_enrichment=None, line_
     thread_key = build_hook_session_key(normalized_event)
     reply_policy = classify_sms_reply_policy(normalized_event.get("text") or "")
     if reply_policy["state"] == "blocked_opt_out":
-        mark_opt_out_fail_closed(
+        opt_out_blocked = mark_opt_out_fail_closed(
             recipient_number,
             reason="customer_opt_out",
             source=normalized_event.get("event_type"),
         )
+        if not opt_out_blocked:
+            return False, "opt_out_persistence_failed", None, None, {
+                **reply_policy,
+                "risk_reason": "explicit opt-out could not be made durable",
+            }
         return False, "blocked_opt_out", None, None, reply_policy
 
     if not should_send_proactive_reply(

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -1396,18 +1396,10 @@ def create_proactive_reply_draft(normalized_event, sender_enrichment=None, line_
                     "reason_code": "filtered_opt_out",
                     "risk_reason": "customer previously opted out",
                 }
-            sms_approval.invalidate_pending(
+            draft = sms_approval.create_replacement_draft(
                 conn,
-                thread_key=thread_key,
-                reason="superseded_by_new_draft",
-            )
-            sms_approval.invalidate_pending(
-                conn,
-                customer_number=recipient_number,
-                reason="superseded_by_new_draft",
-            )
-            draft = sms_approval.create_draft(
-                conn,
+                invalidate_thread_key=thread_key,
+                invalidate_customer_number=recipient_number,
                 thread_key=thread_key,
                 customer_number=recipient_number,
                 sender_number=sender_number,

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -28,8 +28,8 @@ Environment Variables:
 - OPENCLAW_HOOKS_CHANNEL (optional)
 - OPENCLAW_HOOKS_TO (optional)
 - OPENCLAW_HOOKS_AGENT_ID (optional)
-- OPENCLAW_HOOKS_SMS_ENABLED (default: enabled)
-- OPENCLAW_HOOKS_CALL_ENABLED (default: enabled)
+- OPENCLAW_HOOKS_SMS_ENABLED (default: disabled)
+- OPENCLAW_HOOKS_CALL_ENABLED (default: disabled)
 """
 
 import json
@@ -57,6 +57,11 @@ try:
     from send_sms import send_sms as dialpad_send_sms
 except Exception:
     dialpad_send_sms = None
+
+try:
+    import sms_approval
+except Exception:
+    sms_approval = None
 
 
 def parse_bool_env(raw_value, default=True):
@@ -88,12 +93,12 @@ OPENCLAW_HOOKS_CALL_NAME = os.environ.get("OPENCLAW_HOOKS_CALL_NAME", "Dialpad M
 OPENCLAW_HOOKS_CHANNEL = os.environ.get("OPENCLAW_HOOKS_CHANNEL", "")
 OPENCLAW_HOOKS_TO = os.environ.get("OPENCLAW_HOOKS_TO", "")
 OPENCLAW_HOOKS_AGENT_ID = os.environ.get("OPENCLAW_HOOKS_AGENT_ID", "")
-OPENCLAW_HOOKS_SMS_ENABLED = parse_bool_env(os.environ.get("OPENCLAW_HOOKS_SMS_ENABLED"), True)
-OPENCLAW_HOOKS_CALL_ENABLED = parse_bool_env(os.environ.get("OPENCLAW_HOOKS_CALL_ENABLED"), True)
+OPENCLAW_HOOKS_SMS_ENABLED = parse_bool_env(os.environ.get("OPENCLAW_HOOKS_SMS_ENABLED"), False)
+OPENCLAW_HOOKS_CALL_ENABLED = parse_bool_env(os.environ.get("OPENCLAW_HOOKS_CALL_ENABLED"), False)
 DIALPAD_SMS_TELEGRAM_NOTIFY = os.environ.get("DIALPAD_SMS_TELEGRAM_NOTIFY", "1").lower() in {"1", "true", "yes", "on"}
 DIALPAD_PRIORITY_ROUTE_TO = os.environ.get("DIALPAD_PRIORITY_ROUTE_TO", "")
 DIALPAD_PRIORITY_ROUTE_PHONES = os.environ.get("DIALPAD_PRIORITY_ROUTE_PHONES", "")
-DIALPAD_AUTO_REPLY_ENABLED = parse_bool_env(os.environ.get("DIALPAD_AUTO_REPLY_ENABLED"), True)
+DIALPAD_AUTO_REPLY_ENABLED = parse_bool_env(os.environ.get("DIALPAD_AUTO_REPLY_ENABLED"), False)
 
 DEFAULT_LINE_NAMES = {
     "+14155201316": "Sales",
@@ -147,6 +152,20 @@ SENSITIVE_KEYWORD_PATTERNS = (
 
 CODE_TOKEN_PATTERN = re.compile(r"\b(?:\d[\s-]?){4,8}\b")
 CALLS_ENDPOINT = "https://dialpad.com/api/v2/call"
+
+OPT_OUT_PATTERNS = (
+    re.compile(r"^\s*(stop|stopall|unsubscribe|cancel|end|quit)\s*[.!]?\s*$", re.IGNORECASE),
+    re.compile(r"\b(stop|unsubscribe|remove me|do not contact|don't contact)\b", re.IGNORECASE),
+    re.compile(r"\b(do not|don't|please don't)\s+bother me\b", re.IGNORECASE),
+    re.compile(r"\bleave me alone\b", re.IGNORECASE),
+)
+
+RISKY_REPLY_PATTERNS = (
+    re.compile(r"\b(real person|human|representative|manager)\b", re.IGNORECASE),
+    re.compile(r"\b(lawyer|attorney|legal|complaint|report you)\b", re.IGNORECASE),
+    re.compile(r"\b(confused|confusion|wrong time|already|thought today|when are we)\b", re.IGNORECASE),
+    re.compile(r"\b(angry|upset|frustrated|annoyed)\b", re.IGNORECASE),
+)
 
 
 def log_line(message):
@@ -484,6 +503,30 @@ def is_sensitive_message(text="", sender="", contact_number=""):
     return has_code and has_security_context
 
 
+def classify_sms_reply_policy(text):
+    """Classify inbound text for deterministic SMS reply safety."""
+    body = str(text or "")
+    for pattern in OPT_OUT_PATTERNS:
+        if pattern.search(body):
+            return {
+                "state": "blocked_opt_out",
+                "reason_code": "filtered_opt_out",
+                "risk_reason": "explicit opt-out language",
+            }
+    for pattern in RISKY_REPLY_PATTERNS:
+        if pattern.search(body):
+            return {
+                "state": "risky",
+                "reason_code": "risky_confirmation_required",
+                "risk_reason": f"matched risky phrase: {pattern.pattern}",
+            }
+    return {
+        "state": "normal",
+        "reason_code": "eligible",
+        "risk_reason": None,
+    }
+
+
 def first_value(value):
     """Return first item for list-like values, otherwise passthrough."""
     if isinstance(value, (list, tuple)):
@@ -611,11 +654,21 @@ def assess_inbound_sms_alert_eligibility(
             "sensitive_filtered": True,
             "notification_type": resolved_type,
         }
+    reply_policy = classify_sms_reply_policy(text)
+    if reply_policy["state"] == "blocked_opt_out":
+        return {
+            "eligible": False,
+            "reason_code": reply_policy["reason_code"],
+            "sensitive_filtered": False,
+            "notification_type": resolved_type,
+            "reply_policy": reply_policy,
+        }
     return {
         "eligible": True,
         "reason_code": "eligible",
         "sensitive_filtered": False,
         "notification_type": resolved_type,
+        "reply_policy": reply_policy,
     }
 
 
@@ -1225,32 +1278,130 @@ def summarize_message_status(result):
 
 
 def send_proactive_reply(normalized_event, sender_enrichment=None, line_display=None):
-    """Send the sales-line auto-reply SMS for eligible first-contact inbound events."""
-    if dialpad_send_sms is None:
-        return False, "sender_unavailable", None
-
+    """Deprecated direct-send path retained as a safe no-op."""
     if not should_send_proactive_reply(
         normalized_event,
         sender_enrichment=sender_enrichment,
         line_display=line_display,
     ):
         return False, "not_eligible", None
-
-    recipient_number = normalized_event.get("sender_number")
-    sender_number = normalized_event.get("recipient_number")
     message = build_proactive_reply_message(normalized_event, sender_enrichment=sender_enrichment)
+    return False, "approval_required", message
 
-    try:
-        result = dialpad_send_sms(
-            [recipient_number],
-            message,
-            from_number=sender_number,
+
+def build_approval_review_suffix(draft_id, draft_message, reply_policy=None):
+    """Build Telegram review text for an approval draft without implying a send."""
+    if not draft_id or not draft_message:
+        return ""
+
+    reply_policy = reply_policy or {}
+    risk_state = reply_policy.get("state")
+    lines = [
+        "",
+        "",
+        "📝 *SMS approval draft \\(not sent\\)*",
+        f"*Draft ID:* `{escape_telegram_markdown(draft_id)}`",
+        f"*Exact text:*\n{escape_telegram_markdown(draft_message)}",
+        "",
+        f"Approve from an operator shell: `bin/approve_sms_draft.py {escape_telegram_markdown(draft_id)} --actor-id <human-id> --json`",
+    ]
+    if risk_state == "risky":
+        reason = reply_policy.get("risk_reason") or "risk policy matched"
+        lines.extend(
+            [
+                "",
+                f"⚠️ *Risk:* {escape_telegram_markdown(reason)}",
+                f"Second confirmation required: `bin/approve_sms_draft.py {escape_telegram_markdown(draft_id)} --action confirm-risk --actor-id <human-id> --json`",
+            ]
         )
-        status_label, _raw_status = summarize_message_status(result)
-        return True, status_label, message
-    except Exception as e:
-        print(f"⚠️  Proactive auto-reply failed ({type(e).__name__})")
-        return False, "failed", message
+    return "\n".join(lines)
+
+
+def create_proactive_reply_draft(normalized_event, sender_enrichment=None, line_display=None):
+    """Create an approval-gated proactive reply draft instead of sending SMS."""
+    if not should_send_proactive_reply(
+        normalized_event,
+        sender_enrichment=sender_enrichment,
+        line_display=line_display,
+    ):
+        return False, "not_eligible", None, None, None
+
+    thread_key = build_hook_session_key(normalized_event)
+    sender_number = normalized_event.get("recipient_number")
+    recipient_number = normalized_event.get("sender_number")
+    message = build_proactive_reply_message(normalized_event, sender_enrichment=sender_enrichment)
+    reply_policy = classify_sms_reply_policy(normalized_event.get("text") or "")
+    if reply_policy["state"] == "blocked_opt_out":
+        if sms_approval is not None and recipient_number:
+            try:
+                conn = sms_approval.init_db()
+                try:
+                    sms_approval.mark_opt_out(
+                        conn,
+                        customer_number=recipient_number,
+                        reason="customer_opt_out",
+                        source=normalized_event.get("event_type"),
+                    )
+                finally:
+                    conn.close()
+            except Exception as exc:  # noqa: BLE001 - webhook must degrade safely.
+                print(f"⚠️  Failed to persist opt-out ({type(exc).__name__})")
+        return False, "blocked_opt_out", message, None, reply_policy
+    if sms_approval is None:
+        return False, "approval_unavailable", message, None, reply_policy
+    if not sender_number or not recipient_number:
+        return False, "missing_sender_or_recipient", message, None, reply_policy
+
+    risk_state = (
+        sms_approval.RISK_RISKY
+        if reply_policy["state"] == "risky"
+        else sms_approval.RISK_NORMAL
+    )
+    context_fingerprint = sms_approval.build_context_fingerprint(
+        {
+            "thread_key": thread_key,
+            "sender": sender_number,
+            "recipient": recipient_number,
+            "message_id": normalized_event.get("message_id") or normalized_event.get("call_id"),
+            "line_display": line_display or normalized_event.get("line_display"),
+            "first_contact": normalized_event.get("first_contact"),
+        }
+    )
+    try:
+        conn = sms_approval.init_db()
+        try:
+            sms_approval.invalidate_pending(
+                conn,
+                thread_key=thread_key,
+                reason="superseded_by_new_draft",
+            )
+            sms_approval.invalidate_pending(
+                conn,
+                customer_number=recipient_number,
+                reason="superseded_by_new_draft",
+            )
+            draft = sms_approval.create_draft(
+                conn,
+                thread_key=thread_key,
+                customer_number=recipient_number,
+                sender_number=sender_number,
+                draft_text=message,
+                source_inbound_id=normalized_event.get("message_id") or normalized_event.get("call_id"),
+                risk_state=risk_state,
+                risk_reason=reply_policy.get("risk_reason"),
+                context_fingerprint=context_fingerprint,
+                metadata={
+                    "event_type": normalized_event.get("event_type"),
+                    "line_display": line_display or normalized_event.get("line_display"),
+                },
+            )
+        finally:
+            conn.close()
+    except Exception as exc:  # noqa: BLE001 - webhook should not fail because approval storage is down.
+        print(f"⚠️  Approval draft persistence failed ({type(exc).__name__})")
+        return False, "approval_persistence_failed", message, None, reply_policy
+
+    return True, "draft_created", message, draft.get("draft_id"), reply_policy
 
 
 def build_hook_session_key(normalized_event):
@@ -1271,12 +1422,13 @@ def build_hook_session_key(normalized_event):
             return f"hook:dialpad:call:{sender_number}"
         return "hook:dialpad:call:unknown"
 
-    candidate = (
-        normalized_event.get("conversation_id")
-        or normalized_event.get("message_id")
-        or normalize_phone_number(normalized_event.get("sender_number"))
-        or "unknown"
-    )
+    sender_number = normalize_phone_number(normalized_event.get("sender_number"))
+    recipient_number = normalize_phone_number(normalized_event.get("recipient_number"))
+    candidate = normalized_event.get("conversation_id")
+    if not candidate and sender_number and recipient_number:
+        candidate = f"{sender_number}:{recipient_number}"
+    if not candidate:
+        candidate = normalized_event.get("message_id") or sender_number or "unknown"
     return f"hook:dialpad:sms:{candidate}"
 
 
@@ -1538,6 +1690,7 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
         hook_status = None
         auto_reply_sent = False
         auto_reply_status = None
+        auto_reply_draft_id = None
         sensitive_filtered = False
         inbound_alert_decision = {
             "eligible": False,
@@ -1584,28 +1737,60 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                     sender_enrichment=sender_enrichment,
                     line_display=line_display,
                 )
-                auto_reply_sent, auto_reply_status, auto_reply_message = send_proactive_reply(
+                auto_reply_draft_created, auto_reply_status, auto_reply_message, auto_reply_draft_id, reply_policy = create_proactive_reply_draft(
                     normalized_sms,
                     sender_enrichment=sender_enrichment,
                     line_display=line_display,
                 )
                 normalized_sms["auto_reply"] = {
                     "eligible": auto_reply_eligible,
-                    "sent": auto_reply_sent,
+                    "sent": False,
+                    "draftCreated": auto_reply_draft_created,
+                    "draftId": auto_reply_draft_id,
                     "status": auto_reply_status,
                     "message": auto_reply_message,
+                    "replyPolicy": reply_policy,
                 }
                 hook_sent, hook_status = send_sms_to_openclaw_hooks(
                     normalized_sms, line_display=line_display
                 )
-                if auto_reply_sent:
-                    print(f"   🤖 Auto Reply: ✓ ({auto_reply_status})")
-                elif auto_reply_status:
-                    print(f"   🤖 Auto Reply: ✗ ({auto_reply_status})")
+                if auto_reply_status:
+                    print(f"   🤖 Auto Reply Draft: {'✓' if auto_reply_draft_created else '✗'} ({auto_reply_status})")
             elif hook_status == "filtered_shortcode":
                 print("   🔒 Short-code message filtered (not forwarding to OpenClaw hooks)")
             elif hook_status == "filtered_sensitive":
                 print("   🔒 Sensitive message filtered (not forwarding to OpenClaw hooks)")
+            elif hook_status == "filtered_opt_out":
+                print("   🛑 Opt-out message filtered (automation send path blocked)")
+                if sms_approval is not None:
+                    try:
+                        conn = sms_approval.init_db()
+                        try:
+                            sms_approval.mark_opt_out(
+                                conn,
+                                customer_number=from_num,
+                                reason="customer_opt_out",
+                                source="sms",
+                            )
+                        finally:
+                            conn.close()
+                    except Exception as exc:  # noqa: BLE001 - webhook must degrade safely.
+                        print(f"⚠️  Failed to persist opt-out ({type(exc).__name__})")
+        elif direction == "outbound" and sms_approval is not None:
+            outbound_customer = first_value(to_num)
+            if outbound_customer:
+                try:
+                    conn = sms_approval.init_db()
+                    try:
+                        sms_approval.invalidate_pending(
+                            conn,
+                            customer_number=outbound_customer,
+                            reason="manual_outbound",
+                        )
+                    finally:
+                        conn.close()
+                except Exception as exc:  # noqa: BLE001 - webhook must degrade safely.
+                    print(f"⚠️  Failed to invalidate approvals after outbound SMS ({type(exc).__name__})")
         # Optional immediate Telegram notification for inbound SMS
         telegram_sms_sent = None
         telegram_status = TELEGRAM_STATUS_NOT_APPLICABLE
@@ -1626,8 +1811,21 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                     f"Time: {escape_telegram_markdown(time_display)}\n\n"
                     f"Message: {escape_telegram_markdown(text)}"
                 )
+                tg_text += build_approval_review_suffix(
+                    auto_reply_draft_id,
+                    auto_reply_message,
+                    reply_policy,
+                )
                 telegram_sms_sent = send_to_telegram(tg_text)
                 telegram_status = TELEGRAM_STATUS_SENT if telegram_sms_sent else TELEGRAM_STATUS_FAILED
+            elif hook_status == "filtered_opt_out":
+                tg_text = (
+                    "🛑 Dialpad SMS opt-out / human-only\n"
+                    f"From: {escape_telegram_markdown(str(from_num))}\n"
+                    "Automation is not allowed to send on this thread."
+                )
+                telegram_sms_sent = send_to_telegram(tg_text)
+                telegram_status = "human_only_notified" if telegram_sms_sent else TELEGRAM_STATUS_FAILED
             elif not DIALPAD_SMS_TELEGRAM_NOTIFY:
                 telegram_status = "disabled"
             else:
@@ -1684,6 +1882,7 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
             "telegram_status": telegram_status if direction == "inbound" else None,
             "auto_reply_sent": auto_reply_sent if direction == "inbound" else None,
             "auto_reply_status": auto_reply_status if direction == "inbound" else None,
+            "auto_reply_draft_id": auto_reply_draft_id if direction == "inbound" else None,
             "sender_enrichment_degraded": (
                 sender_enrichment.get("degraded") if direction == "inbound" else None
             ),
@@ -1740,6 +1939,7 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
         telegram_sent = False
         auto_reply_sent = False
         auto_reply_status = None
+        auto_reply_draft_id = None
         if should_notify:
             resolved = resolve_missed_call_context(data)
             from_num = resolved["from_number"]
@@ -1798,20 +1998,28 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                 sender_enrichment=sender_enrichment,
                 line_display=line_display,
             )
-            auto_reply_sent, auto_reply_status, auto_reply_message = send_proactive_reply(
+            auto_reply_draft_created, auto_reply_status, auto_reply_message, auto_reply_draft_id, reply_policy = create_proactive_reply_draft(
                 normalized_event,
                 sender_enrichment=sender_enrichment,
                 line_display=line_display,
             )
             normalized_event["auto_reply"] = {
                 "eligible": auto_reply_eligible,
-                "sent": auto_reply_sent,
+                "sent": False,
+                "draftCreated": auto_reply_draft_created,
+                "draftId": auto_reply_draft_id,
                 "status": auto_reply_status,
                 "message": auto_reply_message,
+                "replyPolicy": reply_policy,
             }
             hook_sent, hook_status = send_to_openclaw_hooks(
                 normalized_event,
                 line_display=line_display,
+            )
+            tg_text += build_approval_review_suffix(
+                auto_reply_draft_id,
+                auto_reply_message,
+                reply_policy,
             )
             telegram_sent = send_to_telegram(tg_text)
 
@@ -1849,6 +2057,7 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
             "hook_status": hook_status if should_notify else None,
             "auto_reply_sent": auto_reply_sent if should_notify else None,
             "auto_reply_status": auto_reply_status if should_notify else None,
+            "auto_reply_draft_id": auto_reply_draft_id if should_notify else None,
             "telegram_sent": telegram_sent if should_notify else None
         }
         self.wfile.write(json.dumps(response).encode())
@@ -1858,7 +2067,15 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
         # Limit request body size to prevent memory exhaustion (1MB max)
         MAX_BODY_SIZE = 1024 * 1024  # 1MB
         content_length = min(int(self.headers.get("Content-Length", 0)), MAX_BODY_SIZE)
-        body = self.rfile.read(content_length).decode("utf-8")
+        raw_body = self.rfile.read(content_length)
+
+        auth_ok, auth_source = verify_webhook_auth(self.headers, raw_body, WEBHOOK_SECRET)
+        if not auth_ok:
+            log_line("❌ Unauthorized webhook request on /webhook/dialpad-voicemail")
+            self.send_error(401, "Unauthorized")
+            return
+
+        body = raw_body.decode("utf-8")
 
         try:
             data = json.loads(body) if body else {}
@@ -1915,12 +2132,13 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
 
         auto_reply_sent = False
         auto_reply_status = None
-        telegram_sent = send_to_telegram(tg_text)
+        auto_reply_draft_id = None
         normalized_event = {
             "event_type": "voicemail",
             "sender": contact_info or from_num or "Unknown",
             "sender_number": from_num,
             "recipient_number": to_num,
+            "text": transcription or "",
             "timestamp": data.get("timestamp") or data.get("created_date"),
             "line_display": line_display,
             "direction": "inbound",
@@ -1935,20 +2153,31 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
             sender_enrichment=sender_enrichment,
             line_display=line_display,
         )
-        auto_reply_sent, auto_reply_status, auto_reply_message = send_proactive_reply(
+        auto_reply_draft_created, auto_reply_status, auto_reply_message, auto_reply_draft_id, reply_policy = create_proactive_reply_draft(
             normalized_event,
             sender_enrichment=sender_enrichment,
             line_display=line_display,
         )
         normalized_event["auto_reply"] = {
             "eligible": auto_reply_eligible,
-            "sent": auto_reply_sent,
+            "sent": False,
+            "draftCreated": auto_reply_draft_created,
+            "draftId": auto_reply_draft_id,
             "status": auto_reply_status,
             "message": auto_reply_message,
+            "replyPolicy": reply_policy,
         }
+        tg_text += build_approval_review_suffix(
+            auto_reply_draft_id,
+            auto_reply_message,
+            reply_policy,
+        )
+        telegram_sent = send_to_telegram(tg_text)
 
         print(f"[{datetime.now().isoformat()}]")
         print(f"   📬 VOICEMAIL: {from_num} -> {to_display}")
+        if WEBHOOK_SECRET:
+            print(f"   🔐 Auth: ✓ ({auth_source})")
         print(f"   ⏱️  Duration: {duration_display}")
         if transcription:
             trans_preview = transcription[:80] + "..." if len(transcription) > 80 else transcription
@@ -1968,6 +2197,7 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
             "telegram_sent": telegram_sent,
             "auto_reply_sent": auto_reply_sent,
             "auto_reply_status": auto_reply_status,
+            "auto_reply_draft_id": auto_reply_draft_id,
         }
         self.wfile.write(json.dumps(response).encode())
 

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -1321,17 +1321,8 @@ def build_approval_review_suffix(draft_id, draft_message, reply_policy=None):
 
 def create_proactive_reply_draft(normalized_event, sender_enrichment=None, line_display=None):
     """Create an approval-gated proactive reply draft instead of sending SMS."""
-    if not should_send_proactive_reply(
-        normalized_event,
-        sender_enrichment=sender_enrichment,
-        line_display=line_display,
-    ):
-        return False, "not_eligible", None, None, None
-
-    thread_key = build_hook_session_key(normalized_event)
     sender_number = normalized_event.get("recipient_number")
     recipient_number = normalized_event.get("sender_number")
-    message = build_proactive_reply_message(normalized_event, sender_enrichment=sender_enrichment)
     reply_policy = classify_sms_reply_policy(normalized_event.get("text") or "")
     if reply_policy["state"] == "blocked_opt_out":
         if sms_approval is not None and recipient_number:
@@ -1348,7 +1339,17 @@ def create_proactive_reply_draft(normalized_event, sender_enrichment=None, line_
                     conn.close()
             except Exception as exc:  # noqa: BLE001 - webhook must degrade safely.
                 print(f"⚠️  Failed to persist opt-out ({type(exc).__name__})")
-        return False, "blocked_opt_out", message, None, reply_policy
+        return False, "blocked_opt_out", None, None, reply_policy
+
+    if not should_send_proactive_reply(
+        normalized_event,
+        sender_enrichment=sender_enrichment,
+        line_display=line_display,
+    ):
+        return False, "not_eligible", None, None, None
+
+    thread_key = build_hook_session_key(normalized_event)
+    message = build_proactive_reply_message(normalized_event, sender_enrichment=sender_enrichment)
     if sms_approval is None:
         return False, "approval_unavailable", message, None, reply_policy
     if not sender_number or not recipient_number:

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -648,19 +648,20 @@ def assess_inbound_sms_alert_eligibility(
             "sensitive_filtered": True,
             "notification_type": resolved_type,
         }
-    if is_sensitive_message(text=text, sender=sender, contact_number=from_number):
-        return {
-            "eligible": False,
-            "reason_code": "filtered_sensitive",
-            "sensitive_filtered": True,
-            "notification_type": resolved_type,
-        }
     reply_policy = classify_sms_reply_policy(text)
     if reply_policy["state"] == "blocked_opt_out":
         return {
             "eligible": False,
             "reason_code": reply_policy["reason_code"],
             "sensitive_filtered": False,
+            "notification_type": resolved_type,
+            "reply_policy": reply_policy,
+        }
+    if is_sensitive_message(text=text, sender=sender, contact_number=from_number):
+        return {
+            "eligible": False,
+            "reason_code": "filtered_sensitive",
+            "sensitive_filtered": True,
             "notification_type": resolved_type,
             "reply_policy": reply_policy,
         }

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -1336,10 +1336,31 @@ def build_human_only_blocked_suffix(reply_policy=None):
     return "\n".join(lines)
 
 
+def invalidate_pending_sms_drafts(thread_key=None, customer_number=None, reason="new_inbound"):
+    """Stale pending approval drafts when newer inbound context makes them unsafe."""
+    if sms_approval is None or (not thread_key and not customer_number):
+        return False
+
+    try:
+        conn = sms_approval.init_db()
+        try:
+            if thread_key:
+                sms_approval.invalidate_pending(conn, thread_key=thread_key, reason=reason)
+            if customer_number:
+                sms_approval.invalidate_pending(conn, customer_number=customer_number, reason=reason)
+        finally:
+            conn.close()
+        return True
+    except Exception as exc:  # noqa: BLE001 - webhook must degrade safely.
+        print(f"⚠️  Failed to invalidate pending SMS approvals ({type(exc).__name__})")
+        return False
+
+
 def create_proactive_reply_draft(normalized_event, sender_enrichment=None, line_display=None):
     """Create an approval-gated proactive reply draft instead of sending SMS."""
     sender_number = normalized_event.get("recipient_number")
     recipient_number = normalized_event.get("sender_number")
+    thread_key = build_hook_session_key(normalized_event)
     reply_policy = classify_sms_reply_policy(normalized_event.get("text") or "")
     if reply_policy["state"] == "blocked_opt_out":
         if sms_approval is not None and recipient_number:
@@ -1363,9 +1384,13 @@ def create_proactive_reply_draft(normalized_event, sender_enrichment=None, line_
         sender_enrichment=sender_enrichment,
         line_display=line_display,
     ):
+        invalidate_pending_sms_drafts(
+            thread_key=thread_key,
+            customer_number=recipient_number,
+            reason="new_inbound_not_eligible",
+        )
         return False, "not_eligible", None, None, None
 
-    thread_key = build_hook_session_key(normalized_event)
     message = build_proactive_reply_message(normalized_event, sender_enrichment=sender_enrichment)
     if sms_approval is None:
         return False, "approval_unavailable", message, None, reply_policy
@@ -1741,6 +1766,12 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
             )
             hook_status = inbound_alert_decision["reason_code"]
             sensitive_filtered = inbound_alert_decision["sensitive_filtered"]
+
+            if not inbound_alert_decision["eligible"] and hook_status != "filtered_opt_out":
+                invalidate_pending_sms_drafts(
+                    customer_number=from_num,
+                    reason=f"new_inbound_{hook_status}",
+                )
 
             if inbound_alert_decision["eligible"]:
                 line_display = get_line_name(to_num)

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -1356,6 +1356,39 @@ def invalidate_pending_sms_drafts(thread_key=None, customer_number=None, reason=
         return False
 
 
+def mark_opt_out_fail_closed(customer_number, *, reason="customer_opt_out", source=None):
+    """Persist opt-out, falling back to an emergency block before returning success."""
+    if sms_approval is None or not customer_number:
+        return False
+
+    try:
+        conn = sms_approval.init_db()
+        try:
+            sms_approval.mark_opt_out(
+                conn,
+                customer_number=customer_number,
+                reason=reason,
+                source=source,
+            )
+        finally:
+            conn.close()
+        return True
+    except Exception as exc:  # noqa: BLE001 - explicit opt-outs must fail closed.
+        print(f"⚠️  Failed to persist opt-out ({type(exc).__name__})")
+
+    invalidated = invalidate_pending_sms_drafts(customer_number=customer_number, reason=reason)
+    try:
+        sms_approval.record_emergency_opt_out(
+            customer_number=customer_number,
+            reason=reason,
+            source=source,
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 - webhook must degrade safely.
+        print(f"⚠️  Failed to record emergency opt-out ({type(exc).__name__})")
+        return invalidated
+
+
 def create_proactive_reply_draft(normalized_event, sender_enrichment=None, line_display=None):
     """Create an approval-gated proactive reply draft instead of sending SMS."""
     sender_number = normalized_event.get("recipient_number")
@@ -1363,20 +1396,11 @@ def create_proactive_reply_draft(normalized_event, sender_enrichment=None, line_
     thread_key = build_hook_session_key(normalized_event)
     reply_policy = classify_sms_reply_policy(normalized_event.get("text") or "")
     if reply_policy["state"] == "blocked_opt_out":
-        if sms_approval is not None and recipient_number:
-            try:
-                conn = sms_approval.init_db()
-                try:
-                    sms_approval.mark_opt_out(
-                        conn,
-                        customer_number=recipient_number,
-                        reason="customer_opt_out",
-                        source=normalized_event.get("event_type"),
-                    )
-                finally:
-                    conn.close()
-            except Exception as exc:  # noqa: BLE001 - webhook must degrade safely.
-                print(f"⚠️  Failed to persist opt-out ({type(exc).__name__})")
+        mark_opt_out_fail_closed(
+            recipient_number,
+            reason="customer_opt_out",
+            source=normalized_event.get("event_type"),
+        )
         return False, "blocked_opt_out", None, None, reply_policy
 
     if not should_send_proactive_reply(
@@ -1811,20 +1835,7 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                 print("   🔒 Sensitive message filtered (not forwarding to OpenClaw hooks)")
             elif hook_status == "filtered_opt_out":
                 print("   🛑 Opt-out message filtered (automation send path blocked)")
-                if sms_approval is not None:
-                    try:
-                        conn = sms_approval.init_db()
-                        try:
-                            sms_approval.mark_opt_out(
-                                conn,
-                                customer_number=from_num,
-                                reason="customer_opt_out",
-                                source="sms",
-                            )
-                        finally:
-                            conn.close()
-                    except Exception as exc:  # noqa: BLE001 - webhook must degrade safely.
-                        print(f"⚠️  Failed to persist opt-out ({type(exc).__name__})")
+                mark_opt_out_fail_closed(from_num, reason="customer_opt_out", source="sms")
         elif direction == "outbound" and sms_approval is not None:
             outbound_customers = to_num if isinstance(to_num, list) else [to_num]
             outbound_customers = [customer for customer in outbound_customers if customer]

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -1319,6 +1319,23 @@ def build_approval_review_suffix(draft_id, draft_message, reply_policy=None):
     return "\n".join(lines)
 
 
+def build_human_only_blocked_suffix(reply_policy=None):
+    """Build Telegram text when policy blocks SMS automation outright."""
+    reply_policy = reply_policy or {}
+    if reply_policy.get("state") != "blocked_opt_out":
+        return ""
+
+    reason = reply_policy.get("risk_reason") or "automation is blocked for this thread"
+    lines = [
+        "",
+        "",
+        f"🛑 *{escape_telegram_markdown('Automation blocked / human-only')}*",
+        escape_telegram_markdown("No SMS approval draft was created."),
+        f"*Reason:* {escape_telegram_markdown(reason)}",
+    ]
+    return "\n".join(lines)
+
+
 def create_proactive_reply_draft(normalized_event, sender_enrichment=None, line_display=None):
     """Create an approval-gated proactive reply draft instead of sending SMS."""
     sender_number = normalized_event.get("recipient_number")
@@ -2032,6 +2049,7 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                 auto_reply_message,
                 reply_policy,
             )
+            tg_text += build_human_only_blocked_suffix(reply_policy)
             telegram_sent = send_to_telegram(tg_text)
 
             print(f"[{datetime.now().isoformat()}]")
@@ -2183,6 +2201,7 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
             auto_reply_message,
             reply_policy,
         )
+        tg_text += build_human_only_blocked_suffix(reply_policy)
         telegram_sent = send_to_telegram(tg_text)
 
         print(f"[{datetime.now().isoformat()}]")

--- a/tests/test_openclaw_integration_docs.py
+++ b/tests/test_openclaw_integration_docs.py
@@ -25,3 +25,20 @@ def test_openclaw_docs_require_current_turn_verification():
     assert "ambiguous" in integration
     assert "first name" in integration
     assert "area code" in integration
+
+
+def test_openclaw_docs_require_sms_approval_drafts_not_autonomous_send():
+    readme = (ROOT / "README.md").read_text().lower()
+    skill = (ROOT / "SKILL.md").read_text().lower()
+    api_reference = (ROOT / "references/api-reference.md").read_text().lower()
+    integration = (ROOT / "references/openclaw-integration.md").read_text().lower()
+
+    assert "approval draft" in readme
+    assert "approval drafts" in api_reference
+    assert "approval drafts" in integration
+    assert "inbound hooks may create sms approval drafts" in skill
+    assert "must not send customer sms directly" in skill
+    assert "intentionally unsupported" in integration
+    assert "explicit opt-out language creates no draft" in readme
+    assert "explicit opt-out language creates no draft" in api_reference
+    assert "autonomous sms send is not supported" in integration

--- a/tests/test_sender_enrichment.py
+++ b/tests/test_sender_enrichment.py
@@ -466,6 +466,54 @@ def test_standard_stop_keyword_blocks_sms_automation(monkeypatch, tmp_path):
     assert response["hook_status"] == "filtered_opt_out"
 
 
+def test_stop_by_phrase_does_not_create_permanent_opt_out(monkeypatch, tmp_path):
+    hook_calls = []
+    monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
+    monkeypatch.setattr(webhook_server.sms_approval, "DB_PATH", tmp_path / "approvals.db")
+    monkeypatch.setattr(
+        webhook_server,
+        "handle_sms_webhook",
+        lambda _data: {"stored": True, "message": {"contact_name": "Unknown"}},
+    )
+    monkeypatch.setattr(
+        webhook_server,
+        "lookup_contact_enrichment",
+        lambda _number: {
+            "contact_name": None,
+            "status": "not_found",
+            "degraded": False,
+            "degraded_reason": None,
+        },
+    )
+    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", False)
+    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda _text: True)
+    monkeypatch.setattr(
+        webhook_server,
+        "send_sms_to_openclaw_hooks",
+        lambda normalized_sms, line_display=None: hook_calls.append(normalized_sms) or (True, "http_200"),
+    )
+
+    payload = {
+        "direction": "inbound",
+        "from_number": "+14155550123",
+        "to_number": ["+14155201316"],
+        "text": "Can we stop by later?",
+    }
+    handler, status = _build_handler(payload)
+    webhook_server.DialpadWebhookHandler.handle_webhook(handler)
+
+    conn = webhook_server.sms_approval.init_db()
+    try:
+        opted_out = webhook_server.sms_approval.is_opted_out(conn, "+14155550123")
+    finally:
+        conn.close()
+    response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    assert status["code"] == 200
+    assert response["hook_status"] == "http_200"
+    assert hook_calls
+    assert opted_out is False
+
+
 def test_second_inbound_without_conversation_id_invalidates_previous_draft(monkeypatch, tmp_path):
     monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
     monkeypatch.setattr(webhook_server, "DIALPAD_AUTO_REPLY_ENABLED", True)
@@ -545,13 +593,20 @@ def test_outbound_sms_invalidates_pending_approval_draft(monkeypatch, tmp_path):
             sender_number="+14155201316",
             draft_text="Pending draft.",
         )
+        second_draft = webhook_server.sms_approval.create_draft(
+            conn,
+            thread_key="thread-2",
+            customer_number="+14155550124",
+            sender_number="+14155201316",
+            draft_text="Second pending draft.",
+        )
     finally:
         conn.close()
 
     payload = {
         "direction": "outbound",
         "from_number": "+14155201316",
-        "to_number": ["+14155550123"],
+        "to_number": ["+14155550123", "+14155550124"],
         "text": "Human replied.",
     }
     handler, status = _build_handler(payload)
@@ -560,6 +615,7 @@ def test_outbound_sms_invalidates_pending_approval_draft(monkeypatch, tmp_path):
     conn = webhook_server.sms_approval.init_db()
     try:
         stale = webhook_server.sms_approval.get_draft(conn, draft["draft_id"])
+        second_stale = webhook_server.sms_approval.get_draft(conn, second_draft["draft_id"])
     finally:
         conn.close()
     response = json.loads(handler.wfile.getvalue().decode("utf-8"))
@@ -567,6 +623,8 @@ def test_outbound_sms_invalidates_pending_approval_draft(monkeypatch, tmp_path):
     assert response["hook_forwarded"] is None
     assert stale["status"] == webhook_server.sms_approval.STATUS_STALE
     assert stale["invalidated_reason"] == "manual_outbound"
+    assert second_stale["status"] == webhook_server.sms_approval.STATUS_STALE
+    assert second_stale["invalidated_reason"] == "manual_outbound"
 
 
 def test_risky_inbound_sales_sms_creates_two_step_approval_draft(monkeypatch, tmp_path):

--- a/tests/test_sender_enrichment.py
+++ b/tests/test_sender_enrichment.py
@@ -466,6 +466,48 @@ def test_standard_stop_keyword_blocks_sms_automation(monkeypatch, tmp_path):
     assert response["hook_status"] == "filtered_opt_out"
 
 
+def test_opt_out_with_security_code_persists_opt_out_before_sensitive_filter(monkeypatch, tmp_path):
+    monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
+    monkeypatch.setattr(webhook_server.sms_approval, "DB_PATH", tmp_path / "approvals.db")
+    monkeypatch.setattr(
+        webhook_server,
+        "handle_sms_webhook",
+        lambda _data: {"stored": True, "message": {"contact_name": "Unknown"}},
+    )
+    monkeypatch.setattr(
+        webhook_server,
+        "lookup_contact_enrichment",
+        lambda _number: {
+            "contact_name": None,
+            "status": "not_found",
+            "degraded": False,
+            "degraded_reason": None,
+        },
+    )
+    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", False)
+    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda _text: True)
+    monkeypatch.setattr(webhook_server, "send_sms_to_openclaw_hooks", lambda *_args, **_kwargs: (True, "http_200"))
+
+    payload = {
+        "direction": "inbound",
+        "from_number": "+14155550123",
+        "to_number": ["+14155201316"],
+        "text": "Your security code is 123456. Do not contact me.",
+    }
+    handler, status = _build_handler(payload)
+    webhook_server.DialpadWebhookHandler.handle_webhook(handler)
+
+    conn = webhook_server.sms_approval.init_db()
+    try:
+        opted_out = webhook_server.sms_approval.is_opted_out(conn, "+14155550123")
+    finally:
+        conn.close()
+    response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    assert status["code"] == 200
+    assert response["hook_status"] == "filtered_opt_out"
+    assert opted_out is True
+
+
 def test_stop_by_phrase_does_not_create_permanent_opt_out(monkeypatch, tmp_path):
     hook_calls = []
     monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")

--- a/tests/test_sender_enrichment.py
+++ b/tests/test_sender_enrichment.py
@@ -13,6 +13,13 @@ sys.path.insert(0, str(ROOT))
 import webhook_server
 
 
+@pytest.fixture(autouse=True)
+def _clear_emergency_opt_out_memory():
+    webhook_server.sms_approval._EMERGENCY_OPT_OUT_MEMORY.clear()
+    yield
+    webhook_server.sms_approval._EMERGENCY_OPT_OUT_MEMORY.clear()
+
+
 class _FakeResponse:
     def __init__(self, payload):
         self._payload = payload

--- a/tests/test_sender_enrichment.py
+++ b/tests/test_sender_enrichment.py
@@ -492,6 +492,80 @@ def test_inbound_opt_out_blocks_hooks_sends_and_invalidates_pending_drafts(monke
     assert opted_out is True
 
 
+def test_opt_out_persistence_failure_records_emergency_block(monkeypatch, tmp_path):
+    approval_db = tmp_path / "approvals.db"
+    emergency_path = tmp_path / "emergency-opt-outs.jsonl"
+    monkeypatch.setenv("DIALPAD_SMS_APPROVAL_EMERGENCY_PATH", str(emergency_path))
+    monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
+    monkeypatch.setattr(webhook_server.sms_approval, "DB_PATH", approval_db)
+    monkeypatch.setattr(
+        webhook_server,
+        "handle_sms_webhook",
+        lambda _data: {"stored": True, "message": {"contact_name": "Unknown"}},
+    )
+    monkeypatch.setattr(
+        webhook_server,
+        "lookup_contact_enrichment",
+        lambda _number: {
+            "contact_name": None,
+            "first_name": None,
+            "last_name": None,
+            "company": None,
+            "job_title": None,
+            "status": "not_found",
+            "degraded": False,
+            "degraded_reason": None,
+        },
+    )
+    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", False)
+    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda _text: True)
+
+    conn = webhook_server.sms_approval.init_db()
+    try:
+        pending = webhook_server.sms_approval.create_draft(
+            conn,
+            thread_key="prior-thread",
+            customer_number="+14155550123",
+            sender_number="+14155201316",
+            draft_text="Prior draft must not remain approvable.",
+        )
+    finally:
+        conn.close()
+
+    def _fail_mark_opt_out(*_args, **_kwargs):
+        raise OSError("simulated read-only approval db")
+
+    monkeypatch.setattr(webhook_server.sms_approval, "mark_opt_out", _fail_mark_opt_out)
+
+    payload = {
+        "direction": "inbound",
+        "from_number": "+14155550123",
+        "to_number": ["+14155201316"],
+        "text": "Please stop texting me.",
+    }
+    handler, status = _build_handler(payload)
+    webhook_server.DialpadWebhookHandler.handle_webhook(handler)
+
+    response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    assert status["code"] == 200
+    assert response["hook_status"] == "filtered_opt_out"
+    assert emergency_path.exists()
+
+    conn = webhook_server.sms_approval.init_db()
+    try:
+        stale_draft = webhook_server.sms_approval.get_draft(conn, pending["draft_id"])
+        result = webhook_server.sms_approval.approve_draft(
+            conn,
+            draft_id=pending["draft_id"],
+            actor_id="12345",
+            send_func=lambda *_args, **_kwargs: pytest.fail("send should not run"),
+        )
+    finally:
+        conn.close()
+    assert stale_draft["status"] == webhook_server.sms_approval.STATUS_STALE
+    assert result["sent"] is False
+
+
 def test_standard_stop_keyword_blocks_sms_automation(monkeypatch, tmp_path):
     monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
     monkeypatch.setattr(webhook_server.sms_approval, "DB_PATH", tmp_path / "approvals.db")

--- a/tests/test_sender_enrichment.py
+++ b/tests/test_sender_enrichment.py
@@ -573,6 +573,78 @@ def test_opt_out_persistence_failure_records_emergency_block(monkeypatch, tmp_pa
     assert result["sent"] is False
 
 
+def test_opt_out_persistence_total_failure_reports_failure_status(monkeypatch, tmp_path):
+    approval_db = tmp_path / "approvals.db"
+    emergency_path = tmp_path / "emergency-opt-outs-dir"
+    emergency_path.mkdir()
+    monkeypatch.setenv("DIALPAD_SMS_APPROVAL_EMERGENCY_PATH", str(emergency_path))
+    monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
+    monkeypatch.setattr(webhook_server.sms_approval, "DB_PATH", approval_db)
+    monkeypatch.setattr(
+        webhook_server,
+        "handle_sms_webhook",
+        lambda _data: {"stored": True, "message": {"contact_name": "Unknown"}},
+    )
+    monkeypatch.setattr(
+        webhook_server,
+        "lookup_contact_enrichment",
+        lambda _number: {
+            "contact_name": None,
+            "first_name": None,
+            "last_name": None,
+            "company": None,
+            "job_title": None,
+            "status": "not_found",
+            "degraded": False,
+            "degraded_reason": None,
+        },
+    )
+    telegram_messages = []
+    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", True)
+    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda text: telegram_messages.append(text) or True)
+
+    conn = webhook_server.sms_approval.init_db()
+    try:
+        pending = webhook_server.sms_approval.create_draft(
+            conn,
+            thread_key="prior-thread",
+            customer_number="+14155550123",
+            sender_number="+14155201316",
+            draft_text="Prior draft must not remain approvable.",
+        )
+    finally:
+        conn.close()
+
+    def _fail_mark_opt_out(*_args, **_kwargs):
+        raise OSError("simulated read-only approval db")
+
+    monkeypatch.setattr(webhook_server.sms_approval, "mark_opt_out", _fail_mark_opt_out)
+
+    payload = {
+        "direction": "inbound",
+        "from_number": "+14155550123",
+        "to_number": ["+14155201316"],
+        "text": "Please stop texting me.",
+    }
+    handler, status = _build_handler(payload)
+    webhook_server.DialpadWebhookHandler.handle_webhook(handler)
+
+    response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    assert status["code"] == 200
+    assert response["hook_status"] == "opt_out_persistence_failed"
+    assert response["telegram_status"] == "opt_out_persistence_failed"
+    assert "persistence failed" in telegram_messages[0]
+
+    conn = webhook_server.sms_approval.init_db()
+    try:
+        stale_draft = webhook_server.sms_approval.get_draft(conn, pending["draft_id"])
+        opted_out = webhook_server.sms_approval.is_opted_out(conn, "+14155550123")
+    finally:
+        conn.close()
+    assert stale_draft["status"] == webhook_server.sms_approval.STATUS_STALE
+    assert opted_out is True
+
+
 def test_standard_stop_keyword_blocks_sms_automation(monkeypatch, tmp_path):
     monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
     monkeypatch.setattr(webhook_server.sms_approval, "DB_PATH", tmp_path / "approvals.db")

--- a/tests/test_sender_enrichment.py
+++ b/tests/test_sender_enrichment.py
@@ -282,6 +282,68 @@ def test_inbound_webhook_hook_marks_unknown_sender_first_contact_candidate(monke
     assert hook_calls[0]["normalized_sms"]["first_contact"]["identityState"] == "not_found"
 
 
+def test_not_eligible_inbound_stales_pending_draft(monkeypatch, tmp_path):
+    monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
+    monkeypatch.setattr(webhook_server, "DIALPAD_AUTO_REPLY_ENABLED", True)
+    monkeypatch.setattr(webhook_server, "DIALPAD_AUTO_REPLY_SALES_LINE", "4155201316")
+    monkeypatch.setattr(webhook_server.sms_approval, "DB_PATH", tmp_path / "approvals.db")
+    monkeypatch.setattr(
+        webhook_server,
+        "handle_sms_webhook",
+        lambda _data: {"stored": True, "message": {"contact_name": "Jane Doe"}},
+    )
+    monkeypatch.setattr(
+        webhook_server,
+        "lookup_contact_enrichment",
+        lambda _number: {
+            "contact_name": "Jane Doe",
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "company": "Example Co",
+            "job_title": "Owner",
+            "status": "resolved",
+            "degraded": False,
+            "degraded_reason": None,
+        },
+    )
+    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", False)
+    monkeypatch.setattr(webhook_server, "send_sms_to_openclaw_hooks", lambda *_args, **_kwargs: (True, "http_200"))
+
+    conn = webhook_server.sms_approval.init_db()
+    try:
+        pending = webhook_server.sms_approval.create_draft(
+            conn,
+            thread_key="hook:dialpad:sms:14155550123:14155201316",
+            customer_number="+14155550123",
+            sender_number="+14155201316",
+            draft_text="Old draft must stale when contact is now known.",
+        )
+    finally:
+        conn.close()
+
+    payload = {
+        "direction": "inbound",
+        "from_number": "+14155550123",
+        "to_number": ["+14155201316"],
+        "text": "I already spoke with someone.",
+    }
+    handler, status = _build_handler(payload)
+    webhook_server.DialpadWebhookHandler.handle_webhook(handler)
+
+    response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    assert status["code"] == 200
+    assert response["auto_reply_status"] == "not_eligible"
+    assert response["auto_reply_draft_id"] is None
+
+    conn = webhook_server.sms_approval.init_db()
+    try:
+        stale_draft = webhook_server.sms_approval.get_draft(conn, pending["draft_id"])
+    finally:
+        conn.close()
+    assert stale_draft["status"] == webhook_server.sms_approval.STATUS_STALE
+    assert stale_draft["invalidated_reason"] == "new_inbound_not_eligible"
+
+
 def test_inbound_sales_sms_creates_approval_draft_on_first_contact(monkeypatch, tmp_path):
     monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
     monkeypatch.setattr(webhook_server, "DIALPAD_AUTO_REPLY_ENABLED", True)
@@ -861,8 +923,9 @@ def test_inbound_telegram_escapes_markdown_content(monkeypatch):
     assert "Need \\_bold\\_ \\*now\\* \\[check] \\`code\\`" in telegram_messages[0]
 
 
-def test_inbound_sensitive_sms_filtered_for_hook_and_telegram(monkeypatch):
+def test_inbound_sensitive_sms_filtered_for_hook_and_telegram(monkeypatch, tmp_path):
     monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
+    monkeypatch.setattr(webhook_server.sms_approval, "DB_PATH", tmp_path / "approvals.db")
     monkeypatch.setattr(
         webhook_server,
         "handle_sms_webhook",
@@ -894,6 +957,18 @@ def test_inbound_sensitive_sms_filtered_for_hook_and_telegram(monkeypatch):
         lambda text: telegram_messages.append(text) or True,
     )
 
+    conn = webhook_server.sms_approval.init_db()
+    try:
+        pending = webhook_server.sms_approval.create_draft(
+            conn,
+            thread_key="prior-thread",
+            customer_number="+14155550123",
+            sender_number="+14155201316",
+            draft_text="Old draft must stale when sensitive inbound arrives.",
+        )
+    finally:
+        conn.close()
+
     payload = {
         "direction": "inbound",
         "from_number": "+14155550123",
@@ -911,6 +986,14 @@ def test_inbound_sensitive_sms_filtered_for_hook_and_telegram(monkeypatch):
     assert response["inbound_alert_eligible"] is False
     assert response["inbound_alert_reason"] == "filtered_sensitive"
     assert response["telegram_status"] == "filtered_sensitive"
+
+    conn = webhook_server.sms_approval.init_db()
+    try:
+        stale_draft = webhook_server.sms_approval.get_draft(conn, pending["draft_id"])
+    finally:
+        conn.close()
+    assert stale_draft["status"] == webhook_server.sms_approval.STATUS_STALE
+    assert stale_draft["invalidated_reason"] == "new_inbound_filtered_sensitive"
 
 
 def test_inbound_shortcode_sms_filtered_for_hook_and_telegram(monkeypatch):

--- a/tests/test_sender_enrichment.py
+++ b/tests/test_sender_enrichment.py
@@ -354,6 +354,7 @@ def test_inbound_sales_sms_creates_approval_draft_on_first_contact(monkeypatch, 
     assert "not sent" in telegram_messages[0]
     assert response["auto_reply_draft_id"] in telegram_messages[0].replace("\\_", "_")
     assert "bin/approve_sms_draft.py" in telegram_messages[0]
+    assert "--approval-token" in telegram_messages[0]
 
 
 def test_inbound_opt_out_blocks_hooks_sends_and_invalidates_pending_drafts(monkeypatch, tmp_path):
@@ -623,6 +624,7 @@ def test_risky_inbound_sales_sms_creates_two_step_approval_draft(monkeypatch, tm
     assert hook_calls[0]["auto_reply"]["replyPolicy"]["state"] == "risky"
     assert "Second confirmation required" in telegram_messages[0]
     assert "Risk:" in telegram_messages[0]
+    assert "--approval-token" in telegram_messages[0]
 
     conn = webhook_server.sms_approval.init_db()
     try:
@@ -631,6 +633,60 @@ def test_risky_inbound_sales_sms_creates_two_step_approval_draft(monkeypatch, tm
         conn.close()
     assert draft["risk_state"] == webhook_server.sms_approval.RISK_RISKY
     assert draft["status"] == webhook_server.sms_approval.STATUS_PENDING
+
+
+def test_previously_opted_out_customer_gets_blocked_status_not_persistence_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
+    monkeypatch.setattr(webhook_server, "DIALPAD_AUTO_REPLY_ENABLED", True)
+    monkeypatch.setattr(webhook_server, "DIALPAD_AUTO_REPLY_SALES_LINE", "4155201316")
+    monkeypatch.setattr(webhook_server.sms_approval, "DB_PATH", tmp_path / "approvals.db")
+    monkeypatch.setattr(
+        webhook_server,
+        "handle_sms_webhook",
+        lambda _data: {"stored": True, "message": {"contact_name": "Unknown"}},
+    )
+    monkeypatch.setattr(
+        webhook_server,
+        "lookup_contact_enrichment",
+        lambda _number: {
+            "contact_name": None,
+            "first_name": None,
+            "last_name": None,
+            "company": None,
+            "job_title": None,
+            "status": "not_found",
+            "degraded": False,
+            "degraded_reason": None,
+        },
+    )
+    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", False)
+    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda _text: True)
+    monkeypatch.setattr(webhook_server, "send_sms_to_openclaw_hooks", lambda *_args, **_kwargs: (True, "http_200"))
+
+    conn = webhook_server.sms_approval.init_db()
+    try:
+        webhook_server.sms_approval.mark_opt_out(
+            conn,
+            customer_number="+14155550123",
+            reason="customer_opt_out",
+            source="test",
+        )
+    finally:
+        conn.close()
+
+    payload = {
+        "direction": "inbound",
+        "from_number": "+14155550123",
+        "to_number": ["+14155201316"],
+        "text": "Can you answer one more question?",
+    }
+    handler, status = _build_handler(payload)
+    webhook_server.DialpadWebhookHandler.handle_webhook(handler)
+
+    response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    assert status["code"] == 200
+    assert response["auto_reply_status"] == "blocked_opt_out"
+    assert response["auto_reply_draft_id"] is None
 
 
 

--- a/tests/test_sender_enrichment.py
+++ b/tests/test_sender_enrichment.py
@@ -204,8 +204,9 @@ def test_inbound_webhook_hook_uses_enriched_sender(monkeypatch):
             "degraded_reason": None,
         },
     )
-    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", False)
-    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda _text: True)
+    telegram_messages = []
+    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", True)
+    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda text: telegram_messages.append(text) or True)
 
     hook_calls = []
 
@@ -252,8 +253,9 @@ def test_inbound_webhook_hook_marks_unknown_sender_first_contact_candidate(monke
             "degraded_reason": None,
         },
     )
-    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", False)
-    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda _text: True)
+    telegram_messages = []
+    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", True)
+    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda text: telegram_messages.append(text) or True)
 
     hook_calls = []
 
@@ -280,10 +282,11 @@ def test_inbound_webhook_hook_marks_unknown_sender_first_contact_candidate(monke
     assert hook_calls[0]["normalized_sms"]["first_contact"]["identityState"] == "not_found"
 
 
-def test_inbound_sales_sms_auto_replies_on_first_contact(monkeypatch):
+def test_inbound_sales_sms_creates_approval_draft_on_first_contact(monkeypatch, tmp_path):
     monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
     monkeypatch.setattr(webhook_server, "DIALPAD_AUTO_REPLY_ENABLED", True)
     monkeypatch.setattr(webhook_server, "DIALPAD_AUTO_REPLY_SALES_LINE", "4155201316")
+    monkeypatch.setattr(webhook_server.sms_approval, "DB_PATH", tmp_path / "approvals.db")
     monkeypatch.setattr(
         webhook_server,
         "handle_sms_webhook",
@@ -303,8 +306,9 @@ def test_inbound_sales_sms_auto_replies_on_first_contact(monkeypatch):
             "degraded_reason": None,
         },
     )
-    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", False)
-    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda _text: True)
+    telegram_messages = []
+    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", True)
+    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda text: telegram_messages.append(text) or True)
 
     hook_calls = []
     sms_calls = []
@@ -338,13 +342,296 @@ def test_inbound_sales_sms_auto_replies_on_first_contact(monkeypatch):
 
     response = json.loads(handler.wfile.getvalue().decode("utf-8"))
     assert status["code"] == 200
-    assert len(sms_calls) == 1
-    assert sms_calls[0]["to_numbers"] == ["+14155550123"]
-    assert sms_calls[0]["from_number"] == "+14155201316"
-    assert "ShapeScale for Business Sales" in sms_calls[0]["message"]
+    assert sms_calls == []
     assert hook_calls[0]["normalized_sms"]["first_contact"]["identityState"] == "not_found"
-    assert response["auto_reply_sent"] is True
-    assert response["auto_reply_status"] == "accepted/queued"
+    assert hook_calls[0]["normalized_sms"]["auto_reply"]["sent"] is False
+    assert hook_calls[0]["normalized_sms"]["auto_reply"]["draftCreated"] is True
+    assert hook_calls[0]["normalized_sms"]["auto_reply"]["draftId"]
+    assert response["auto_reply_sent"] is False
+    assert response["auto_reply_status"] == "draft_created"
+    assert response["auto_reply_draft_id"]
+    assert "SMS approval draft" in telegram_messages[0]
+    assert "not sent" in telegram_messages[0]
+    assert response["auto_reply_draft_id"] in telegram_messages[0].replace("\\_", "_")
+    assert "bin/approve_sms_draft.py" in telegram_messages[0]
+
+
+def test_inbound_opt_out_blocks_hooks_sends_and_invalidates_pending_drafts(monkeypatch, tmp_path):
+    approval_db = tmp_path / "approvals.db"
+    monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
+    monkeypatch.setattr(webhook_server.sms_approval, "DB_PATH", approval_db)
+    monkeypatch.setattr(
+        webhook_server,
+        "handle_sms_webhook",
+        lambda _data: {"stored": True, "message": {"contact_name": "Unknown"}},
+    )
+    monkeypatch.setattr(
+        webhook_server,
+        "lookup_contact_enrichment",
+        lambda _number: {
+            "contact_name": None,
+            "first_name": None,
+            "last_name": None,
+            "company": None,
+            "job_title": None,
+            "status": "not_found",
+            "degraded": False,
+            "degraded_reason": None,
+        },
+    )
+
+    telegram_messages = []
+    hook_calls = []
+    sms_calls = []
+    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", False)
+    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda text: telegram_messages.append(text) or True)
+    monkeypatch.setattr(webhook_server, "send_sms_to_openclaw_hooks", lambda *args, **kwargs: hook_calls.append(args) or (True, "http_200"))
+    monkeypatch.setattr(webhook_server, "dialpad_send_sms", lambda *args, **kwargs: sms_calls.append(args) or {"id": "msg-1"})
+
+    conn = webhook_server.sms_approval.init_db()
+    try:
+        pending = webhook_server.sms_approval.create_draft(
+            conn,
+            thread_key="prior-thread",
+            customer_number="+14155550123",
+            sender_number="+14155201316",
+            draft_text="Prior draft must not remain approvable.",
+        )
+    finally:
+        conn.close()
+
+    payload = {
+        "direction": "inbound",
+        "from_number": "+14155550123",
+        "to_number": ["+14155201316"],
+        "text": "I need a real person. Please don't bother me anymore.",
+    }
+    handler, status = _build_handler(payload)
+    webhook_server.DialpadWebhookHandler.handle_webhook(handler)
+
+    response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    assert status["code"] == 200
+    assert hook_calls == []
+    assert sms_calls == []
+    assert response["hook_status"] == "filtered_opt_out"
+    assert response["telegram_status"] == "human_only_notified"
+    assert response["auto_reply_draft_id"] is None
+    assert "human-only" in telegram_messages[0]
+
+    conn = webhook_server.sms_approval.init_db()
+    try:
+        stale_draft = webhook_server.sms_approval.get_draft(conn, pending["draft_id"])
+        opted_out = webhook_server.sms_approval.is_opted_out(conn, "+14155550123")
+    finally:
+        conn.close()
+    assert stale_draft["status"] == webhook_server.sms_approval.STATUS_STALE
+    assert stale_draft["invalidated_reason"] == "customer_opt_out"
+    assert opted_out is True
+
+
+def test_standard_stop_keyword_blocks_sms_automation(monkeypatch, tmp_path):
+    monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
+    monkeypatch.setattr(webhook_server.sms_approval, "DB_PATH", tmp_path / "approvals.db")
+    monkeypatch.setattr(
+        webhook_server,
+        "handle_sms_webhook",
+        lambda _data: {"stored": True, "message": {"contact_name": "Unknown"}},
+    )
+    monkeypatch.setattr(
+        webhook_server,
+        "lookup_contact_enrichment",
+        lambda _number: {
+            "contact_name": None,
+            "status": "not_found",
+            "degraded": False,
+            "degraded_reason": None,
+        },
+    )
+    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", False)
+    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda _text: True)
+    monkeypatch.setattr(webhook_server, "send_sms_to_openclaw_hooks", lambda *_args, **_kwargs: (True, "http_200"))
+
+    payload = {
+        "direction": "inbound",
+        "from_number": "+14155550123",
+        "to_number": ["+14155201316"],
+        "text": "STOPALL",
+    }
+    handler, status = _build_handler(payload)
+    webhook_server.DialpadWebhookHandler.handle_webhook(handler)
+
+    response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    assert status["code"] == 200
+    assert response["hook_status"] == "filtered_opt_out"
+
+
+def test_second_inbound_without_conversation_id_invalidates_previous_draft(monkeypatch, tmp_path):
+    monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
+    monkeypatch.setattr(webhook_server, "DIALPAD_AUTO_REPLY_ENABLED", True)
+    monkeypatch.setattr(webhook_server, "DIALPAD_AUTO_REPLY_SALES_LINE", "4155201316")
+    monkeypatch.setattr(webhook_server.sms_approval, "DB_PATH", tmp_path / "approvals.db")
+    monkeypatch.setattr(
+        webhook_server,
+        "handle_sms_webhook",
+        lambda _data: {"stored": True, "message": {"contact_name": "Unknown"}},
+    )
+    monkeypatch.setattr(
+        webhook_server,
+        "lookup_contact_enrichment",
+        lambda _number: {
+            "contact_name": None,
+            "first_name": None,
+            "last_name": None,
+            "company": None,
+            "job_title": None,
+            "status": "not_found",
+            "degraded": False,
+            "degraded_reason": None,
+        },
+    )
+    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", False)
+    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda _text: True)
+    monkeypatch.setattr(webhook_server, "send_sms_to_openclaw_hooks", lambda *_args, **_kwargs: (True, "http_200"))
+
+    first = {
+        "direction": "inbound",
+        "from_number": "+14155550123",
+        "to_number": ["+14155201316"],
+        "message_id": "msg-1",
+        "text": "First question.",
+    }
+    first_handler, _first_status = _build_handler(first)
+    webhook_server.DialpadWebhookHandler.handle_webhook(first_handler)
+    first_response = json.loads(first_handler.wfile.getvalue().decode("utf-8"))
+
+    second = {
+        "direction": "inbound",
+        "from_number": "+14155550123",
+        "to_number": ["+14155201316"],
+        "message_id": "msg-2",
+        "text": "Second question.",
+    }
+    second_handler, status = _build_handler(second)
+    webhook_server.DialpadWebhookHandler.handle_webhook(second_handler)
+
+    conn = webhook_server.sms_approval.init_db()
+    try:
+        stale = webhook_server.sms_approval.get_draft(conn, first_response["auto_reply_draft_id"])
+    finally:
+        conn.close()
+    assert status["code"] == 200
+    assert stale["status"] == webhook_server.sms_approval.STATUS_STALE
+    assert stale["invalidated_reason"] == "superseded_by_new_draft"
+
+
+def test_outbound_sms_invalidates_pending_approval_draft(monkeypatch, tmp_path):
+    approval_db = tmp_path / "approvals.db"
+    monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
+    monkeypatch.setattr(webhook_server.sms_approval, "DB_PATH", approval_db)
+    monkeypatch.setattr(
+        webhook_server,
+        "handle_sms_webhook",
+        lambda _data: {"stored": True, "message": {"contact_name": "Unknown"}},
+    )
+    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda _text: True)
+
+    conn = webhook_server.sms_approval.init_db()
+    try:
+        draft = webhook_server.sms_approval.create_draft(
+            conn,
+            thread_key="thread-1",
+            customer_number="+14155550123",
+            sender_number="+14155201316",
+            draft_text="Pending draft.",
+        )
+    finally:
+        conn.close()
+
+    payload = {
+        "direction": "outbound",
+        "from_number": "+14155201316",
+        "to_number": ["+14155550123"],
+        "text": "Human replied.",
+    }
+    handler, status = _build_handler(payload)
+    webhook_server.DialpadWebhookHandler.handle_webhook(handler)
+
+    conn = webhook_server.sms_approval.init_db()
+    try:
+        stale = webhook_server.sms_approval.get_draft(conn, draft["draft_id"])
+    finally:
+        conn.close()
+    response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    assert status["code"] == 200
+    assert response["hook_forwarded"] is None
+    assert stale["status"] == webhook_server.sms_approval.STATUS_STALE
+    assert stale["invalidated_reason"] == "manual_outbound"
+
+
+def test_risky_inbound_sales_sms_creates_two_step_approval_draft(monkeypatch, tmp_path):
+    approval_db = tmp_path / "approvals.db"
+    monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
+    monkeypatch.setattr(webhook_server, "DIALPAD_AUTO_REPLY_ENABLED", True)
+    monkeypatch.setattr(webhook_server, "DIALPAD_AUTO_REPLY_SALES_LINE", "4155201316")
+    monkeypatch.setattr(webhook_server.sms_approval, "DB_PATH", approval_db)
+    monkeypatch.setattr(
+        webhook_server,
+        "handle_sms_webhook",
+        lambda _data: {"stored": True, "message": {"contact_name": "Unknown"}},
+    )
+    monkeypatch.setattr(
+        webhook_server,
+        "lookup_contact_enrichment",
+        lambda _number: {
+            "contact_name": None,
+            "first_name": None,
+            "last_name": None,
+            "company": None,
+            "job_title": None,
+            "status": "not_found",
+            "degraded": False,
+            "degraded_reason": None,
+        },
+    )
+
+    hook_calls = []
+    sms_calls = []
+    telegram_messages = []
+    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", True)
+    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda text: telegram_messages.append(text) or True)
+    monkeypatch.setattr(
+        webhook_server,
+        "send_sms_to_openclaw_hooks",
+        lambda normalized_sms, line_display=None: hook_calls.append(normalized_sms) or (True, "http_200"),
+    )
+    monkeypatch.setattr(webhook_server, "dialpad_send_sms", lambda *args, **kwargs: sms_calls.append(args) or {"id": "msg-1"})
+
+    payload = {
+        "direction": "inbound",
+        "from_number": "+14155550123",
+        "to_number": ["+14155201316"],
+        "text": "I need to talk to a real person about the meeting time.",
+    }
+    handler, status = _build_handler(payload)
+    webhook_server.DialpadWebhookHandler.handle_webhook(handler)
+
+    response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    assert status["code"] == 200
+    assert sms_calls == []
+    assert response["auto_reply_status"] == "draft_created"
+    assert response["auto_reply_draft_id"]
+    assert hook_calls[0]["auto_reply"]["replyPolicy"]["state"] == "risky"
+    assert "Second confirmation required" in telegram_messages[0]
+    assert "Risk:" in telegram_messages[0]
+
+    conn = webhook_server.sms_approval.init_db()
+    try:
+        draft = webhook_server.sms_approval.get_draft(conn, response["auto_reply_draft_id"])
+    finally:
+        conn.close()
+    assert draft["risk_state"] == webhook_server.sms_approval.RISK_RISKY
+    assert draft["status"] == webhook_server.sms_approval.STATUS_PENDING
+
 
 
 @pytest.mark.parametrize("lookup_status", ["disabled", "not_applicable", "resolved"])

--- a/tests/test_sender_enrichment.py
+++ b/tests/test_sender_enrichment.py
@@ -448,8 +448,9 @@ def test_standard_stop_keyword_blocks_sms_automation(monkeypatch, tmp_path):
             "degraded_reason": None,
         },
     )
-    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", False)
-    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda _text: True)
+    telegram_messages = []
+    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", True)
+    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda text: telegram_messages.append(text) or True)
     monkeypatch.setattr(webhook_server, "send_sms_to_openclaw_hooks", lambda *_args, **_kwargs: (True, "http_200"))
 
     payload = {
@@ -484,8 +485,9 @@ def test_opt_out_with_security_code_persists_opt_out_before_sensitive_filter(mon
             "degraded_reason": None,
         },
     )
-    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", False)
-    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda _text: True)
+    telegram_messages = []
+    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", True)
+    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda text: telegram_messages.append(text) or True)
     monkeypatch.setattr(webhook_server, "send_sms_to_openclaw_hooks", lambda *_args, **_kwargs: (True, "http_200"))
 
     payload = {
@@ -759,8 +761,9 @@ def test_previously_opted_out_customer_gets_blocked_status_not_persistence_failu
             "degraded_reason": None,
         },
     )
-    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", False)
-    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda _text: True)
+    telegram_messages = []
+    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", True)
+    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda text: telegram_messages.append(text) or True)
     monkeypatch.setattr(webhook_server, "send_sms_to_openclaw_hooks", lambda *_args, **_kwargs: (True, "http_200"))
 
     conn = webhook_server.sms_approval.init_db()
@@ -787,6 +790,11 @@ def test_previously_opted_out_customer_gets_blocked_status_not_persistence_failu
     assert status["code"] == 200
     assert response["auto_reply_status"] == "blocked_opt_out"
     assert response["auto_reply_draft_id"] is None
+    assert response["telegram_status"] == "sent"
+    assert len(telegram_messages) == 1
+    assert "Automation blocked" in telegram_messages[0]
+    assert "human" in telegram_messages[0]
+    assert "No SMS approval draft" in telegram_messages[0]
 
 
 

--- a/tests/test_sms_approval.py
+++ b/tests/test_sms_approval.py
@@ -246,6 +246,45 @@ class SmsApprovalTests(unittest.TestCase):
         self.assertEqual(len(send_calls), 1)
         self.assertEqual(sum(1 for result in results if result.get("sent")), 1)
 
+    def test_concurrent_replacement_drafts_leave_one_pending(self):
+        barrier = threading.Barrier(2)
+
+        def create_from_new_connection(suffix):
+            conn = sms_approval.init_db(sms_approval.DB_PATH)
+            try:
+                barrier.wait(timeout=2)
+                return sms_approval.create_replacement_draft(
+                    conn,
+                    invalidate_thread_key="thread-1",
+                    invalidate_customer_number="+15125550100",
+                    thread_key="thread-1",
+                    customer_number="+15125550100",
+                    sender_number="+14155201316",
+                    draft_text=f"Replacement draft {suffix}.",
+                )
+            finally:
+                conn.close()
+
+        results = []
+        threads = [
+            threading.Thread(target=lambda suffix=suffix: results.append(create_from_new_connection(suffix)))
+            for suffix in ("A", "B")
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        rows = self.conn.execute(
+            "SELECT draft_id, status FROM sms_approval_drafts WHERE thread_key = ?",
+            ("thread-1",),
+        ).fetchall()
+        pending = [row for row in rows if row["status"] == sms_approval.STATUS_PENDING]
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(len(pending), 1)
+
     def test_opted_out_customer_cannot_get_new_or_approved_drafts(self):
         sms_approval.mark_opt_out(
             self.conn,

--- a/tests/test_sms_approval.py
+++ b/tests/test_sms_approval.py
@@ -319,6 +319,40 @@ class SmsApprovalTests(unittest.TestCase):
         self.assertEqual(result["status"], "stale")
         self.assertFalse(result["sent"])
 
+    def test_emergency_opt_out_blocks_new_and_existing_drafts(self):
+        emergency_path = Path(self.temp_dir.name) / "emergency-opt-outs.jsonl"
+        original_emergency_path = os.environ.get("DIALPAD_SMS_APPROVAL_EMERGENCY_PATH")
+        os.environ["DIALPAD_SMS_APPROVAL_EMERGENCY_PATH"] = str(emergency_path)
+        self.addCleanup(
+            lambda: (
+                os.environ.pop("DIALPAD_SMS_APPROVAL_EMERGENCY_PATH", None)
+                if original_emergency_path is None
+                else os.environ.__setitem__(
+                    "DIALPAD_SMS_APPROVAL_EMERGENCY_PATH",
+                    original_emergency_path,
+                )
+            )
+        )
+
+        draft = self._draft()
+        sms_approval.record_emergency_opt_out(
+            customer_number="+15125550100",
+            reason="customer_opt_out",
+            source="test_failure",
+        )
+
+        result = sms_approval.approve_draft(
+            self.conn,
+            draft_id=draft["draft_id"],
+            actor_id="12345",
+            send_func=lambda *_args, **_kwargs: self.fail("send should not run"),
+        )
+
+        self.assertEqual(result["status"], "blocked_opt_out")
+        self.assertFalse(result["sent"])
+        with self.assertRaisesRegex(ValueError, "opted out"):
+            self._draft(thread_key="thread-2")
+
     def test_create_draft_cli_persists_without_sending(self):
         db_path = Path(self.temp_dir.name) / "cli-approvals.db"
         env = {**os.environ, "DIALPAD_SMS_APPROVAL_DB": str(db_path)}

--- a/tests/test_sms_approval.py
+++ b/tests/test_sms_approval.py
@@ -180,6 +180,41 @@ class SmsApprovalTests(unittest.TestCase):
         self.assertEqual(stored["dialpad_sms_id"], None)
         self.assertIn("Dialpad unavailable", stored["send_error"])
 
+    def test_failed_delivery_status_remains_unsent(self):
+        draft = self._draft()
+
+        result = sms_approval.approve_draft(
+            self.conn,
+            draft_id=draft["draft_id"],
+            actor_id="12345",
+            send_func=lambda *_args, **_kwargs: {"id": "sms-1", "message_status": "failed"},
+        )
+
+        self.assertFalse(result["sent"])
+        self.assertEqual(result["status"], sms_approval.STATUS_FAILED)
+        self.assertEqual(result["error"], "delivery_status_failed")
+        stored = sms_approval.get_draft(self.conn, draft["draft_id"])
+        self.assertEqual(stored["status"], sms_approval.STATUS_FAILED)
+        self.assertEqual(stored["dialpad_sms_id"], "sms-1")
+        self.assertEqual(stored["delivery_status"], "failed")
+
+    def test_malformed_send_response_without_sms_id_remains_unsent(self):
+        draft = self._draft()
+
+        result = sms_approval.approve_draft(
+            self.conn,
+            draft_id=draft["draft_id"],
+            actor_id="12345",
+            send_func=lambda *_args, **_kwargs: {"message_status": "queued"},
+        )
+
+        self.assertFalse(result["sent"])
+        self.assertEqual(result["status"], sms_approval.STATUS_FAILED)
+        self.assertEqual(result["error"], "missing_dialpad_sms_id")
+        stored = sms_approval.get_draft(self.conn, draft["draft_id"])
+        self.assertEqual(stored["status"], sms_approval.STATUS_FAILED)
+        self.assertEqual(stored["send_error"], "missing_dialpad_sms_id")
+
     def test_concurrent_approvals_only_send_once(self):
         draft = self._draft()
         send_calls = []

--- a/tests/test_sms_approval.py
+++ b/tests/test_sms_approval.py
@@ -121,6 +121,34 @@ class SmsApprovalTests(unittest.TestCase):
         stored = sms_approval.get_draft(self.conn, draft["draft_id"])
         self.assertEqual(stored["status"], sms_approval.STATUS_PENDING)
 
+    def test_risky_draft_repeated_first_step_preserves_original_confirmer(self):
+        draft = self._draft(
+            risk_state=sms_approval.RISK_RISKY,
+            risk_reason="customer asked for a real person",
+        )
+
+        sms_approval.approve_draft(
+            self.conn,
+            draft_id=draft["draft_id"],
+            actor_id="12345",
+            actor_username="first",
+            send_func=lambda *_args, **_kwargs: self.fail("first step should not send"),
+            approved_at_ms=1000,
+        )
+        sms_approval.approve_draft(
+            self.conn,
+            draft_id=draft["draft_id"],
+            actor_id="67890",
+            actor_username="second",
+            send_func=lambda *_args, **_kwargs: self.fail("repeat first step should not send"),
+            approved_at_ms=2000,
+        )
+
+        stored = sms_approval.get_draft(self.conn, draft["draft_id"])
+        self.assertEqual(stored["first_confirmed_by"], "12345")
+        self.assertEqual(stored["first_confirmed_username"], "first")
+        self.assertEqual(stored["first_confirmed_at_ms"], 1000)
+
     def test_bot_actor_is_rejected(self):
         draft = self._draft()
         result = sms_approval.approve_draft(

--- a/tests/test_sms_approval.py
+++ b/tests/test_sms_approval.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import json
+import os
+import subprocess
+import sys
+import threading
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import sms_approval
+
+
+class SmsApprovalTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.original_db_path = sms_approval.DB_PATH
+        sms_approval.DB_PATH = Path(self.temp_dir.name) / "approvals.db"
+        self.addCleanup(self._restore_db_path)
+        self.conn = sms_approval.init_db()
+        self.addCleanup(self.conn.close)
+
+    def _restore_db_path(self):
+        sms_approval.DB_PATH = self.original_db_path
+
+    def _draft(self, **kwargs):
+        params = {
+            "thread_key": "thread-1",
+            "customer_number": "+15125550100",
+            "sender_number": "+14155201316",
+            "draft_text": "See you at 2:30 PM Central.",
+        }
+        params.update(kwargs)
+        return sms_approval.create_draft(self.conn, **params)
+
+    def test_approve_normal_draft_sends_exact_stored_text(self):
+        draft = self._draft()
+        calls = []
+
+        def fake_send(to_numbers, message, from_number=None):
+            calls.append((to_numbers, message, from_number))
+            return {"id": "sms-1", "message_status": "pending"}
+
+        result = sms_approval.approve_draft(
+            self.conn,
+            draft_id=draft["draft_id"],
+            actor_id="12345",
+            actor_username="operator",
+            send_func=fake_send,
+        )
+
+        self.assertTrue(result["sent"])
+        self.assertEqual(result["dialpad_sms_id"], "sms-1")
+        self.assertEqual(calls, [(["+15125550100"], "See you at 2:30 PM Central.", "+14155201316")])
+        stored = sms_approval.get_draft(self.conn, draft["draft_id"])
+        self.assertEqual(stored["status"], sms_approval.STATUS_SENT)
+        self.assertEqual(stored["approved_by"], "12345")
+
+    def test_stale_draft_does_not_send(self):
+        draft = self._draft()
+        sms_approval.invalidate_pending(self.conn, thread_key="thread-1", reason="newer_inbound")
+
+        result = sms_approval.approve_draft(
+            self.conn,
+            draft_id=draft["draft_id"],
+            actor_id="12345",
+            send_func=lambda *_args, **_kwargs: self.fail("send should not run"),
+        )
+
+        self.assertFalse(result["sent"])
+        self.assertEqual(result["status"], "stale")
+        self.assertEqual(result["reason"], "newer_inbound")
+
+    def test_risky_draft_requires_second_confirmation(self):
+        draft = self._draft(
+            risk_state=sms_approval.RISK_RISKY,
+            risk_reason="customer asked for a real person",
+        )
+
+        first = sms_approval.approve_draft(
+            self.conn,
+            draft_id=draft["draft_id"],
+            actor_id="12345",
+            send_func=lambda *_args, **_kwargs: self.fail("first step should not send"),
+        )
+        self.assertEqual(first["status"], "risky_confirmation_required")
+        self.assertFalse(first["sent"])
+
+        second = sms_approval.approve_draft(
+            self.conn,
+            draft_id=draft["draft_id"],
+            actor_id="67890",
+            action=sms_approval.ACTION_CONFIRM_RISK,
+            send_func=lambda *_args, **_kwargs: {"id": "sms-risk", "status": "queued"},
+        )
+        self.assertTrue(second["sent"])
+        self.assertEqual(second["dialpad_sms_id"], "sms-risk")
+
+    def test_risky_draft_direct_confirm_first_still_does_not_send(self):
+        draft = self._draft(
+            risk_state=sms_approval.RISK_RISKY,
+            risk_reason="customer asked for a real person",
+        )
+
+        result = sms_approval.approve_draft(
+            self.conn,
+            draft_id=draft["draft_id"],
+            actor_id="12345",
+            action=sms_approval.ACTION_CONFIRM_RISK,
+            send_func=lambda *_args, **_kwargs: self.fail("direct confirm should not send"),
+        )
+
+        self.assertEqual(result["status"], "risky_confirmation_required")
+        self.assertFalse(result["sent"])
+        stored = sms_approval.get_draft(self.conn, draft["draft_id"])
+        self.assertEqual(stored["status"], sms_approval.STATUS_PENDING)
+
+    def test_bot_actor_is_rejected(self):
+        draft = self._draft()
+        result = sms_approval.approve_draft(
+            self.conn,
+            draft_id=draft["draft_id"],
+            actor_id="bot",
+            send_func=lambda *_args, **_kwargs: self.fail("send should not run"),
+        )
+        self.assertEqual(result["status"], "blocked_actor")
+        self.assertFalse(result["sent"])
+
+    def test_failed_send_remains_unsent(self):
+        draft = self._draft()
+
+        def fake_send(*_args, **_kwargs):
+            raise RuntimeError("Dialpad unavailable")
+
+        result = sms_approval.approve_draft(
+            self.conn,
+            draft_id=draft["draft_id"],
+            actor_id="12345",
+            send_func=fake_send,
+        )
+
+        self.assertFalse(result["sent"])
+        self.assertEqual(result["status"], sms_approval.STATUS_FAILED)
+        stored = sms_approval.get_draft(self.conn, draft["draft_id"])
+        self.assertEqual(stored["status"], sms_approval.STATUS_FAILED)
+        self.assertEqual(stored["dialpad_sms_id"], None)
+        self.assertIn("Dialpad unavailable", stored["send_error"])
+
+    def test_concurrent_approvals_only_send_once(self):
+        draft = self._draft()
+        send_calls = []
+        barrier = threading.Barrier(2)
+
+        def approve_from_new_connection(actor_id):
+            conn = sms_approval.init_db(sms_approval.DB_PATH)
+            try:
+                barrier.wait(timeout=2)
+                return sms_approval.approve_draft(
+                    conn,
+                    draft_id=draft["draft_id"],
+                    actor_id=actor_id,
+                    send_func=lambda *_args, **_kwargs: send_calls.append(actor_id) or {"id": f"sms-{actor_id}"},
+                )
+            finally:
+                conn.close()
+
+        results = []
+        threads = [
+            threading.Thread(target=lambda actor_id=actor_id: results.append(approve_from_new_connection(actor_id)))
+            for actor_id in ("12345", "67890")
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual(len(send_calls), 1)
+        self.assertEqual(sum(1 for result in results if result.get("sent")), 1)
+
+    def test_opted_out_customer_cannot_get_new_or_approved_drafts(self):
+        sms_approval.mark_opt_out(
+            self.conn,
+            customer_number="+15125550100",
+            reason="customer_opt_out",
+            source="test",
+        )
+
+        with self.assertRaisesRegex(ValueError, "opted out"):
+            self._draft()
+
+        other_draft = sms_approval.create_draft(
+            self.conn,
+            thread_key="thread-2",
+            customer_number="+15125550101",
+            sender_number="+14155201316",
+            draft_text="Temporary draft.",
+        )
+        sms_approval.mark_opt_out(
+            self.conn,
+            customer_number="+15125550101",
+            reason="customer_opt_out",
+            source="test",
+        )
+        result = sms_approval.approve_draft(
+            self.conn,
+            draft_id=other_draft["draft_id"],
+            actor_id="12345",
+            send_func=lambda *_args, **_kwargs: self.fail("send should not run"),
+        )
+
+        self.assertEqual(result["status"], "stale")
+        self.assertFalse(result["sent"])
+
+    def test_create_draft_cli_persists_without_sending(self):
+        db_path = Path(self.temp_dir.name) / "cli-approvals.db"
+        env = {**os.environ, "DIALPAD_SMS_APPROVAL_DB": str(db_path)}
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(ROOT / "bin" / "create_sms_draft.py"),
+                "--thread-key",
+                "cli-thread",
+                "--to",
+                "+15125550100",
+                "--from",
+                "+14155201316",
+                "--message",
+                "Exact CLI draft.",
+                "--json",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        payload = json.loads(result.stdout)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["data"]["draft"]["draft_text"], "Exact CLI draft.")
+        self.assertEqual(payload["data"]["draft"]["status"], sms_approval.STATUS_PENDING)
+
+    def test_approve_draft_cli_rejects_bot_actor_without_sending(self):
+        db_path = Path(self.temp_dir.name) / "cli-approvals.db"
+        env = {
+            **os.environ,
+            "DIALPAD_SMS_APPROVAL_DB": str(db_path),
+            "DIALPAD_SMS_APPROVAL_TOKEN": "test-token",
+        }
+        create_result = subprocess.run(
+            [
+                sys.executable,
+                str(ROOT / "bin" / "create_sms_draft.py"),
+                "--thread-key",
+                "cli-thread",
+                "--to",
+                "+15125550100",
+                "--from",
+                "+14155201316",
+                "--message",
+                "Exact CLI draft.",
+                "--json",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        draft_id = json.loads(create_result.stdout)["data"]["draft"]["draft_id"]
+
+        approve_result = subprocess.run(
+            [
+                sys.executable,
+                str(ROOT / "bin" / "approve_sms_draft.py"),
+                draft_id,
+                "--actor-id",
+                "bot",
+                "--actor-is-bot",
+                "--approval-token",
+                "test-token",
+                "--json",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        payload = json.loads(approve_result.stdout)
+        self.assertEqual(approve_result.returncode, 2)
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["error"]["message"], "blocked_actor")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sms_approval.py
+++ b/tests/test_sms_approval.py
@@ -21,13 +21,26 @@ class SmsApprovalTests(unittest.TestCase):
         self.temp_dir = tempfile.TemporaryDirectory()
         self.addCleanup(self.temp_dir.cleanup)
         self.original_db_path = sms_approval.DB_PATH
+        self.original_emergency_path = os.environ.get("DIALPAD_SMS_APPROVAL_EMERGENCY_PATH")
         sms_approval.DB_PATH = Path(self.temp_dir.name) / "approvals.db"
+        os.environ["DIALPAD_SMS_APPROVAL_EMERGENCY_PATH"] = str(
+            Path(self.temp_dir.name) / "emergency-opt-outs.jsonl"
+        )
+        sms_approval._EMERGENCY_OPT_OUT_MEMORY.clear()
         self.addCleanup(self._restore_db_path)
+        self.addCleanup(self._restore_emergency_path)
         self.conn = sms_approval.init_db()
         self.addCleanup(self.conn.close)
 
     def _restore_db_path(self):
         sms_approval.DB_PATH = self.original_db_path
+
+    def _restore_emergency_path(self):
+        sms_approval._EMERGENCY_OPT_OUT_MEMORY.clear()
+        if self.original_emergency_path is None:
+            os.environ.pop("DIALPAD_SMS_APPROVAL_EMERGENCY_PATH", None)
+        else:
+            os.environ["DIALPAD_SMS_APPROVAL_EMERGENCY_PATH"] = self.original_emergency_path
 
     def _draft(self, **kwargs):
         params = {
@@ -320,20 +333,6 @@ class SmsApprovalTests(unittest.TestCase):
         self.assertFalse(result["sent"])
 
     def test_emergency_opt_out_blocks_new_and_existing_drafts(self):
-        emergency_path = Path(self.temp_dir.name) / "emergency-opt-outs.jsonl"
-        original_emergency_path = os.environ.get("DIALPAD_SMS_APPROVAL_EMERGENCY_PATH")
-        os.environ["DIALPAD_SMS_APPROVAL_EMERGENCY_PATH"] = str(emergency_path)
-        self.addCleanup(
-            lambda: (
-                os.environ.pop("DIALPAD_SMS_APPROVAL_EMERGENCY_PATH", None)
-                if original_emergency_path is None
-                else os.environ.__setitem__(
-                    "DIALPAD_SMS_APPROVAL_EMERGENCY_PATH",
-                    original_emergency_path,
-                )
-            )
-        )
-
         draft = self._draft()
         sms_approval.record_emergency_opt_out(
             customer_number="+15125550100",

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -760,6 +760,50 @@ class VoicemailWebhookHandlerTests(unittest.TestCase):
         self.assertIsNone(response["auto_reply_draft_id"])
         self.assertTrue(opted_out)
 
+    def test_known_contact_voicemail_opt_out_persists_even_when_reply_not_eligible(self):
+        with tempfile.TemporaryDirectory() as temp_dir, patch.object(
+            webhook_server.sms_approval,
+            "DB_PATH",
+            Path(temp_dir) / "approvals.db",
+        ), patch.object(webhook_server, "DIALPAD_AUTO_REPLY_ENABLED", True), patch.object(
+            webhook_server,
+            "DIALPAD_AUTO_REPLY_SALES_LINE",
+            "4155201316",
+        ), patch.object(
+            webhook_server,
+            "lookup_contact_enrichment",
+            return_value={
+                "contact_name": "Jane Doe",
+                "first_name": "Jane",
+                "last_name": "Doe",
+                "company": "Example Co",
+                "job_title": "Owner",
+                "status": "resolved",
+                "degraded": False,
+                "degraded_reason": None,
+            },
+        ), patch.object(webhook_server, "send_to_telegram", return_value=True):
+            payload = {
+                "from_number": "+14155550123",
+                "to_number": ["+14155201316"],
+                "duration": 19,
+                "voicemail_transcription": "Please stop texting me.",
+            }
+            handler, status = _build_handler(payload)
+            webhook_server.DialpadWebhookHandler.handle_voicemail_webhook(handler)
+
+            conn = webhook_server.sms_approval.init_db()
+            try:
+                opted_out = webhook_server.sms_approval.is_opted_out(conn, "+14155550123")
+            finally:
+                conn.close()
+
+        response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+        self.assertEqual(status["code"], 200)
+        self.assertEqual(response["auto_reply_status"], "blocked_opt_out")
+        self.assertIsNone(response["auto_reply_draft_id"])
+        self.assertTrue(opted_out)
+
     def test_voicemail_risky_transcription_creates_risky_draft(self):
         with tempfile.TemporaryDirectory() as temp_dir, patch.object(
             webhook_server.sms_approval,

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -1,5 +1,6 @@
 import io
 import json
+import tempfile
 from pathlib import Path
 import sys
 import unittest
@@ -355,7 +356,11 @@ class CallWebhookHandlerTests(unittest.TestCase):
         telegram_messages = []
         sms_calls = []
 
-        with patch.object(webhook_server, "OPENCLAW_HOOKS_CALL_ENABLED", True), \
+        with tempfile.TemporaryDirectory() as temp_dir, \
+                patch.object(webhook_server.sms_approval, "DB_PATH", Path(temp_dir) / "approvals.db"), \
+                patch.object(webhook_server, "DIALPAD_AUTO_REPLY_ENABLED", True), \
+                patch.object(webhook_server, "DIALPAD_AUTO_REPLY_SALES_LINE", "4155201316"), \
+                patch.object(webhook_server, "OPENCLAW_HOOKS_CALL_ENABLED", True), \
                 patch.object(webhook_server, "OPENCLAW_HOOKS_TOKEN", "token-123"), \
                 patch.object(
                     webhook_server,
@@ -411,20 +416,23 @@ class CallWebhookHandlerTests(unittest.TestCase):
         response = json.loads(handler.wfile.getvalue().decode("utf-8"))
         self.assertEqual(status["code"], 200)
         self.assertEqual(len(hook_calls), 1)
-        self.assertEqual(len(sms_calls), 1)
+        self.assertEqual(sms_calls, [])
         self.assertEqual(hook_calls[0]["normalized_event"]["event_type"], "missed_call")
         self.assertEqual(hook_calls[0]["normalized_event"]["call_id"], "call-123")
         self.assertEqual(hook_calls[0]["normalized_event"]["first_contact"]["knownContact"], False)
         self.assertEqual(hook_calls[0]["normalized_event"]["first_contact"]["keepBrief"], False)
         self.assertEqual(hook_calls[0]["normalized_event"]["first_contact"]["identityState"], "not_found")
-        self.assertIn("ShapeScale for Business Sales", sms_calls[0]["message"])
+        self.assertFalse(hook_calls[0]["normalized_event"]["auto_reply"]["sent"])
+        self.assertTrue(hook_calls[0]["normalized_event"]["auto_reply"]["draftCreated"])
+        self.assertTrue(hook_calls[0]["normalized_event"]["auto_reply"]["draftId"])
         self.assertEqual(len(telegram_messages), 1)
         self.assertTrue(response["missed_call"])
         self.assertTrue(response["hook_forwarded"])
         self.assertEqual(response["hook_status"], "http_200")
         self.assertTrue(response["telegram_sent"])
-        self.assertTrue(response["auto_reply_sent"])
-        self.assertEqual(response["auto_reply_status"], "accepted/queued")
+        self.assertFalse(response["auto_reply_sent"])
+        self.assertEqual(response["auto_reply_status"], "draft_created")
+        self.assertTrue(response["auto_reply_draft_id"])
 
     def test_inbound_missed_call_respects_disabled_hook_config(self):
         telegram_messages = []
@@ -630,11 +638,32 @@ class CallWebhookHandlerTests(unittest.TestCase):
 
 
 class VoicemailWebhookHandlerTests(unittest.TestCase):
-    def test_voicemail_sales_auto_reply_reaches_sender(self):
+    def test_voicemail_webhook_requires_auth_when_secret_configured(self):
+        with patch.object(webhook_server, "WEBHOOK_SECRET", "secret-123"):
+            payload = {
+                "from_number": "+14155550123",
+                "to_number": ["+14155201316"],
+                "duration": 19,
+                "voicemail_transcription": "Please call me back.",
+            }
+            handler, status = _build_handler(payload)
+            webhook_server.DialpadWebhookHandler.handle_voicemail_webhook(handler)
+
+        self.assertEqual(status["code"], 401)
+
+    def test_voicemail_sales_auto_reply_creates_approval_draft(self):
         sms_calls = []
         telegram_messages = []
 
-        with patch.object(
+        with tempfile.TemporaryDirectory() as temp_dir, patch.object(
+            webhook_server.sms_approval,
+            "DB_PATH",
+            Path(temp_dir) / "approvals.db",
+        ), patch.object(webhook_server, "DIALPAD_AUTO_REPLY_ENABLED", True), patch.object(
+            webhook_server,
+            "DIALPAD_AUTO_REPLY_SALES_LINE",
+            "4155201316",
+        ), patch.object(
             webhook_server,
             "lookup_contact_enrichment",
             return_value={
@@ -675,12 +704,104 @@ class VoicemailWebhookHandlerTests(unittest.TestCase):
         response = json.loads(handler.wfile.getvalue().decode("utf-8"))
         self.assertEqual(status["code"], 200)
         self.assertEqual(len(telegram_messages), 1)
-        self.assertEqual(len(sms_calls), 1)
-        self.assertEqual(sms_calls[0]["to_numbers"], ["+14155550123"])
-        self.assertEqual(sms_calls[0]["from_number"], "+14155201316")
-        self.assertIn("thanks for the voicemail", sms_calls[0]["message"])
-        self.assertTrue(response["auto_reply_sent"])
-        self.assertEqual(response["auto_reply_status"], "accepted/queued")
+        self.assertEqual(sms_calls, [])
+        self.assertFalse(response["auto_reply_sent"])
+        self.assertEqual(response["auto_reply_status"], "draft_created")
+        self.assertTrue(response["auto_reply_draft_id"])
+
+    def test_voicemail_opt_out_transcription_blocks_draft_and_persists_opt_out(self):
+        telegram_messages = []
+
+        with tempfile.TemporaryDirectory() as temp_dir, patch.object(
+            webhook_server.sms_approval,
+            "DB_PATH",
+            Path(temp_dir) / "approvals.db",
+        ), patch.object(webhook_server, "DIALPAD_AUTO_REPLY_ENABLED", True), patch.object(
+            webhook_server,
+            "DIALPAD_AUTO_REPLY_SALES_LINE",
+            "4155201316",
+        ), patch.object(
+            webhook_server,
+            "lookup_contact_enrichment",
+            return_value={
+                "contact_name": None,
+                "first_name": None,
+                "last_name": None,
+                "company": None,
+                "job_title": None,
+                "status": "not_found",
+                "degraded": False,
+                "degraded_reason": None,
+            },
+        ), patch.object(
+            webhook_server,
+            "send_to_telegram",
+            side_effect=lambda text: telegram_messages.append(text) or True,
+        ):
+            payload = {
+                "from_number": "+14155550123",
+                "to_number": ["+14155201316"],
+                "duration": 19,
+                "voicemail_transcription": "STOP texting me.",
+            }
+            handler, status = _build_handler(payload)
+            webhook_server.DialpadWebhookHandler.handle_voicemail_webhook(handler)
+
+            conn = webhook_server.sms_approval.init_db()
+            try:
+                opted_out = webhook_server.sms_approval.is_opted_out(conn, "+14155550123")
+            finally:
+                conn.close()
+
+        response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+        self.assertEqual(status["code"], 200)
+        self.assertFalse(response["auto_reply_sent"])
+        self.assertEqual(response["auto_reply_status"], "blocked_opt_out")
+        self.assertIsNone(response["auto_reply_draft_id"])
+        self.assertTrue(opted_out)
+
+    def test_voicemail_risky_transcription_creates_risky_draft(self):
+        with tempfile.TemporaryDirectory() as temp_dir, patch.object(
+            webhook_server.sms_approval,
+            "DB_PATH",
+            Path(temp_dir) / "approvals.db",
+        ), patch.object(webhook_server, "DIALPAD_AUTO_REPLY_ENABLED", True), patch.object(
+            webhook_server,
+            "DIALPAD_AUTO_REPLY_SALES_LINE",
+            "4155201316",
+        ), patch.object(
+            webhook_server,
+            "lookup_contact_enrichment",
+            return_value={
+                "contact_name": None,
+                "first_name": None,
+                "last_name": None,
+                "company": None,
+                "job_title": None,
+                "status": "not_found",
+                "degraded": False,
+                "degraded_reason": None,
+            },
+        ), patch.object(webhook_server, "send_to_telegram", return_value=True):
+            payload = {
+                "from_number": "+14155550123",
+                "to_number": ["+14155201316"],
+                "duration": 19,
+                "voicemail_transcription": "I need to talk to a real person.",
+            }
+            handler, status = _build_handler(payload)
+            webhook_server.DialpadWebhookHandler.handle_voicemail_webhook(handler)
+
+            response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+            conn = webhook_server.sms_approval.init_db()
+            try:
+                draft = webhook_server.sms_approval.get_draft(conn, response["auto_reply_draft_id"])
+            finally:
+                conn.close()
+
+        self.assertEqual(status["code"], 200)
+        self.assertEqual(response["auto_reply_status"], "draft_created")
+        self.assertEqual(draft["risk_state"], webhook_server.sms_approval.RISK_RISKY)
 
 
 if __name__ == "__main__":

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -1,5 +1,6 @@
 import io
 import json
+import os
 import tempfile
 from pathlib import Path
 import sys
@@ -638,6 +639,10 @@ class CallWebhookHandlerTests(unittest.TestCase):
 
 
 class VoicemailWebhookHandlerTests(unittest.TestCase):
+    def setUp(self):
+        webhook_server.sms_approval._EMERGENCY_OPT_OUT_MEMORY.clear()
+        self.addCleanup(webhook_server.sms_approval._EMERGENCY_OPT_OUT_MEMORY.clear)
+
     def test_voicemail_webhook_requires_auth_when_secret_configured(self):
         with patch.object(webhook_server, "WEBHOOK_SECRET", "secret-123"):
             payload = {
@@ -763,6 +768,62 @@ class VoicemailWebhookHandlerTests(unittest.TestCase):
         self.assertIn("Automation blocked", telegram_messages[0])
         self.assertIn("human", telegram_messages[0])
         self.assertIn("No SMS approval draft", telegram_messages[0])
+
+    def test_voicemail_opt_out_persistence_failure_returns_failed_status(self):
+        customer_number = "+14155550987"
+        with tempfile.TemporaryDirectory() as temp_dir, patch.dict(
+            os.environ,
+            {"DIALPAD_SMS_APPROVAL_EMERGENCY_PATH": temp_dir},
+        ), patch.object(
+            webhook_server.sms_approval,
+            "DB_PATH",
+            Path(temp_dir) / "approvals.db",
+        ), patch.object(webhook_server, "DIALPAD_AUTO_REPLY_ENABLED", True), patch.object(
+            webhook_server,
+            "DIALPAD_AUTO_REPLY_SALES_LINE",
+            "4155201316",
+        ), patch.object(
+            webhook_server,
+            "lookup_contact_enrichment",
+            return_value={
+                "contact_name": None,
+                "first_name": None,
+                "last_name": None,
+                "company": None,
+                "job_title": None,
+                "status": "not_found",
+                "degraded": False,
+                "degraded_reason": None,
+            },
+        ), patch.object(
+            webhook_server,
+            "send_to_telegram",
+            return_value=True,
+        ), patch.object(
+            webhook_server.sms_approval,
+            "mark_opt_out",
+            side_effect=OSError("simulated approval db failure"),
+        ):
+            payload = {
+                "from_number": customer_number,
+                "to_number": ["+14155201316"],
+                "duration": 19,
+                "voicemail_transcription": "STOP texting me.",
+            }
+            handler, status = _build_handler(payload)
+            webhook_server.DialpadWebhookHandler.handle_voicemail_webhook(handler)
+
+            conn = webhook_server.sms_approval.init_db()
+            try:
+                opted_out = webhook_server.sms_approval.is_opted_out(conn, customer_number)
+            finally:
+                conn.close()
+
+        response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+        self.assertEqual(status["code"], 200)
+        self.assertEqual(response["auto_reply_status"], "opt_out_persistence_failed")
+        self.assertIsNone(response["auto_reply_draft_id"])
+        self.assertTrue(opted_out)
 
     def test_known_contact_voicemail_opt_out_persists_even_when_reply_not_eligible(self):
         telegram_messages = []

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -759,8 +759,13 @@ class VoicemailWebhookHandlerTests(unittest.TestCase):
         self.assertEqual(response["auto_reply_status"], "blocked_opt_out")
         self.assertIsNone(response["auto_reply_draft_id"])
         self.assertTrue(opted_out)
+        self.assertEqual(len(telegram_messages), 1)
+        self.assertIn("Automation blocked", telegram_messages[0])
+        self.assertIn("human", telegram_messages[0])
+        self.assertIn("No SMS approval draft", telegram_messages[0])
 
     def test_known_contact_voicemail_opt_out_persists_even_when_reply_not_eligible(self):
+        telegram_messages = []
         with tempfile.TemporaryDirectory() as temp_dir, patch.object(
             webhook_server.sms_approval,
             "DB_PATH",
@@ -782,7 +787,11 @@ class VoicemailWebhookHandlerTests(unittest.TestCase):
                 "degraded": False,
                 "degraded_reason": None,
             },
-        ), patch.object(webhook_server, "send_to_telegram", return_value=True):
+        ), patch.object(
+            webhook_server,
+            "send_to_telegram",
+            side_effect=lambda text: telegram_messages.append(text) or True,
+        ):
             payload = {
                 "from_number": "+14155550123",
                 "to_number": ["+14155201316"],
@@ -803,6 +812,9 @@ class VoicemailWebhookHandlerTests(unittest.TestCase):
         self.assertEqual(response["auto_reply_status"], "blocked_opt_out")
         self.assertIsNone(response["auto_reply_draft_id"])
         self.assertTrue(opted_out)
+        self.assertEqual(len(telegram_messages), 1)
+        self.assertIn("Automation blocked", telegram_messages[0])
+        self.assertIn("No SMS approval draft", telegram_messages[0])
 
     def test_voicemail_risky_transcription_creates_risky_draft(self):
         with tempfile.TemporaryDirectory() as temp_dir, patch.object(


### PR DESCRIPTION
## What

- Default Dialpad/OpenClaw hook forwarding and sales-line auto-reply behavior remains disabled unless explicitly enabled.
- Replaces inbound-triggered direct SMS sends with persistent exact-text approval drafts.
- Adds deterministic approval ledger with stale invalidation, opt-out persistence, risky two-step confirmation, atomic send claiming, and audit fields.
- Adds stable `bin/create_sms_draft.py` and `bin/approve_sms_draft.py` wrappers plus operator-token gating for CLI approvals.
- Applies opt-out/risk classification to SMS and voicemail paths, adds auth to voicemail webhooks, and updates docs for the new safety contract.

## Why

A Dialpad inbound SMS routed through OpenClaw caused live outgoing SMS without fresh human send approval. The hotfix keeps enrichment/drafting useful while moving send authority out of agent reasoning and into a deterministic approval path.

Closes #71.

## Review Notes

The PR is larger than the usual target because it includes the incident requirements/plan docs and regression tests with the code hotfix. The split seam would be code vs docs/tests, but keeping them together makes the safety contract reviewable end-to-end.

## Verification

- `python3 -m py_compile scripts/sms_approval.py scripts/webhook_server.py scripts/create_sms_draft.py scripts/approve_sms_draft.py bin/create_sms_draft.py bin/approve_sms_draft.py`
- `python3 -m pytest -q`
- Result: `151 passed`
