### PR TITLE
feat(dialpad): add Telegram SMS approval buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ export OPENCLAW_HOOKS_CALL_ENABLED="1"
 export DIALPAD_AUTO_REPLY_ENABLED="1"
 export DIALPAD_SMS_APPROVAL_DB="/home/art/clawd/logs/sms_approvals.db"
 export DIALPAD_SMS_APPROVAL_TOKEN="operator-only-random-token"
+
+# Optional Telegram inline approval buttons (disabled by default)
+export DIALPAD_TELEGRAM_APPROVAL_BUTTONS_ENABLED="0"
+export TELEGRAM_WEBHOOK_SECRET="telegram-secret-token"
 ```
 
 When `OPENCLAW_HOOKS_TOKEN` is configured, inbound SMS and inbound missed-call events are only forwarded to OpenClaw when the matching event flag is explicitly enabled. Leave `OPENCLAW_HOOKS_SMS_ENABLED=0` and `OPENCLAW_HOOKS_CALL_ENABLED=0` for notification-only mode.
@@ -92,6 +96,12 @@ For identity work, treat `resolved` as the only state that is safe to mutate aut
 When `DIALPAD_AUTO_REPLY_ENABLED` is set, first-contact inbound events to the sales line `(415) 520-1316` create a short exact-text approval draft instead of sending SMS directly. Missed calls get a "sorry we missed you" draft variant; SMS and voicemail get a "we'll be in touch shortly" draft variant. Explicit opt-out language creates no draft, invalidates pending drafts for that customer, and sends only a human-only Telegram notice.
 CLI approval is disabled unless `DIALPAD_SMS_APPROVAL_TOKEN` is configured and supplied to `bin/approve_sms_draft.py`; keep that token out of agent runtime environments.
 
+Telegram inline approval buttons are optional. Before setting `DIALPAD_TELEGRAM_APPROVAL_BUTTONS_ENABLED=1`, run a bot-delivery preflight: check Telegram `getWebhookInfo` for the configured bot and confirm no OpenClaw runtime or operator process is already consuming that bot with `getUpdates` polling or another webhook. Telegram webhooks and `getUpdates` polling are mutually exclusive for the same bot. If another owner exists, route callback handling through that owner or use a separate Dialpad approval bot.
+
+When enabled, Telegram buttons call `POST /webhook/telegram` with callback queries. Configure Telegram with `allowed_updates=["callback_query"]`, `drop_pending_updates=true`, and `secret_token="$TELEGRAM_WEBHOOK_SECRET"` so requests include `X-Telegram-Bot-Api-Secret-Token`. The webhook validates that header, the configured Telegram chat id, and the human actor before dispatching to the deterministic SMS approval ledger. The button payload contains only a short draft id/action reference; it never contains the draft text or `DIALPAD_SMS_APPROVAL_TOKEN`.
+
+Live smoke test for buttons: send a harmless fake/test inbound SMS, verify the Telegram review message shows inline buttons, click `Reject`, and confirm the draft is rejected/stale in `sms_approvals.db`. Do not click approve on smoke tests unless the destination is a controlled non-customer number.
+
 Create/list webhook subscriptions:
 
 ```bash
@@ -102,6 +112,7 @@ bin/create_sms_webhook.py list
 Notes:
 
 - `/webhook/dialpad` handles SMS storage plus optional OpenClaw/Telegram fan-out
+- `/webhook/telegram` handles Telegram inline approval button callbacks; it requires `X-Telegram-Bot-Api-Secret-Token` and the configured Telegram chat id
 - `/webhook/dialpad-call` handles missed-call Telegram alerts using the event timestamp when available, with dynamic Markdown escaping, plus optional OpenClaw hook forwarding
 - `/webhook/dialpad-voicemail` sends Telegram alerts and can create first-contact sales-line SMS approval drafts, but does not send SMS directly
 - This repo validates hook request shape, gating, and graceful degradation only. It does not validate downstream OpenClaw proactive enrichment behavior

--- a/docs/plans/2026-04-27-001-feat-telegram-inline-sms-approval-plan.md
+++ b/docs/plans/2026-04-27-001-feat-telegram-inline-sms-approval-plan.md
@@ -1,0 +1,325 @@
+---
+title: feat: Add Telegram inline buttons for SMS approval drafts
+type: feat
+status: completed
+date: 2026-04-27
+origin: docs/brainstorms/2026-04-24-dialpad-one-click-sms-approval-requirements.md
+supersedes_partial: docs/plans/2026-04-24-001-fix-dialpad-sms-approval-gate-plan.md
+---
+
+# feat: Add Telegram Inline Buttons for SMS Approval Drafts
+
+## Overview
+
+The current hotfix correctly prevents autonomous Dialpad SMS sends by creating durable approval drafts and showing a deterministic shell approval command in Telegram. That is safe but operationally clumsy. The missing piece is native Telegram inline buttons attached to the same review message so a real operator can approve, confirm risk, or reject a draft without opening a shell.
+
+The core safety decision does not change: Telegram buttons are only a human approval surface over `scripts/sms_approval.py`. Button callbacks must never carry draft text, approval tokens, or send authority by themselves. They identify a stored draft, prove the callback came from Telegram and the configured chat, record the human actor, and then call the existing deterministic approval state machine.
+
+## Problem Frame
+
+The April 27 smoke test showed the deployed flow creating a draft and posting this fallback instruction:
+
+```text
+Approve from an operator shell: bin/approve_sms_draft.py ...
+```
+
+That proves the safety gate is working, but it does not meet the preferred UX from the origin requirements: "Telegram inline button when callback support exists" (see origin: `docs/brainstorms/2026-04-24-dialpad-one-click-sms-approval-requirements.md`). The plan is to add that preferred UX without reopening the original incident class where an agent could send a customer SMS without a fresh human approval.
+
+## Requirements Trace
+
+- R1. Inbound Dialpad SMS must never cause outbound SMS without explicit human approval.
+- R2. Inbound SMS remains notification plus draft generation, not sending.
+- R3. Preferred approval UX is Telegram inline buttons; shell approval remains the fallback.
+- R4. Approval sends the exact stored draft text shown to the operator.
+- R5. Pending approvals stay invalidated by newer inbound, manual outbound, or material context change.
+- R6. Risky messages still require two-step confirmation.
+- R7. Risk confirmation must show the risk reason before sending.
+- R8. A real Telegram group member may approve; bot/agent actors may not.
+- R9. Audit logging must retain actor, timestamp, draft id, risk reason, and Dialpad SMS result.
+- R10. Opt-out/human-only cases must show no send button and no override.
+- R11. Review messages distinguish draft text from sent text.
+- R12. Review messages show normal, risky, blocked, stale, sent, or failed state.
+- R13. Blocked opt-out/human-only cases notify the group that automation cannot send.
+- R14. Stale button clicks fail closed with a visible reason.
+- R15. Dialpad failures remain visibly unsent and cannot be described as sent.
+- R16. Telegram callback HTTP requests must be authenticated with Telegram webhook secret-token validation and scoped to the configured chat.
+- R17. Telegram bot update delivery must not break any existing OpenClaw or operator workflow already using the same bot.
+
+## Scope Boundaries
+
+- This does not re-enable autonomous SMS or OpenClaw hook auto-send behavior.
+- This does not replace `scripts/sms_approval.py`; it reuses that ledger and state machine.
+- This does not expose `DIALPAD_SMS_APPROVAL_TOKEN` in Telegram callback payloads.
+- This does not implement free-text editing in Telegram. Edited replies must create a new draft in a later feature.
+- This does not add buttons for opt-out, blocked, sensitive, shortcode, or human-only cases.
+- This does not require moving the webhook into a native OpenClaw plugin before shipping buttons. A plugin bridge can be revisited later if OpenClaw owns all Telegram delivery.
+
+## Context & Research
+
+### Local Code and Patterns
+
+- `scripts/webhook_server.py` owns inbound Dialpad handling, Telegram posting, draft creation, and the current approval review suffix.
+- `send_to_telegram()` currently sends text only. It needs optional `reply_markup` support for inline buttons.
+- `build_approval_review_suffix()` currently appends the shell approval command. It should produce button-friendly copy when buttons are enabled and keep the command fallback when not.
+- `scripts/sms_approval.py` already provides durable draft creation, stale invalidation, opt-out fail-closed behavior, risky two-step state, bot actor rejection, actor allowlisting, and exact-text sends.
+- `bin/approve_sms_draft.py` remains the emergency/operator-shell fallback.
+- `tests/test_webhook_server.py` and `tests/test_sms_approval.py` are the primary unit-test surfaces for webhook payloads and approval state.
+
+### External References
+
+- Telegram `sendMessage` accepts `reply_markup` as an `InlineKeyboardMarkup` object; inline buttons carry `callback_data`.
+- Telegram limits `callback_data` to 1-64 bytes, so callback payloads must be short and reference a stored draft id instead of embedding draft text.
+- Telegram sends a `CallbackQuery` when a callback button is pressed, and clients show a progress bar until the bot calls `answerCallbackQuery`.
+- Telegram `editMessageReplyMarkup` can remove or replace the inline keyboard after approval, rejection, stale detection, or failure.
+- Telegram `setWebhook` supports `allowed_updates` including `callback_query`, `drop_pending_updates`, and `secret_token`; webhook requests then include `X-Telegram-Bot-Api-Secret-Token`, which should be validated before processing.
+- Telegram notes that a bot cannot receive updates through `getUpdates` while an outgoing webhook is configured, so implementation must confirm current bot ownership before calling `setWebhook`.
+
+References:
+- <https://core.telegram.org/bots/api#inlinekeyboardmarkup>
+- <https://core.telegram.org/bots/api#inlinekeyboardbutton>
+- <https://core.telegram.org/bots/api#callbackquery>
+- <https://core.telegram.org/bots/api#answercallbackquery>
+- <https://core.telegram.org/bots/api#editmessagereplymarkup>
+- <https://core.telegram.org/bots/api#setwebhook>
+
+## Key Technical Decisions
+
+- Add buttons in `scripts/webhook_server.py`, not by letting an agent send or interpret Telegram commands. The Python webhook is already the deterministic system creating the draft and sending the Telegram alert, so it should also own the callback endpoint for the button UX.
+- Do not blindly overwrite Telegram update delivery. If `getWebhookInfo` or local OpenClaw runtime inspection shows the same bot already uses another webhook or polling consumer, pause and choose one of two safe paths: route callbacks through that existing Telegram runtime, or provision a separate approval bot for Dialpad approvals.
+- Keep the approval token out of button callbacks. Webhook authenticity comes from Telegram's secret-token header, configured chat id, and actor checks in the approval ledger.
+- Use compact callback data. A safe shape is `smsa:<action>:<draft_id>` where action is `a`, `r`, or `c` for approve, reject, or confirm-risk. The implementation must assert the encoded value is at most 64 bytes.
+- Store no sendable text in Telegram callback data. The callback only selects the durable draft row; `approve_draft()` sends the stored exact text.
+- Make risky approval visibly two-step. The first click records risk acknowledgement and edits the message to show the risk reason plus a `Confirm send` button. The second click sends.
+- Remove or replace buttons immediately after any terminal result. Sent, stale, rejected, failed, actor-blocked, and opt-out-blocked states should not leave active approve buttons visible.
+- Keep shell approval fallback. If `DIALPAD_TELEGRAM_APPROVAL_BUTTONS_ENABLED` is off, the Telegram webhook secret is missing, or Telegram button posting fails, the existing CLI approval text remains available.
+
+## High-Level Technical Design
+
+```mermaid
+sequenceDiagram
+  participant Dialpad
+  participant Webhook as scripts/webhook_server.py
+  participant Ledger as scripts/sms_approval.py
+  participant Telegram
+  participant Operator
+
+  Dialpad->>Webhook: inbound SMS webhook
+  Webhook->>Ledger: create exact-text draft
+  Webhook->>Telegram: sendMessage + InlineKeyboardMarkup
+  Operator->>Telegram: tap approve/reject/confirm-risk
+  Telegram->>Webhook: POST /webhook/telegram callback_query
+  Webhook->>Webhook: validate secret header, chat, actor, callback_data
+  Webhook->>Telegram: answerCallbackQuery
+  Webhook->>Ledger: approve_draft() or reject_draft()
+  Ledger-->>Webhook: sent/stale/risk-required/failed result
+  Webhook->>Telegram: editMessageReplyMarkup or editMessageText
+```
+
+## Implementation Units
+
+- [x] **Unit 0: Telegram Bot Ownership and Delivery Preflight**
+
+**Goal:** Verify that enabling a Telegram webhook for callback queries will not break an existing consumer of the same bot.
+
+**Requirements:** R3, R16, R17
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `README.md`
+- Test: `tests/test_openclaw_integration_docs.py`
+
+**Approach:**
+- Check `getWebhookInfo` for the configured bot before deployment and document the expected empty or owned-by-Dialpad state.
+- Inspect the local OpenClaw/Telegram runtime configuration enough to determine whether it uses this bot with `getUpdates`, its own webhook, or no update receiver.
+- If another consumer owns updates for the same bot, do not call `setWebhook` from this skill. Either add the callback handler inside that owner or use a separate Dialpad approval bot.
+- Document the decision in the rollout notes so future deploys do not accidentally replace another webhook.
+
+**Test Scenarios:**
+- Docs require bot-delivery preflight before `setWebhook`.
+- Docs mention that `getUpdates` polling and outgoing webhook delivery are mutually exclusive for the same bot.
+- Rollout instructions include a stop condition when another webhook or polling owner is detected.
+
+- [x] **Unit 1: Telegram Send Helper With Inline Keyboard Support**
+
+**Goal:** Allow existing Telegram review messages to carry native inline buttons while preserving text-only behavior.
+
+**Requirements:** R3, R11, R12
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `scripts/webhook_server.py`
+- Test: `tests/test_webhook_server.py`
+
+**Approach:**
+- Extend `send_to_telegram(text)` to accept optional `reply_markup`.
+- Add a small builder for SMS approval inline keyboards using compact callback data.
+- Add `DIALPAD_TELEGRAM_APPROVAL_BUTTONS_ENABLED` as an explicit feature flag.
+- Validate callback data length during construction; fail closed to command fallback if it exceeds 64 bytes.
+- Keep shell approval instructions when buttons are disabled or not safely configured.
+
+**Test Scenarios:**
+- Low-risk draft produces an inline keyboard with approve and reject buttons when the feature flag is enabled.
+- Risky draft produces an initial approve/acknowledge-risk button plus reject button, not a direct confirm-risk send button.
+- Button payloads are at most 64 bytes.
+- Feature flag disabled preserves the current shell command text and sends no `reply_markup`.
+- Telegram send failure does not break Dialpad webhook response.
+
+- [x] **Unit 2: Telegram Callback Webhook Endpoint and Authentication**
+
+**Goal:** Receive Telegram button clicks through a deterministic endpoint that authenticates Telegram delivery and scopes actions to the configured group.
+
+**Requirements:** R1, R8, R16
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `scripts/webhook_server.py`
+- Test: `tests/test_webhook_server.py`
+
+**Approach:**
+- Add `POST /webhook/telegram` handling alongside the existing Dialpad webhook route.
+- Require `TELEGRAM_WEBHOOK_SECRET` and validate `X-Telegram-Bot-Api-Secret-Token` with constant-time comparison.
+- Parse only `callback_query` updates; ignore or reject unrelated Telegram updates.
+- Validate `callback_query.message.chat.id` equals `DIALPAD_TELEGRAM_CHAT_ID`.
+- Extract actor id, username, and `is_bot` from `callback_query.from`.
+- Call `answerCallbackQuery` for every accepted callback id, including stale or rejected outcomes, so Telegram clients stop showing a spinner.
+- Return 200 for authenticated, understood callback envelopes even when the approval result is blocked or stale; return 401/403 for failed authentication or wrong chat.
+
+**Test Scenarios:**
+- Valid callback with matching secret and chat reaches the approval dispatcher.
+- Missing or wrong secret returns unauthorized and does not read or mutate the approval DB.
+- Callback from a different chat returns forbidden and does not mutate the approval DB.
+- Non-callback Telegram update is ignored without attempting a send.
+- Bot actor is passed through as `actor_is_bot=True` and rejected by the approval layer.
+
+- [x] **Unit 3: Callback Action Dispatcher and Draft Rejection**
+
+**Goal:** Map button actions to the existing approval state machine and add an exact-draft reject action for operator dismissal.
+
+**Requirements:** R1, R4, R5, R6, R7, R8, R9, R10, R14, R15
+
+**Dependencies:** Unit 2.
+
+**Files:**
+- Modify: `scripts/sms_approval.py`
+- Modify: `scripts/webhook_server.py`
+- Test: `tests/test_sms_approval.py`
+- Test: `tests/test_webhook_server.py`
+
+**Approach:**
+- Add a focused `reject_draft()` or `invalidate_draft()` helper that marks one pending draft stale/rejected by exact `draft_id` and records actor metadata where practical.
+- Dispatch `approve` button clicks to `sms_approval.approve_draft(..., action="approve")`.
+- Dispatch `confirm-risk` clicks to `sms_approval.approve_draft(..., action="confirm-risk")`.
+- Dispatch `reject` clicks to the new exact-draft rejection helper.
+- Treat unknown actions, malformed callback data, resolved drafts, stale drafts, opt-out state, and failed sends as terminal no-send results.
+- Preserve existing actor allowlist behavior by passing Telegram user id as the approval actor.
+
+**Test Scenarios:**
+- Normal approve sends the stored exact draft text and records Telegram actor id and username.
+- Risky first approve returns `risky_confirmation_required` and does not call Dialpad.
+- Risky second confirmation sends only after the first risk acknowledgement exists.
+- Reject marks the exact draft stale/rejected and never calls Dialpad.
+- Duplicate approve after sent returns already-resolved and does not send twice.
+- Stale draft click returns stale reason and does not call Dialpad.
+- Unknown callback action is rejected without send.
+
+- [x] **Unit 4: Telegram Message Updates After Callback**
+
+**Goal:** Keep the Telegram review surface truthful after every button click.
+
+**Requirements:** R11, R12, R14, R15
+
+**Dependencies:** Unit 3.
+
+**Files:**
+- Modify: `scripts/webhook_server.py`
+- Test: `tests/test_webhook_server.py`
+
+**Approach:**
+- Add Telegram API helpers for `answerCallbackQuery`, `editMessageReplyMarkup`, and, where useful, `editMessageText`.
+- On normal sent result, remove buttons and append/replace status with "sent" plus Dialpad SMS id when available.
+- On risky first approval, edit the message to show the risk reason and replace buttons with `Confirm send` and `Reject`.
+- On reject, stale, blocked actor, opt-out, or failed send, remove buttons and show the no-send reason.
+- Make update failures non-fatal to webhook processing but log them clearly; the ledger remains the source of truth.
+
+**Test Scenarios:**
+- Successful send removes inline keyboard and includes sent status.
+- Risky first click leaves no direct approve button and adds only confirm-risk/reject controls.
+- Stale click removes inline keyboard and shows stale reason.
+- Telegram edit failure does not retry the Dialpad send and does not mark an unsent draft as sent.
+
+- [x] **Unit 5: Operational Setup and Documentation**
+
+**Goal:** Make deployment and live smoke testing repeatable without leaking tokens or accidentally approving test SMS.
+
+**Requirements:** R3, R8, R10, R14, R16
+
+**Dependencies:** Units 1-4.
+
+**Files:**
+- Modify: `README.md`
+- Modify: `references/openclaw-integration.md`
+- Modify: `systemd/dialpad-webhook.service`
+- Test: `tests/test_openclaw_integration_docs.py`
+
+**Approach:**
+- Document required environment variables:
+  - `DIALPAD_TELEGRAM_APPROVAL_BUTTONS_ENABLED=1`
+  - `TELEGRAM_WEBHOOK_SECRET`
+  - `DIALPAD_TELEGRAM_BOT_TOKEN`
+  - `DIALPAD_TELEGRAM_CHAT_ID`
+  - optional `DIALPAD_SMS_APPROVAL_ALLOWED_ACTORS`
+- Document the Telegram `setWebhook` call using `allowed_updates=["callback_query"]`, `drop_pending_updates=true`, and `secret_token`.
+- Document the live smoke test:
+  - Send a harmless test inbound SMS from a fake/test number.
+  - Verify the Telegram message shows inline buttons.
+  - Click `Reject` on the smoke draft.
+  - Confirm the draft is rejected/stale in `sms_approvals.db`.
+  - Do not click approve on smoke tests unless using a controlled non-customer Dialpad destination.
+- Update service docs/template so the repo matches the deployed `scripts/webhook_server.py` entrypoint.
+
+**Test Scenarios:**
+- Docs mention the secret-token header and wrong-chat rejection.
+- Docs preserve shell approval fallback.
+- Docs warn that opt-out/human-only messages do not receive buttons.
+
+## Rollout Plan
+
+1. Ship code with `DIALPAD_TELEGRAM_APPROVAL_BUTTONS_ENABLED=0` by default.
+2. Run Telegram bot ownership preflight with `getWebhookInfo` and local runtime inspection.
+3. Stop if another webhook or polling owner already consumes updates for this bot; route through that owner or use a separate approval bot.
+4. Deploy the callback endpoint and verify `/health` is unchanged.
+5. Configure Telegram webhook with `allowed_updates=["callback_query"]`, `drop_pending_updates=true`, and `secret_token`.
+6. Enable `DIALPAD_TELEGRAM_APPROVAL_BUTTONS_ENABLED=1`.
+7. Run the reject-only live smoke test against a fake/test number.
+8. Run one controlled approval test only if the destination is confirmed non-customer and safe.
+9. Keep CLI approval fallback documented and available.
+
+## Risks and Mitigations
+
+- **Spoofed callback HTTP request:** Require Telegram secret-token header and configured chat id before processing.
+- **Wrong group or forwarded callback:** Reject callbacks whose message chat id does not match `DIALPAD_TELEGRAM_CHAT_ID`.
+- **Agent/bot approval:** Pass `from.is_bot` and Telegram user id to `approve_draft()`, preserving existing bot actor rejection and actor allowlist.
+- **Callback payload too long:** Enforce the 64-byte callback_data limit in tests and fall back to shell approval if violated.
+- **Duplicate clicks or races:** Keep `approve_draft()` as the atomic state transition and treat already-resolved results as no-send.
+- **Risky one-click send regression:** First risky click can only transition to risk-pending; second click must use explicit confirm-risk action.
+- **Button remains visible after failure:** Attempt Telegram message edit for every terminal state; ledger remains authoritative if Telegram edit fails.
+- **Existing Telegram bot consumer breakage:** Preflight `getWebhookInfo` and local runtime ownership before `setWebhook`; do not overwrite another owner.
+- **Tunnel/public URL changes:** Document webhook re-registration as part of deploy and smoke testing.
+
+## Verification Checklist
+
+- `python -m pytest tests/test_sms_approval.py tests/test_webhook_server.py`
+- `python -m pytest tests/test_openclaw_integration_docs.py`
+- Local callback fixture tests for valid approve, risky confirm, reject, stale, wrong secret, wrong chat, and bot actor.
+- Live smoke test with a fake/test inbound SMS and `Reject`, confirming no outbound Dialpad SMS was sent.
+- Controlled approval test only on a non-customer destination if needed to verify end-to-end Dialpad send.
+
+## Deferred Work
+
+- Native OpenClaw plugin bridge if future architecture moves Telegram delivery and callback dispatch out of `scripts/webhook_server.py`.
+- Telegram text editing for draft modifications; edited text should create a replacement draft and reset approval.
+- Richer actor policy, such as requiring a small allowlist for production approvals instead of any real group member.
+- Automatic stale invalidation from CRM/calendar context fingerprints beyond the currently captured webhook events.

--- a/references/openclaw-integration.md
+++ b/references/openclaw-integration.md
@@ -67,6 +67,8 @@ export OPENCLAW_HOOKS_CALL_ENABLED="0"
 export DIALPAD_AUTO_REPLY_ENABLED="0"
 export DIALPAD_SMS_APPROVAL_DB="/home/art/clawd/logs/sms_approvals.db"
 export DIALPAD_SMS_APPROVAL_TOKEN="operator-only-random-token"
+export DIALPAD_TELEGRAM_APPROVAL_BUTTONS_ENABLED="0"
+export TELEGRAM_WEBHOOK_SECRET="telegram-secret-token"
 ```
 
 Behavior:
@@ -76,6 +78,9 @@ Behavior:
 - voicemail remains Telegram-only for OpenClaw fan-out, but first-contact sales-line voicemails can create SMS approval drafts when draft creation is enabled
 - explicit opt-out language creates no draft, invalidates pending drafts for that customer, and emits only a human-only Telegram notice
 - CLI approval is disabled unless `DIALPAD_SMS_APPROVAL_TOKEN` is configured and supplied by the operator approval surface
+- Telegram inline approval buttons are disabled unless `DIALPAD_TELEGRAM_APPROVAL_BUTTONS_ENABLED=1`, Telegram bot/chat credentials are configured, and `TELEGRAM_WEBHOOK_SECRET` is set
+- before enabling Telegram buttons, check `getWebhookInfo` and local OpenClaw runtime ownership; do not replace another webhook or `getUpdates` polling owner for the same bot
+- Telegram callback requests must include `X-Telegram-Bot-Api-Secret-Token`, must come from the configured Telegram chat, and must identify a real non-bot actor
 - if your gateway listens on a different port, change `OPENCLAW_GATEWAY_URL` accordingly
 - the local gateway allows explicit `niemand-work` routing and the `hook:dialpad:` session-key namespace
 
@@ -96,6 +101,11 @@ Relevant endpoints in `scripts/webhook_server.py`:
   - creates approval drafts for eligible first-contact sales-line missed-call acknowledgments, but does not send SMS directly
 - `POST /webhook/dialpad-voicemail`
   - Telegram notification plus optional approval-draft creation for eligible first-contact sales-line voicemails
+- `POST /webhook/telegram`
+  - receives Telegram `callback_query` updates from inline approval buttons
+  - validates `X-Telegram-Bot-Api-Secret-Token`
+  - rejects callbacks outside the configured Telegram chat
+  - dispatches approve, confirm-risk, and reject actions to the deterministic SMS approval ledger
 
 ## OpenClaw Receiver Contract
 
@@ -450,6 +460,14 @@ OpenClaw should:
 
 Outbound send must always go through `scripts/approve_sms_draft.py` or an equivalent deterministic approval handler with a real human actor id plus a trusted approval token/callback. The agent or bot must not approve its own draft.
 
+For Telegram inline approval, the trusted callback path is:
+
+1. the review message shows the exact draft text plus inline approve/reject controls
+2. Telegram sends a `callback_query` to `/webhook/telegram`
+3. the webhook validates `X-Telegram-Bot-Api-Secret-Token`, chat id, callback payload shape, and actor identity
+4. the callback references only the durable `smsdraft_*` id and action; it does not contain draft text or `DIALPAD_SMS_APPROVAL_TOKEN`
+5. normal approvals send the stored exact text, risky approvals require a second `confirm-risk` callback, and reject/stale/failed outcomes remove the active buttons
+
 ## Rollout Plan
 
 Recommended rollout:
@@ -460,6 +478,7 @@ Recommended rollout:
 4. add normalization and proactive enrichment
 5. ship `approval_required` mode first
 6. re-enable hook classes only after approval drafts and stale/opt-out behavior are verified
+7. enable Telegram buttons only after `getWebhookInfo` confirms the bot is unowned by another webhook or deliberately owned by this service; if the bot is consumed through `getUpdates`, route callbacks through that owner or use a separate approval bot
 
 ## Validation Checklist
 
@@ -467,6 +486,8 @@ Dialpad-side:
 - `OPENCLAW_HOOKS_TOKEN` configured
 - `OPENCLAW_HOOKS_PATH` points at a live OpenClaw receiver
 - `DIALPAD_WEBHOOK_SECRET` matches the sender expectations
+- Telegram button rollout preflight checks `getWebhookInfo` and confirms no conflicting `getUpdates` polling owner
+- `/webhook/telegram` validates `X-Telegram-Bot-Api-Secret-Token` and wrong-chat callbacks fail closed
 - test SMS and missed-call webhooks return HTTP 200
 
 OpenClaw-side:

--- a/scripts/sms_approval.py
+++ b/scripts/sms_approval.py
@@ -23,6 +23,7 @@ STATUS_SENDING = "sending"
 STATUS_SENT = "sent"
 STATUS_FAILED = "failed"
 STATUS_STALE = "stale"
+STATUS_REJECTED = "rejected"
 
 RISK_NORMAL = "normal"
 RISK_RISKY = "risky"
@@ -160,10 +161,16 @@ def init_db(path: Path | None = None) -> sqlite3.Connection:
             dialpad_sms_id TEXT,
             delivery_status TEXT,
             send_error TEXT,
+            rejected_by TEXT,
+            rejected_username TEXT,
+            rejected_at_ms INTEGER,
             metadata_json TEXT
         )
         """
     )
+    ensure_column(conn, "sms_approval_drafts", "rejected_by", "TEXT")
+    ensure_column(conn, "sms_approval_drafts", "rejected_username", "TEXT")
+    ensure_column(conn, "sms_approval_drafts", "rejected_at_ms", "INTEGER")
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_sms_approval_thread_status "
         "ON sms_approval_drafts(thread_key, status)"
@@ -185,6 +192,16 @@ def init_db(path: Path | None = None) -> sqlite3.Connection:
     )
     conn.commit()
     return conn
+
+
+def ensure_column(conn: sqlite3.Connection, table_name: str, column_name: str, column_type: str) -> None:
+    """Add a nullable column when opening an older SQLite approval database."""
+    columns = {
+        row["name"] if isinstance(row, sqlite3.Row) else row[1]
+        for row in conn.execute(f"PRAGMA table_info({table_name})")
+    }
+    if column_name not in columns:
+        conn.execute(f"ALTER TABLE {table_name} ADD COLUMN {column_name} {column_type}")
 
 
 def row_to_dict(row: sqlite3.Row | None) -> dict[str, Any] | None:
@@ -340,6 +357,70 @@ def invalidate_pending(
     if commit:
         conn.commit()
     return cursor.rowcount
+
+
+def reject_draft(
+    conn: sqlite3.Connection,
+    *,
+    draft_id: str,
+    actor_id: str,
+    actor_username: str | None = None,
+    actor_is_bot: bool = False,
+    rejected_at_ms: int | None = None,
+) -> dict[str, Any]:
+    """Reject one pending draft without sending it."""
+    if _is_bot_actor(actor_id, actor_is_bot=actor_is_bot):
+        return {"ok": False, "status": "blocked_actor", "sent": False, "reason": "agent_or_bot_cannot_reject"}
+    if not _actor_is_allowed(actor_id):
+        return {"ok": False, "status": "actor_not_allowed", "sent": False, "reason": "actor_not_in_allowlist"}
+
+    draft = get_draft(conn, draft_id)
+    if not draft:
+        return {"ok": False, "status": "not_found", "sent": False}
+    if draft.get("status") == STATUS_SENT:
+        return {"ok": True, "status": "already_resolved", "sent": False, "draft": draft}
+    if draft.get("status") not in {STATUS_PENDING, STATUS_RISK_PENDING}:
+        return {
+            "ok": False,
+            "status": draft.get("status") or STATUS_STALE,
+            "sent": False,
+            "reason": draft.get("invalidated_reason") or draft.get("status"),
+            "draft": draft,
+        }
+
+    ts = rejected_at_ms or now_ms()
+    cursor = conn.execute(
+        """
+        UPDATE sms_approval_drafts
+        SET status = ?, invalidated_at_ms = ?, invalidated_reason = ?,
+            rejected_by = ?, rejected_username = ?, rejected_at_ms = ?
+        WHERE draft_id = ?
+          AND status IN (?, ?)
+          AND invalidated_at_ms IS NULL
+        """,
+        (
+            STATUS_REJECTED,
+            ts,
+            "operator_rejected",
+            actor_id,
+            actor_username,
+            ts,
+            draft_id,
+            STATUS_PENDING,
+            STATUS_RISK_PENDING,
+        ),
+    )
+    conn.commit()
+    current = get_draft(conn, draft_id)
+    if cursor.rowcount != 1:
+        return {
+            "ok": False,
+            "status": "stale",
+            "sent": False,
+            "reason": (current or {}).get("invalidated_reason") or (current or {}).get("status") or "not_claimed",
+            "draft": current,
+        }
+    return {"ok": True, "status": STATUS_REJECTED, "sent": False, "draft": current}
 
 
 def create_replacement_draft(

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -137,6 +137,15 @@ TELEGRAM_CALLBACK_APPROVE = "a"
 TELEGRAM_CALLBACK_REJECT = "r"
 TELEGRAM_CALLBACK_CONFIRM_RISK = "c"
 TELEGRAM_CALLBACK_MAX_BYTES = 64
+TELEGRAM_TERMINAL_APPROVAL_STATUSES = {
+    "already_resolved",
+    "blocked_opt_out",
+    "failed",
+    "not_found",
+    "rejected",
+    "sent",
+    "stale",
+}
 
 SENSITIVE_KEYWORD_PATTERNS = (
     re.compile(
@@ -946,7 +955,7 @@ def update_telegram_review_after_callback(callback_query, result, draft_id):
             risk_confirmation=True,
         )
         edit_telegram_message_reply_markup(chat_id, message_id, reply_markup=reply_markup)
-    else:
+    elif (result or {}).get("sent") or status in TELEGRAM_TERMINAL_APPROVAL_STATUSES:
         edit_telegram_message_reply_markup(chat_id, message_id, reply_markup=None)
 
     return send_to_telegram(build_telegram_callback_status_message(result, draft_id))

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -18,6 +18,8 @@ Environment Variables:
 - PORT (default: 8081) - HTTP server port
 - DIALPAD_TELEGRAM_BOT_TOKEN - Telegram bot token (required for call/voicemail notifications)
 - DIALPAD_TELEGRAM_CHAT_ID - Telegram chat ID (required for call/voicemail notifications)
+- DIALPAD_TELEGRAM_APPROVAL_BUTTONS_ENABLED (default: disabled)
+- TELEGRAM_WEBHOOK_SECRET - Telegram secret_token for inline approval callbacks
 - DIALPAD_API_KEY - Dialpad API key (required for contact lookup)
 - DIALPAD_WEBHOOK_SECRET - webhook auth secret (optional, enables signature/JWT verification)
 - OPENCLAW_GATEWAY_URL (default: http://127.0.0.1:8080)
@@ -83,6 +85,7 @@ PORT = int(os.environ.get("PORT", "8081"))
 WEBHOOK_SECRET = os.environ.get("DIALPAD_WEBHOOK_SECRET", "")
 TELEGRAM_BOT_TOKEN = os.environ.get("DIALPAD_TELEGRAM_BOT_TOKEN", "")
 TELEGRAM_CHAT_ID = os.environ.get("DIALPAD_TELEGRAM_CHAT_ID", "")
+TELEGRAM_WEBHOOK_SECRET = os.environ.get("TELEGRAM_WEBHOOK_SECRET", "")
 DIALPAD_API_KEY = os.environ.get("DIALPAD_API_KEY", "")
 DIALPAD_LINE_NAMES = os.environ.get("DIALPAD_LINE_NAMES", "")
 OPENCLAW_GATEWAY_URL = os.environ.get("OPENCLAW_GATEWAY_URL", "http://127.0.0.1:8080")
@@ -96,6 +99,10 @@ OPENCLAW_HOOKS_AGENT_ID = os.environ.get("OPENCLAW_HOOKS_AGENT_ID", "")
 OPENCLAW_HOOKS_SMS_ENABLED = parse_bool_env(os.environ.get("OPENCLAW_HOOKS_SMS_ENABLED"), False)
 OPENCLAW_HOOKS_CALL_ENABLED = parse_bool_env(os.environ.get("OPENCLAW_HOOKS_CALL_ENABLED"), False)
 DIALPAD_SMS_TELEGRAM_NOTIFY = os.environ.get("DIALPAD_SMS_TELEGRAM_NOTIFY", "1").lower() in {"1", "true", "yes", "on"}
+DIALPAD_TELEGRAM_APPROVAL_BUTTONS_ENABLED = parse_bool_env(
+    os.environ.get("DIALPAD_TELEGRAM_APPROVAL_BUTTONS_ENABLED"),
+    False,
+)
 DIALPAD_PRIORITY_ROUTE_TO = os.environ.get("DIALPAD_PRIORITY_ROUTE_TO", "")
 DIALPAD_PRIORITY_ROUTE_PHONES = os.environ.get("DIALPAD_PRIORITY_ROUTE_PHONES", "")
 DIALPAD_AUTO_REPLY_ENABLED = parse_bool_env(os.environ.get("DIALPAD_AUTO_REPLY_ENABLED"), False)
@@ -124,6 +131,12 @@ TELEGRAM_STATUS_SENT = "sent"
 TELEGRAM_STATUS_FILTERED = "filtered"
 TELEGRAM_STATUS_NOT_APPLICABLE = "not_applicable"
 TELEGRAM_STATUS_FAILED = "failed"
+
+TELEGRAM_CALLBACK_NAMESPACE = "smsa"
+TELEGRAM_CALLBACK_APPROVE = "a"
+TELEGRAM_CALLBACK_REJECT = "r"
+TELEGRAM_CALLBACK_CONFIRM_RISK = "c"
+TELEGRAM_CALLBACK_MAX_BYTES = 64
 
 SENSITIVE_KEYWORD_PATTERNS = (
     re.compile(
@@ -710,7 +723,96 @@ def escape_telegram_markdown(text):
     return escaped
 
 
-def send_to_telegram(text):
+def telegram_buttons_available():
+    """Return True when inline approval buttons can be safely rendered."""
+    return bool(
+        DIALPAD_TELEGRAM_APPROVAL_BUTTONS_ENABLED
+        and TELEGRAM_BOT_TOKEN
+        and TELEGRAM_CHAT_ID
+        and TELEGRAM_WEBHOOK_SECRET
+    )
+
+
+def build_telegram_callback_data(action, draft_id):
+    """Build compact Telegram callback data and enforce Bot API length limits."""
+    if not action or not draft_id:
+        return None
+    callback_data = f"{TELEGRAM_CALLBACK_NAMESPACE}:{action}:{draft_id}"
+    if len(callback_data.encode("utf-8")) > TELEGRAM_CALLBACK_MAX_BYTES:
+        return None
+    return callback_data
+
+
+def parse_telegram_callback_data(callback_data):
+    """Parse SMS approval callback data into an action and draft id."""
+    parts = str(callback_data or "").split(":", 2)
+    if len(parts) != 3 or parts[0] != TELEGRAM_CALLBACK_NAMESPACE:
+        return None
+    action, draft_id = parts[1], parts[2]
+    if action not in {
+        TELEGRAM_CALLBACK_APPROVE,
+        TELEGRAM_CALLBACK_REJECT,
+        TELEGRAM_CALLBACK_CONFIRM_RISK,
+    }:
+        return None
+    if not draft_id.startswith("smsdraft_"):
+        return None
+    return {"action": action, "draft_id": draft_id}
+
+
+def build_sms_approval_reply_markup(draft_id, reply_policy=None, *, risk_confirmation=False):
+    """Build Telegram InlineKeyboardMarkup for an SMS approval draft."""
+    if not telegram_buttons_available() or not draft_id:
+        return None
+
+    approve_action = TELEGRAM_CALLBACK_CONFIRM_RISK if risk_confirmation else TELEGRAM_CALLBACK_APPROVE
+    approve_data = build_telegram_callback_data(approve_action, draft_id)
+    reject_data = build_telegram_callback_data(TELEGRAM_CALLBACK_REJECT, draft_id)
+    if not approve_data or not reject_data:
+        return None
+
+    reply_policy = reply_policy or {}
+    risk_state = reply_policy.get("state")
+    if risk_confirmation:
+        approve_label = "Confirm send"
+    elif risk_state == "risky":
+        approve_label = "Acknowledge risk"
+    else:
+        approve_label = "Approve send"
+
+    return {
+        "inline_keyboard": [
+            [
+                {"text": approve_label, "callback_data": approve_data},
+                {"text": "Reject", "callback_data": reject_data},
+            ]
+        ]
+    }
+
+
+def call_telegram_api(method, payload, *, timeout=10):
+    """Call Telegram Bot API and return True on success."""
+    if not TELEGRAM_BOT_TOKEN:
+        print("⚠️  Telegram not configured (missing BOT_TOKEN)")
+        return False
+
+    url = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/{method}"
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout):
+            return True
+    except Exception as e:
+        print(f"❌ Error calling Telegram {method}: {e}")
+        return False
+
+
+def send_to_telegram(text, reply_markup=None):
     """
     Send a message to the configured Telegram channel.
     Returns True on success, False on failure (non-blocking).
@@ -719,25 +821,190 @@ def send_to_telegram(text):
         print("⚠️  Telegram not configured (missing BOT_TOKEN or CHAT_ID)")
         return False
 
-    url = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendMessage"
     payload = {
         "chat_id": TELEGRAM_CHAT_ID,
         "text": text,
         "parse_mode": "Markdown"
     }
-    data = json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(
-        url,
-        data=data,
-        headers={"Content-Type": "application/json"}
+    if reply_markup:
+        payload["reply_markup"] = reply_markup
+
+    return call_telegram_api("sendMessage", payload)
+
+
+def answer_telegram_callback(callback_query_id, text=None, *, show_alert=False):
+    """Stop Telegram's callback spinner and optionally show operator feedback."""
+    if not callback_query_id:
+        return False
+    payload = {
+        "callback_query_id": callback_query_id,
+        "show_alert": show_alert,
+    }
+    if text:
+        payload["text"] = str(text)[:200]
+    return call_telegram_api("answerCallbackQuery", payload, timeout=5)
+
+
+def edit_telegram_message_reply_markup(chat_id, message_id, reply_markup=None):
+    """Replace or remove a Telegram message inline keyboard."""
+    if chat_id is None or message_id is None:
+        return False
+    payload = {
+        "chat_id": chat_id,
+        "message_id": message_id,
+    }
+    if reply_markup is not None:
+        payload["reply_markup"] = reply_markup
+    return call_telegram_api("editMessageReplyMarkup", payload, timeout=5)
+
+
+def edit_telegram_message_text(chat_id, message_id, text, reply_markup=None):
+    """Edit Telegram review message text and optional inline keyboard."""
+    if chat_id is None or message_id is None:
+        return False
+    payload = {
+        "chat_id": chat_id,
+        "message_id": message_id,
+        "text": text,
+        "parse_mode": "Markdown",
+    }
+    if reply_markup:
+        payload["reply_markup"] = reply_markup
+    return call_telegram_api("editMessageText", payload, timeout=5)
+
+
+def build_telegram_callback_status_message(result, draft_id):
+    """Build visible group status for a Telegram approval callback result."""
+    result = result or {}
+    status = result.get("status") or "unknown"
+    draft = result.get("draft") or {}
+    resolved_draft_id = draft.get("draft_id") or draft_id or "unknown"
+    escaped_draft_id = escape_telegram_markdown(resolved_draft_id)
+
+    if result.get("sent"):
+        sms_id = result.get("dialpad_sms_id") or draft.get("dialpad_sms_id") or "unknown"
+        return (
+            "✅ *SMS approval sent*\n"
+            f"*Draft ID:* `{escaped_draft_id}`\n"
+            f"*Dialpad SMS ID:* `{escape_telegram_markdown(sms_id)}`"
+        )
+    if status == "risky_confirmation_required":
+        reason = result.get("risk_reason") or draft.get("risk_reason") or "risk policy matched"
+        return (
+            "⚠️ *Risk acknowledged \\(not sent\\)*\n"
+            f"*Draft ID:* `{escaped_draft_id}`\n"
+            f"*Risk:* {escape_telegram_markdown(reason)}\n"
+            "Tap *Confirm send* to send this exact draft."
+        )
+    if status == "rejected":
+        return (
+            "🚫 *SMS approval rejected \\(not sent\\)*\n"
+            f"*Draft ID:* `{escaped_draft_id}`"
+        )
+    if status == "already_resolved":
+        return (
+            "ℹ️ *SMS approval already resolved*\n"
+            f"*Draft ID:* `{escaped_draft_id}`"
+        )
+
+    reason = result.get("reason") or result.get("error") or status
+    return (
+        "⛔ *SMS approval not sent*\n"
+        f"*Draft ID:* `{escaped_draft_id}`\n"
+        f"*Reason:* {escape_telegram_markdown(reason)}"
     )
 
+
+def callback_answer_text(result):
+    """Build short Telegram toast text for callback query responses."""
+    result = result or {}
+    if result.get("sent"):
+        return "Sent."
+    status = result.get("status")
+    if status == "risky_confirmation_required":
+        return "Risk acknowledged. Confirm send required."
+    if status == "rejected":
+        return "Rejected. Not sent."
+    if status == "already_resolved":
+        return "Already resolved."
+    reason = result.get("reason") or result.get("error") or status or "Not sent."
+    return f"Not sent: {reason}"
+
+
+def update_telegram_review_after_callback(callback_query, result, draft_id):
+    """Update Telegram controls and post a visible status after a callback."""
+    message = callback_query.get("message") or {}
+    chat = message.get("chat") or {}
+    chat_id = chat.get("id")
+    message_id = message.get("message_id")
+    status = (result or {}).get("status")
+
+    if status == "risky_confirmation_required":
+        reply_markup = build_sms_approval_reply_markup(
+            draft_id,
+            {"state": "risky"},
+            risk_confirmation=True,
+        )
+        edit_telegram_message_reply_markup(chat_id, message_id, reply_markup=reply_markup)
+    else:
+        edit_telegram_message_reply_markup(chat_id, message_id, reply_markup=None)
+
+    return send_to_telegram(build_telegram_callback_status_message(result, draft_id))
+
+
+def dispatch_telegram_approval_callback(callback_query, parsed_callback):
+    """Execute an authenticated Telegram approval callback against the approval ledger."""
+    if sms_approval is None:
+        return {
+            "ok": False,
+            "status": "approval_unavailable",
+            "sent": False,
+            "reason": "approval module unavailable",
+        }
+
+    actor = callback_query.get("from") or {}
+    actor_id = str(actor.get("id") or "")
+    actor_username = actor.get("username")
+    actor_is_bot = bool(actor.get("is_bot"))
+    draft_id = parsed_callback["draft_id"]
+    action = parsed_callback["action"]
+
     try:
-        with urllib.request.urlopen(req, timeout=10) as response:
-            return True
-    except Exception as e:
-        print(f"❌ Error sending to Telegram: {e}")
-        return False
+        conn = sms_approval.init_db()
+        try:
+            if action == TELEGRAM_CALLBACK_REJECT:
+                return sms_approval.reject_draft(
+                    conn,
+                    draft_id=draft_id,
+                    actor_id=actor_id,
+                    actor_username=actor_username,
+                    actor_is_bot=actor_is_bot,
+                )
+            approval_action = (
+                sms_approval.ACTION_CONFIRM_RISK
+                if action == TELEGRAM_CALLBACK_CONFIRM_RISK
+                else sms_approval.ACTION_APPROVE
+            )
+            return sms_approval.approve_draft(
+                conn,
+                draft_id=draft_id,
+                actor_id=actor_id,
+                actor_username=actor_username,
+                actor_is_bot=actor_is_bot,
+                action=approval_action,
+                send_func=dialpad_send_sms,
+            )
+        finally:
+            conn.close()
+    except Exception as exc:  # noqa: BLE001 - callbacks must fail closed.
+        print(f"⚠️  Telegram approval callback failed ({type(exc).__name__})")
+        return {
+            "ok": False,
+            "status": "callback_failed",
+            "sent": False,
+            "reason": str(exc),
+            "draft": {"draft_id": draft_id},
+        }
 
 
 def _get_header(headers, name):
@@ -1324,24 +1591,37 @@ def build_approval_review_suffix(draft_id, draft_message, reply_policy=None):
 
     reply_policy = reply_policy or {}
     risk_state = reply_policy.get("state")
+    buttons_enabled = build_sms_approval_reply_markup(draft_id, reply_policy) is not None
     lines = [
         "",
         "",
         "📝 *SMS approval draft \\(not sent\\)*",
         f"*Draft ID:* `{escape_telegram_markdown(draft_id)}`",
         f"*Exact text:*\n{escape_telegram_markdown(draft_message)}",
-        "",
-        f"Approve from an operator shell: `bin/approve_sms_draft.py {escape_telegram_markdown(draft_id)} --actor-id <human-id> --approval-token \"$DIALPAD_SMS_APPROVAL_TOKEN\" --json`",
     ]
+    if buttons_enabled:
+        lines.extend(["", "Use the Telegram buttons below to approve or reject this exact draft."])
+    else:
+        lines.extend(
+            [
+                "",
+                f"Approve from an operator shell: `bin/approve_sms_draft.py {escape_telegram_markdown(draft_id)} --actor-id <human-id> --approval-token \"$DIALPAD_SMS_APPROVAL_TOKEN\" --json`",
+            ]
+        )
     if risk_state == "risky":
         reason = reply_policy.get("risk_reason") or "risk policy matched"
         lines.extend(
             [
                 "",
                 f"⚠️ *Risk:* {escape_telegram_markdown(reason)}",
-                f"Second confirmation required: `bin/approve_sms_draft.py {escape_telegram_markdown(draft_id)} --action confirm-risk --actor-id <human-id> --approval-token \"$DIALPAD_SMS_APPROVAL_TOKEN\" --json`",
             ]
         )
+        if buttons_enabled:
+            lines.append("Approval is two-step: first acknowledge risk, then confirm send.")
+        else:
+            lines.append(
+                f"Second confirmation required: `bin/approve_sms_draft.py {escape_telegram_markdown(draft_id)} --action confirm-risk --actor-id <human-id> --approval-token \"$DIALPAD_SMS_APPROVAL_TOKEN\" --json`"
+            )
     return "\n".join(lines)
 
 
@@ -1696,6 +1976,11 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
             self.handle_webhook()
             return
 
+        # /webhook/telegram - Telegram inline approval callbacks
+        if self.path == "/webhook/telegram":
+            self.handle_telegram_webhook()
+            return
+
         # /webhook/dialpad-call - missed call notifications
         if self.path == "/webhook/dialpad-call":
             self.handle_call_webhook()
@@ -1707,6 +1992,93 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
             return
 
         self.send_error(404, "Not Found")
+
+    def send_json_response(self, status_code, payload):
+        """Send a JSON response."""
+        self.send_response(status_code)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(payload).encode())
+
+    def read_json_body(self, endpoint_label):
+        """Read a bounded JSON request body."""
+        max_body_size = 1024 * 1024
+        try:
+            requested_length = int(self.headers.get("Content-Length", 0))
+        except (TypeError, ValueError):
+            requested_length = 0
+        content_length = min(requested_length, max_body_size)
+        raw_body = self.rfile.read(content_length)
+        try:
+            return raw_body, json.loads(raw_body.decode("utf-8")) if raw_body else {}
+        except json.JSONDecodeError as exc:
+            print(f"❌ Invalid JSON payload on {endpoint_label}: {exc}")
+            return raw_body, None
+
+    def handle_telegram_webhook(self):
+        """Handle Telegram inline button callback updates."""
+        _raw_body, data = self.read_json_body("/webhook/telegram")
+        if data is None:
+            self.send_error(400, "Invalid JSON")
+            return
+
+        if not TELEGRAM_WEBHOOK_SECRET:
+            log_line("❌ Telegram webhook secret is not configured")
+            self.send_json_response(503, {"status": "misconfigured", "reason": "secret_missing"})
+            return
+
+        provided_secret = _get_header(self.headers, "X-Telegram-Bot-Api-Secret-Token")
+        if not provided_secret or not hmac.compare_digest(
+            str(provided_secret),
+            str(TELEGRAM_WEBHOOK_SECRET),
+        ):
+            log_line("❌ Unauthorized Telegram webhook request")
+            self.send_error(401, "Unauthorized")
+            return
+
+        callback_query = data.get("callback_query")
+        if not isinstance(callback_query, dict):
+            self.send_json_response(200, {"status": "ignored", "reason": "not_callback_query"})
+            return
+
+        message = callback_query.get("message") or {}
+        chat = message.get("chat") or {}
+        chat_id = chat.get("id")
+        if str(chat_id) != str(TELEGRAM_CHAT_ID):
+            answer_telegram_callback(
+                callback_query.get("id"),
+                "This approval button is not valid in this chat.",
+                show_alert=True,
+            )
+            self.send_error(403, "Forbidden")
+            return
+
+        parsed = parse_telegram_callback_data(callback_query.get("data"))
+        if not parsed:
+            answer_telegram_callback(
+                callback_query.get("id"),
+                "Invalid approval action.",
+                show_alert=True,
+            )
+            self.send_json_response(200, {"status": "invalid_callback"})
+            return
+
+        result = dispatch_telegram_approval_callback(callback_query, parsed)
+        answer_telegram_callback(
+            callback_query.get("id"),
+            callback_answer_text(result),
+            show_alert=not bool(result.get("ok")),
+        )
+        update_telegram_review_after_callback(callback_query, result, parsed["draft_id"])
+        self.send_json_response(
+            200,
+            {
+                "status": "ok",
+                "approval_status": result.get("status"),
+                "sent": bool(result.get("sent")),
+                "draft_id": parsed["draft_id"],
+            },
+        )
 
     def handle_store(self):
         """Handle /store endpoint - stores message in SQLite, called by OpenClaw plugin"""
@@ -1916,7 +2288,12 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                     reply_policy,
                 )
                 tg_text += build_human_only_blocked_suffix(reply_policy)
-                telegram_sms_sent = send_to_telegram(tg_text)
+                reply_markup = build_sms_approval_reply_markup(auto_reply_draft_id, reply_policy)
+                telegram_sms_sent = (
+                    send_to_telegram(tg_text, reply_markup=reply_markup)
+                    if reply_markup
+                    else send_to_telegram(tg_text)
+                )
                 telegram_status = TELEGRAM_STATUS_SENT if telegram_sms_sent else TELEGRAM_STATUS_FAILED
             elif hook_status == "filtered_opt_out":
                 tg_text = (
@@ -2130,7 +2507,12 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                 reply_policy,
             )
             tg_text += build_human_only_blocked_suffix(reply_policy)
-            telegram_sent = send_to_telegram(tg_text)
+            reply_markup = build_sms_approval_reply_markup(auto_reply_draft_id, reply_policy)
+            telegram_sent = (
+                send_to_telegram(tg_text, reply_markup=reply_markup)
+                if reply_markup
+                else send_to_telegram(tg_text)
+            )
 
             print(f"[{datetime.now().isoformat()}]")
             print(f"   📞 MISSED CALL: {from_num} -> {to_display}")
@@ -2282,7 +2664,12 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
             reply_policy,
         )
         tg_text += build_human_only_blocked_suffix(reply_policy)
-        telegram_sent = send_to_telegram(tg_text)
+        reply_markup = build_sms_approval_reply_markup(auto_reply_draft_id, reply_policy)
+        telegram_sent = (
+            send_to_telegram(tg_text, reply_markup=reply_markup)
+            if reply_markup
+            else send_to_telegram(tg_text)
+        )
 
         print(f"[{datetime.now().isoformat()}]")
         print(f"   📬 VOICEMAIL: {from_num} -> {to_display}")
@@ -2326,6 +2713,7 @@ def main():
     print(f"Port: {PORT}")
     print(f"Endpoints:")
     print(f"  - POST /webhook/dialpad (main webhook)")
+    print(f"  - POST /webhook/telegram (Telegram approval callbacks)")
     print(f"  - POST /webhook/dialpad-call (missed call webhook)")
     print(f"  - POST /webhook/dialpad-voicemail (voicemail webhook)")
     print(f"  - GET  /health (health check)")
@@ -2335,6 +2723,7 @@ def main():
     print(f"  - OpenClaw Gateway URL: {OPENCLAW_GATEWAY_URL}")
     print(f"  - OpenClaw Hooks Path: {OPENCLAW_HOOKS_PATH}")
     print(f"  - OpenClaw Hooks Token: {'✓' if OPENCLAW_HOOKS_TOKEN else '✗ (hook forwarding disabled)'}")
+    print(f"  - Telegram Approval Buttons: {'✓' if telegram_buttons_available() else '✗ (disabled or incomplete config)'}")
     print(f"  - OpenClaw Hooks Name: {OPENCLAW_HOOKS_NAME}")
     print(f"  - OpenClaw Call Hooks Name: {OPENCLAW_HOOKS_CALL_NAME}")
     print(f"  - OpenClaw Hooks Channel: {OPENCLAW_HOOKS_CHANNEL or '(unset)'}")

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -316,6 +316,46 @@ def _flatten_strings(value, out):
             _flatten_strings(nested, out)
 
 
+def contact_contains_phone(contact, phone_number):
+    """Return True only when a Dialpad contact payload includes the queried phone."""
+    expected = normalize_phone_number(phone_number)
+    if not expected or not isinstance(contact, dict):
+        return False
+
+    values = []
+    for key in ("phones", "phone_numbers", "primary_phone", "phone", "number", "numbers"):
+        _flatten_strings(contact.get(key), values)
+
+    for value in values:
+        if normalize_phone_number(value) == expected:
+            return True
+    return False
+
+
+def format_contact_enrichment(contact):
+    """Build sender enrichment fields from a verified Dialpad contact."""
+    first_name = str(contact.get("first_name", "") or "").strip()
+    last_name = str(contact.get("last_name", "") or "").strip()
+    company = str(contact.get("company", "") or "").strip()
+    title = str(contact.get("job_title", "") or "").strip()
+    name = f"{first_name} {last_name}".strip()
+    info = name or "Known Contact"
+    if company:
+        info += f" ({company})"
+    if title:
+        info = f"{title} | {info}"
+    return {
+        "contact_name": info,
+        "first_name": first_name or None,
+        "last_name": last_name or None,
+        "company": company or None,
+        "job_title": title or None,
+        "status": "resolved",
+        "degraded": False,
+        "degraded_reason": None,
+    }
+
+
 def _extract_unauthorized_hint_text(raw_body):
     """Decode 401 body into searchable hint text (never logged directly)."""
     if not raw_body:
@@ -408,24 +448,10 @@ def lookup_contact_enrichment(phone_number):
         with urllib.request.urlopen(req, timeout=5) as response:
             data = json.loads(response.read().decode())
             items = data.get("items", [])
-            if items:
-                c = items[0]
-                first_name = str(c.get("first_name", "") or "").strip()
-                last_name = str(c.get("last_name", "") or "").strip()
-                company = str(c.get("company", "") or "").strip()
-                title = str(c.get("job_title", "") or "").strip()
-                name = f"{first_name} {last_name}".strip()
-                info = name or "Known Contact"
-                if company:
-                    info += f" ({company})"
-                if title:
-                    info = f"{title} | {info}"
-                result["contact_name"] = info
-                result["first_name"] = first_name or None
-                result["last_name"] = last_name or None
-                result["company"] = company or None
-                result["job_title"] = title or None
-                result["status"] = "resolved"
+            for contact in items:
+                if contact_contains_phone(contact, phone_value):
+                    result.update(format_contact_enrichment(contact))
+                    break
             return result
     except urllib.error.HTTPError as e:
         if e.code == 401:

--- a/systemd/dialpad-webhook.service
+++ b/systemd/dialpad-webhook.service
@@ -7,7 +7,7 @@ Type=simple
 WorkingDirectory=%h/projects/skills/work/dialpad
 EnvironmentFile=%h/projects/skills/work/dialpad/.env
 # NOTE: Adjust Python path to your system (e.g., /usr/bin/python3, ~/.nix-profile/bin/python3)
-ExecStart=%h/.linuxbrew/bin/python3 %h/projects/skills/work/dialpad/webhook_server.py
+ExecStart=%h/.linuxbrew/bin/python3 %h/projects/skills/work/dialpad/scripts/webhook_server.py
 Restart=always
 RestartSec=5
 StandardOutput=journal

--- a/tests/test_openclaw_integration_docs.py
+++ b/tests/test_openclaw_integration_docs.py
@@ -42,3 +42,19 @@ def test_openclaw_docs_require_sms_approval_drafts_not_autonomous_send():
     assert "explicit opt-out language creates no draft" in readme
     assert "explicit opt-out language creates no draft" in api_reference
     assert "autonomous sms send is not supported" in integration
+
+
+def test_openclaw_docs_require_telegram_inline_button_safety_preflight():
+    readme = (ROOT / "README.md").read_text().lower()
+    integration = (ROOT / "references/openclaw-integration.md").read_text().lower()
+
+    assert "dialpad_telegram_approval_buttons_enabled" in readme
+    assert "telegram_webhook_secret" in readme
+    assert "getwebhookinfo" in readme
+    assert "getupdates" in readme
+    assert "x-telegram-bot-api-secret-token" in readme
+    assert "wrong-chat" in integration or "wrong chat" in integration
+    assert "getwebhookinfo" in integration
+    assert "getupdates" in integration
+    assert "x-telegram-bot-api-secret-token" in integration
+    assert "smsdraft_*" in integration

--- a/tests/test_sender_enrichment.py
+++ b/tests/test_sender_enrichment.py
@@ -72,6 +72,7 @@ def test_lookup_contact_enrichment_valid_token_path(monkeypatch):
                 "last_name": "Doe",
                 "company": "Acme",
                 "job_title": "VP Sales",
+                "phones": ["+14155550123"],
             }
         ]
     }

--- a/tests/test_sms_approval.py
+++ b/tests/test_sms_approval.py
@@ -90,6 +90,39 @@ class SmsApprovalTests(unittest.TestCase):
         self.assertEqual(result["status"], "stale")
         self.assertEqual(result["reason"], "newer_inbound")
 
+    def test_reject_draft_marks_exact_draft_rejected_without_sending(self):
+        draft = self._draft()
+
+        result = sms_approval.reject_draft(
+            self.conn,
+            draft_id=draft["draft_id"],
+            actor_id="12345",
+            actor_username="operator",
+            rejected_at_ms=1000,
+        )
+
+        self.assertFalse(result["sent"])
+        self.assertEqual(result["status"], sms_approval.STATUS_REJECTED)
+        stored = sms_approval.get_draft(self.conn, draft["draft_id"])
+        self.assertEqual(stored["status"], sms_approval.STATUS_REJECTED)
+        self.assertEqual(stored["invalidated_reason"], "operator_rejected")
+        self.assertEqual(stored["rejected_by"], "12345")
+        self.assertEqual(stored["rejected_username"], "operator")
+        self.assertEqual(stored["rejected_at_ms"], 1000)
+
+    def test_reject_draft_rejects_bot_actor_without_mutating(self):
+        draft = self._draft()
+
+        result = sms_approval.reject_draft(
+            self.conn,
+            draft_id=draft["draft_id"],
+            actor_id="bot",
+        )
+
+        self.assertEqual(result["status"], "blocked_actor")
+        stored = sms_approval.get_draft(self.conn, draft["draft_id"])
+        self.assertEqual(stored["status"], sms_approval.STATUS_PENDING)
+
     def test_risky_draft_requires_second_confirmation(self):
         draft = self._draft(
             risk_state=sms_approval.RISK_RISKY,

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import sys
 import unittest
 from unittest.mock import patch
+import urllib.request
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "scripts"))
@@ -107,6 +108,81 @@ class WebhookNotificationClassificationTests(unittest.TestCase):
     def test_non_sensitive_message_not_detected(self):
         text = "See you at 6pm for dinner."
         self.assertFalse(is_sensitive_message(text=text, sender="Friend"))
+
+    def test_contact_match_requires_exact_phone(self):
+        contact = {
+            "first_name": "Keysha",
+            "last_name": "Griffin",
+            "phones": ["+17202248024"],
+            "primary_phone": "+17202248024",
+        }
+
+        self.assertFalse(webhook_server.contact_contains_phone(contact, "+14782326499"))
+        self.assertTrue(webhook_server.contact_contains_phone(contact, "+17202248024"))
+
+    def test_lookup_ignores_fuzzy_contact_without_matching_phone(self):
+        payload = {
+            "items": [
+                {
+                    "first_name": "Keysha",
+                    "last_name": "Griffin",
+                    "phones": ["+17202248024"],
+                    "primary_phone": "+17202248024",
+                }
+            ]
+        }
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return json.dumps(payload).encode()
+
+        with patch.object(webhook_server, "DIALPAD_API_KEY", "token"), patch.object(
+            urllib.request,
+            "urlopen",
+            return_value=FakeResponse(),
+        ):
+            result = webhook_server.lookup_contact_enrichment("+14782326499")
+
+        self.assertEqual(result["status"], "not_found")
+        self.assertIsNone(result["contact_name"])
+
+    def test_lookup_resolves_contact_with_matching_phone(self):
+        payload = {
+            "items": [
+                {
+                    "first_name": "Nicole",
+                    "last_name": "Roberson",
+                    "phones": ["+14782326499"],
+                    "primary_phone": "+14782326499",
+                }
+            ]
+        }
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return json.dumps(payload).encode()
+
+        with patch.object(webhook_server, "DIALPAD_API_KEY", "token"), patch.object(
+            urllib.request,
+            "urlopen",
+            return_value=FakeResponse(),
+        ):
+            result = webhook_server.lookup_contact_enrichment("+14782326499")
+
+        self.assertEqual(result["status"], "resolved")
+        self.assertEqual(result["contact_name"], "Nicole Roberson")
 
     def test_inbound_alert_eligibility_filters_sensitive_sms(self):
         payload = {

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -659,6 +659,28 @@ class TelegramCallbackHandlerTests(unittest.TestCase):
         self.assertEqual(send_calls, [])
         self.assertEqual(stored["status"], "rejected")
 
+    def test_non_terminal_actor_failure_keeps_existing_approval_buttons(self):
+        callback_query = {
+            "message": {"message_id": 99, "chat": {"id": "-100123"}},
+        }
+
+        with patch.object(webhook_server, "edit_telegram_message_reply_markup") as edit_markup, \
+                patch.object(webhook_server, "send_to_telegram", return_value=True) as send_status:
+            webhook_server.update_telegram_review_after_callback(
+                callback_query,
+                {
+                    "ok": False,
+                    "status": "actor_not_allowed",
+                    "sent": False,
+                    "reason": "actor_not_in_allowlist",
+                    "draft": {"draft_id": "smsdraft_1234567890abcdef"},
+                },
+                "smsdraft_1234567890abcdef",
+            )
+
+        edit_markup.assert_not_called()
+        send_status.assert_called_once()
+
 
 class CallWebhookHandlerTests(unittest.TestCase):
     class _FakeMoment:

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -54,6 +54,26 @@ def _build_handler(payload, headers=None):
     return handler, status
 
 
+def _telegram_callback_payload(draft_id, action="a", chat_id="-100123", user_id=42, is_bot=False):
+    return {
+        "update_id": 1,
+        "callback_query": {
+            "id": "callback-1",
+            "from": {
+                "id": user_id,
+                "is_bot": is_bot,
+                "username": "operator",
+            },
+            "message": {
+                "message_id": 99,
+                "chat": {"id": chat_id, "type": "group"},
+                "text": "review",
+            },
+            "data": f"smsa:{action}:{draft_id}",
+        },
+    }
+
+
 class WebhookNotificationClassificationTests(unittest.TestCase):
     def test_normal_inbound_sms_classified_as_sms(self):
         payload = {
@@ -238,6 +258,77 @@ class WebhookNotificationClassificationTests(unittest.TestCase):
         self.assertEqual(extract_message_text(payload), "Real body")
         self.assertEqual(classify_inbound_notification(payload), "sms")
 
+    def test_sms_approval_reply_markup_uses_compact_callback_data(self):
+        with patch.object(webhook_server, "DIALPAD_TELEGRAM_APPROVAL_BUTTONS_ENABLED", True), \
+                patch.object(webhook_server, "TELEGRAM_BOT_TOKEN", "bot-token"), \
+                patch.object(webhook_server, "TELEGRAM_CHAT_ID", "-100123"), \
+                patch.object(webhook_server, "TELEGRAM_WEBHOOK_SECRET", "secret"):
+            markup = webhook_server.build_sms_approval_reply_markup(
+                "smsdraft_1234567890abcdef",
+                {"state": "normal"},
+            )
+
+        self.assertEqual(markup["inline_keyboard"][0][0]["text"], "Approve send")
+        callback_data = markup["inline_keyboard"][0][0]["callback_data"]
+        self.assertEqual(callback_data, "smsa:a:smsdraft_1234567890abcdef")
+        self.assertLessEqual(len(callback_data.encode("utf-8")), 64)
+
+    def test_sms_approval_reply_markup_disabled_without_webhook_secret(self):
+        with patch.object(webhook_server, "DIALPAD_TELEGRAM_APPROVAL_BUTTONS_ENABLED", True), \
+                patch.object(webhook_server, "TELEGRAM_BOT_TOKEN", "bot-token"), \
+                patch.object(webhook_server, "TELEGRAM_CHAT_ID", "-100123"), \
+                patch.object(webhook_server, "TELEGRAM_WEBHOOK_SECRET", ""):
+            markup = webhook_server.build_sms_approval_reply_markup(
+                "smsdraft_1234567890abcdef",
+                {"state": "normal"},
+            )
+
+        self.assertIsNone(markup)
+
+    def test_risky_sms_approval_reply_markup_requires_acknowledgement_first(self):
+        with patch.object(webhook_server, "DIALPAD_TELEGRAM_APPROVAL_BUTTONS_ENABLED", True), \
+                patch.object(webhook_server, "TELEGRAM_BOT_TOKEN", "bot-token"), \
+                patch.object(webhook_server, "TELEGRAM_CHAT_ID", "-100123"), \
+                patch.object(webhook_server, "TELEGRAM_WEBHOOK_SECRET", "secret"):
+            markup = webhook_server.build_sms_approval_reply_markup(
+                "smsdraft_1234567890abcdef",
+                {"state": "risky"},
+            )
+
+        self.assertEqual(markup["inline_keyboard"][0][0]["text"], "Acknowledge risk")
+        self.assertEqual(
+            markup["inline_keyboard"][0][0]["callback_data"],
+            "smsa:a:smsdraft_1234567890abcdef",
+        )
+
+    def test_parse_telegram_callback_data_rejects_unknown_namespace(self):
+        self.assertIsNone(webhook_server.parse_telegram_callback_data("other:a:smsdraft_1"))
+
+    def test_send_to_telegram_includes_reply_markup_payload(self):
+        requests = []
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+        def fake_urlopen(request, timeout=10):
+            requests.append(json.loads(request.data.decode("utf-8")))
+            return FakeResponse()
+
+        reply_markup = {
+            "inline_keyboard": [[{"text": "Approve send", "callback_data": "smsa:a:smsdraft_1"}]]
+        }
+        with patch.object(webhook_server, "TELEGRAM_BOT_TOKEN", "bot-token"), \
+                patch.object(webhook_server, "TELEGRAM_CHAT_ID", "-100123"), \
+                patch.object(urllib.request, "urlopen", side_effect=fake_urlopen):
+            sent = webhook_server.send_to_telegram("Review", reply_markup=reply_markup)
+
+        self.assertTrue(sent)
+        self.assertEqual(requests[0]["reply_markup"], reply_markup)
+
 
 class MissedCallResolutionTests(unittest.TestCase):
     def test_sparse_payload_nested_key_resolution(self):
@@ -390,6 +481,183 @@ class MissedCallResolutionTests(unittest.TestCase):
         resolved = resolve_missed_call_context(payload, history_fetcher=fake_history)
         self.assertIsNone(resolved["to_number"])
         self.assertEqual(resolved["line_resolution_path"], "unresolved")
+
+
+class TelegramCallbackHandlerTests(unittest.TestCase):
+    def test_telegram_callback_requires_secret(self):
+        payload = _telegram_callback_payload("smsdraft_1234567890abcdef")
+        with patch.object(webhook_server, "TELEGRAM_WEBHOOK_SECRET", "secret"), \
+                patch.object(webhook_server, "TELEGRAM_CHAT_ID", "-100123"):
+            handler, status = _build_handler(payload)
+            webhook_server.DialpadWebhookHandler.handle_telegram_webhook(handler)
+
+        self.assertEqual(status["code"], 401)
+
+    def test_telegram_callback_rejects_wrong_chat_without_dispatch(self):
+        payload = _telegram_callback_payload("smsdraft_1234567890abcdef", chat_id="-100999")
+        with patch.object(webhook_server, "TELEGRAM_WEBHOOK_SECRET", "secret"), \
+                patch.object(webhook_server, "TELEGRAM_CHAT_ID", "-100123"), \
+                patch.object(webhook_server, "answer_telegram_callback", return_value=True) as answer, \
+                patch.object(webhook_server, "dispatch_telegram_approval_callback") as dispatch:
+            handler, status = _build_handler(
+                payload,
+                headers={"X-Telegram-Bot-Api-Secret-Token": "secret"},
+            )
+            webhook_server.DialpadWebhookHandler.handle_telegram_webhook(handler)
+
+        self.assertEqual(status["code"], 403)
+        answer.assert_called_once()
+        dispatch.assert_not_called()
+
+    def test_telegram_callback_approve_sends_exact_stored_draft(self):
+        send_calls = []
+        telegram_api_calls = []
+
+        with tempfile.TemporaryDirectory() as temp_dir, \
+                patch.object(webhook_server.sms_approval, "DB_PATH", Path(temp_dir) / "approvals.db"), \
+                patch.object(webhook_server, "TELEGRAM_WEBHOOK_SECRET", "secret"), \
+                patch.object(webhook_server, "TELEGRAM_CHAT_ID", "-100123"), \
+                patch.object(webhook_server, "TELEGRAM_BOT_TOKEN", "bot-token"), \
+                patch.object(
+                    webhook_server,
+                    "dialpad_send_sms",
+                    side_effect=lambda to_numbers, message, from_number=None: send_calls.append(
+                        (to_numbers, message, from_number)
+                    ) or {"id": "sms-1", "message_status": "pending"},
+                ), \
+                patch.object(
+                    webhook_server,
+                    "call_telegram_api",
+                    side_effect=lambda method, payload, timeout=10: telegram_api_calls.append(
+                        (method, payload)
+                    ) or True,
+                ):
+            conn = webhook_server.sms_approval.init_db()
+            try:
+                draft = webhook_server.sms_approval.create_draft(
+                    conn,
+                    thread_key="thread-1",
+                    customer_number="+15125550100",
+                    sender_number="+14155201316",
+                    draft_text="Stored exact text.",
+                )
+            finally:
+                conn.close()
+
+            handler, status = _build_handler(
+                _telegram_callback_payload(draft["draft_id"], action="a"),
+                headers={"X-Telegram-Bot-Api-Secret-Token": "secret"},
+            )
+            webhook_server.DialpadWebhookHandler.handle_telegram_webhook(handler)
+
+        response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+        self.assertEqual(status["code"], 200)
+        self.assertTrue(response["sent"])
+        self.assertEqual(send_calls, [(["+15125550100"], "Stored exact text.", "+14155201316")])
+        self.assertIn("answerCallbackQuery", [method for method, _payload in telegram_api_calls])
+        self.assertIn("editMessageReplyMarkup", [method for method, _payload in telegram_api_calls])
+        self.assertIn("sendMessage", [method for method, _payload in telegram_api_calls])
+
+    def test_telegram_callback_risky_first_click_replaces_markup_without_send(self):
+        send_calls = []
+        telegram_api_calls = []
+
+        with tempfile.TemporaryDirectory() as temp_dir, \
+                patch.object(webhook_server.sms_approval, "DB_PATH", Path(temp_dir) / "approvals.db"), \
+                patch.object(webhook_server, "DIALPAD_TELEGRAM_APPROVAL_BUTTONS_ENABLED", True), \
+                patch.object(webhook_server, "TELEGRAM_WEBHOOK_SECRET", "secret"), \
+                patch.object(webhook_server, "TELEGRAM_CHAT_ID", "-100123"), \
+                patch.object(webhook_server, "TELEGRAM_BOT_TOKEN", "bot-token"), \
+                patch.object(
+                    webhook_server,
+                    "dialpad_send_sms",
+                    side_effect=lambda *_args, **_kwargs: send_calls.append(True) or {"id": "sms-1"},
+                ), \
+                patch.object(
+                    webhook_server,
+                    "call_telegram_api",
+                    side_effect=lambda method, payload, timeout=10: telegram_api_calls.append(
+                        (method, payload)
+                    ) or True,
+                ):
+            conn = webhook_server.sms_approval.init_db()
+            try:
+                draft = webhook_server.sms_approval.create_draft(
+                    conn,
+                    thread_key="thread-1",
+                    customer_number="+15125550100",
+                    sender_number="+14155201316",
+                    draft_text="Stored exact text.",
+                    risk_state=webhook_server.sms_approval.RISK_RISKY,
+                    risk_reason="customer asked for a real person",
+                )
+            finally:
+                conn.close()
+
+            handler, status = _build_handler(
+                _telegram_callback_payload(draft["draft_id"], action="a"),
+                headers={"X-Telegram-Bot-Api-Secret-Token": "secret"},
+            )
+            webhook_server.DialpadWebhookHandler.handle_telegram_webhook(handler)
+
+        response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+        self.assertEqual(status["code"], 200)
+        self.assertFalse(response["sent"])
+        self.assertEqual(response["approval_status"], "risky_confirmation_required")
+        self.assertEqual(send_calls, [])
+        reply_markups = [
+            payload.get("reply_markup")
+            for method, payload in telegram_api_calls
+            if method == "editMessageReplyMarkup"
+        ]
+        self.assertEqual(
+            reply_markups[0]["inline_keyboard"][0][0]["callback_data"],
+            f"smsa:c:{draft['draft_id']}",
+        )
+
+    def test_telegram_callback_reject_marks_draft_rejected_without_send(self):
+        send_calls = []
+
+        with tempfile.TemporaryDirectory() as temp_dir, \
+                patch.object(webhook_server.sms_approval, "DB_PATH", Path(temp_dir) / "approvals.db"), \
+                patch.object(webhook_server, "TELEGRAM_WEBHOOK_SECRET", "secret"), \
+                patch.object(webhook_server, "TELEGRAM_CHAT_ID", "-100123"), \
+                patch.object(webhook_server, "TELEGRAM_BOT_TOKEN", "bot-token"), \
+                patch.object(
+                    webhook_server,
+                    "dialpad_send_sms",
+                    side_effect=lambda *_args, **_kwargs: send_calls.append(True) or {"id": "sms-1"},
+                ), \
+                patch.object(webhook_server, "call_telegram_api", return_value=True):
+            conn = webhook_server.sms_approval.init_db()
+            try:
+                draft = webhook_server.sms_approval.create_draft(
+                    conn,
+                    thread_key="thread-1",
+                    customer_number="+15125550100",
+                    sender_number="+14155201316",
+                    draft_text="Stored exact text.",
+                )
+            finally:
+                conn.close()
+
+            handler, status = _build_handler(
+                _telegram_callback_payload(draft["draft_id"], action="r"),
+                headers={"X-Telegram-Bot-Api-Secret-Token": "secret"},
+            )
+            webhook_server.DialpadWebhookHandler.handle_telegram_webhook(handler)
+            conn = webhook_server.sms_approval.init_db()
+            try:
+                stored = webhook_server.sms_approval.get_draft(conn, draft["draft_id"])
+            finally:
+                conn.close()
+
+        response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+        self.assertEqual(status["code"], 200)
+        self.assertFalse(response["sent"])
+        self.assertEqual(response["approval_status"], "rejected")
+        self.assertEqual(send_calls, [])
+        self.assertEqual(stored["status"], "rejected")
 
 
 class CallWebhookHandlerTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
Adds native Telegram inline approval controls for Dialpad SMS approval drafts while preserving the deterministic human-approval gate. Operators can approve, reject, or complete risky two-step confirmations from Telegram; callbacks validate Telegram's secret-token header, the configured chat, and the human actor before touching the approval ledger.

This PR also includes the already-deployed exact-phone contact-match hotfix because `origin/main` did not yet contain local commit `101b80d`; keeping it in this branch prevents the Telegram work from reintroducing the wrong-contact regression.

[size/exempt: implementation, tests, docs, and the durable plan ship together because the webhook callback endpoint is send-adjacent and needs safety coverage plus rollout instructions in the same review]

## What Changed
- Added Telegram inline keyboard generation for SMS approval drafts, with compact callback payloads that reference only `smsdraft_*` ids.
- Added `POST /webhook/telegram` for callback queries with `X-Telegram-Bot-Api-Secret-Token` validation and configured-chat enforcement.
- Routed approve, confirm-risk, and reject actions through `scripts/sms_approval.py`, including exact-draft rejection audit fields.
- Added visible Telegram status updates after sent, rejected, stale, blocked, risky-confirmation-required, and failed outcomes.
- Documented Telegram bot ownership preflight, webhook setup, reject-only smoke testing, and updated the systemd template to use `scripts/webhook_server.py`.

## Review
`ce:review` local review found no P0/P1/P2 issues after the implementation pass. Full sub-agent dispatch was not used because the current Codex tool policy requires explicit sub-agent authorization.

## Verification
- `python -m py_compile scripts/webhook_server.py scripts/sms_approval.py`
- `python -m pytest` -> `183 passed`
- `git diff --check`

## Post-Deploy Monitoring & Validation
- Pre-deploy: run Telegram bot ownership preflight with `getWebhookInfo`; do not enable `setWebhook` if another webhook or `getUpdates` owner is consuming the same bot.
- Validate: configure Telegram webhook with `allowed_updates=["callback_query"]`, `drop_pending_updates=true`, and `secret_token=$TELEGRAM_WEBHOOK_SECRET`.
- Smoke: send a fake/test inbound SMS, verify Telegram buttons render, click `Reject`, and confirm the draft status is rejected/stale in `sms_approvals.db`; do not approve smoke drafts unless using a controlled non-customer destination.
- Healthy logs: `/webhook/telegram`, `SMS approval sent`, `SMS approval rejected`, `risky_confirmation_required`, and normal `/health` responses.
- Failure signals: `Unauthorized Telegram webhook request`, wrong-chat 403s, repeated `callback_failed`, Telegram API edit/send failures, or any Dialpad send without an approval audit row.
- Rollback: set `DIALPAD_TELEGRAM_APPROVAL_BUTTONS_ENABLED=0` and remove or repoint the Telegram webhook; CLI approval remains available through `bin/approve_sms_draft.py`.