### PR TITLE
fix(dialpad): keep payload contacts unverified

### DIFF
--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -1223,7 +1223,7 @@ def _extract_payload_contact_name(data):
 
 
 def apply_payload_contact_fallback(sender_enrichment, data):
-    """Use webhook contact identity when API lookup has no exact contact name."""
+    """Use webhook contact identity as display-only context when exact lookup has no name."""
     sender_enrichment = dict(sender_enrichment or {})
     if sender_enrichment.get("contact_name"):
         return sender_enrichment
@@ -1238,7 +1238,7 @@ def apply_payload_contact_fallback(sender_enrichment, data):
     sender_enrichment.setdefault("company", None)
     sender_enrichment.setdefault("job_title", None)
     if sender_enrichment.get("status") in {None, "not_found", "not_applicable", "disabled"}:
-        sender_enrichment["status"] = "resolved"
+        sender_enrichment["status"] = "payload_contact"
     sender_enrichment["payload_contact_name"] = payload_name
     sender_enrichment["payload_contact_used"] = True
     return sender_enrichment
@@ -1356,14 +1356,13 @@ def build_inbound_context(normalized_event, sender_enrichment=None, line_display
     contact_name = first_contact.get("contactName") if isinstance(first_contact, dict) else None
     degraded = bool((lookup or {}).get("degraded") or sender_enrichment.get("degraded"))
     identity_state = first_contact.get("identityState") if isinstance(first_contact, dict) else "degraded"
+    payload_contact_only = bool(sender_enrichment.get("payload_contact_used")) and identity_state != "resolved"
 
     evidence = []
     if contact_name:
-        evidence.append("dialpad_contact_name")
-    if known_contact and not degraded:
+        evidence.append("webhook_contact_payload" if payload_contact_only else "dialpad_contact_name")
+    if known_contact and not degraded and not payload_contact_only:
         evidence.append("exact_phone_match")
-    if sender_enrichment.get("payload_contact_used"):
-        evidence.append("webhook_contact_payload")
     if degraded:
         evidence.append("lookup_degraded")
     if not known_contact and identity_state == "not_found":
@@ -1394,7 +1393,7 @@ def build_inbound_context(normalized_event, sender_enrichment=None, line_display
         recency["state"] = "not_applicable"
 
     identity_confidence = "low"
-    if known_contact and not degraded:
+    if known_contact and not degraded and not payload_contact_only:
         identity_confidence = "high"
     elif known_contact:
         identity_confidence = "medium"
@@ -1709,11 +1708,19 @@ def build_first_contact_context(normalized_event, sender_enrichment=None, line_d
     sender_enrichment = sender_enrichment or {}
     contact_name = sender_enrichment.get("contact_name")
     contact_name_text = str(contact_name or "").strip()
-    known_contact = bool(contact_name_text) and contact_name_text.lower() != "unknown"
-    first_contact_candidate = not known_contact
     lookup_status = str(sender_enrichment.get("status") or "not_applicable")
+    payload_contact_only = bool(sender_enrichment.get("payload_contact_used")) and lookup_status != "resolved"
+    known_contact = (
+        bool(contact_name_text)
+        and contact_name_text.lower() != "unknown"
+        and lookup_status == "resolved"
+        and not payload_contact_only
+    )
+    first_contact_candidate = not known_contact
     if sender_enrichment.get("degraded") or lookup_status in {"disabled", "not_applicable"}:
         identity_state = "degraded"
+    elif payload_contact_only:
+        identity_state = "payload_contact"
     elif known_contact:
         identity_state = "resolved"
     else:
@@ -2483,7 +2490,7 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                     sender_enrichment.setdefault("payload_contact_name", cached)
                     sender_enrichment["payload_contact_used"] = True
                     if sender_enrichment.get("status") in {None, "not_found", "not_applicable", "disabled"}:
-                        sender_enrichment["status"] = "resolved"
+                        sender_enrichment["status"] = "payload_contact"
             sender_enrichment["contact_name"] = contact_info
 
             inbound_alert_decision = assess_inbound_sms_alert_eligibility(

--- a/tests/test_sender_enrichment.py
+++ b/tests/test_sender_enrichment.py
@@ -150,9 +150,11 @@ def test_lookup_contact_enrichment_401_degraded_and_cached_fallback(monkeypatch)
     assert response["sender_enrichment_degraded"] is True
     assert response["sender_enrichment_degraded_reason"] == "expired_token"
     assert hook_calls[0]["normalized_sms"]["sender"] == "Cached Person"
-    assert hook_calls[0]["normalized_sms"]["first_contact"]["knownContact"] is True
-    assert hook_calls[0]["normalized_sms"]["first_contact"]["keepBrief"] is True
+    assert hook_calls[0]["normalized_sms"]["first_contact"]["knownContact"] is False
+    assert hook_calls[0]["normalized_sms"]["first_contact"]["keepBrief"] is False
     assert hook_calls[0]["normalized_sms"]["first_contact"]["identityState"] == "degraded"
+    assert hook_calls[0]["normalized_sms"]["inbound_context"]["identityConfidence"] == "low"
+    assert hook_calls[0]["normalized_sms"]["inbound_context"]["contextDraftAllowed"] is False
 
 
 def test_inbound_telegram_uses_enriched_sender(monkeypatch):

--- a/tests/test_webhook_hooks.py
+++ b/tests/test_webhook_hooks.py
@@ -346,6 +346,46 @@ def test_inbound_context_blocks_stale_known_contact_draft():
     assert context["contextDraftAllowed"] is False
 
 
+def test_payload_contact_name_is_not_resolved_identity():
+    sender_enrichment = webhook_server.apply_payload_contact_fallback(
+        {
+            "contact_name": None,
+            "status": "not_found",
+            "degraded": False,
+            "degraded_reason": None,
+        },
+        {"contact": {"name": "Payload Person"}},
+    )
+    normalized = {
+        "event_type": "missed_call",
+        "sender_number": "+14322083277",
+        "recipient_number": "+14155201316",
+        "timestamp": 1760000000000,
+    }
+    normalized["first_contact"] = webhook_server.build_first_contact_context(
+        normalized,
+        sender_enrichment=sender_enrichment,
+        line_display="Sales",
+    )
+    context = build_inbound_context(
+        normalized,
+        sender_enrichment=sender_enrichment,
+        line_display="Sales",
+        recent_context={
+            "source": "dialpad_call_history",
+            "lastActivityAt": 1759913600000,
+        },
+    )
+
+    assert sender_enrichment["status"] == "payload_contact"
+    assert normalized["first_contact"]["identityState"] == "payload_contact"
+    assert normalized["first_contact"]["knownContact"] is False
+    assert context["identityConfidence"] == "low"
+    assert context["contextDraftAllowed"] is False
+    assert "exact_phone_match" not in context["evidence"]
+    assert "webhook_contact_payload" in context["evidence"]
+
+
 def test_recent_sms_context_does_not_self_match_without_event_identity(monkeypatch):
     def _fail_if_called():
         raise AssertionError("history DB should not be opened without event id or timestamp")

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -1153,6 +1153,81 @@ class CallWebhookHandlerTests(unittest.TestCase):
         self.assertIn("Inbound context", telegram_messages[0])
         self.assertNotIn("SMS approval draft", telegram_messages[0])
 
+    def test_payload_only_contact_name_does_not_create_context_draft(self):
+        hook_calls = []
+        telegram_messages = []
+        event_ts = 1760000000000
+        recent_call = {
+            "external_number": "+14322083277",
+            "entry_point_target": {"phone": "+14155201316", "name": "Sales"},
+            "date_started": event_ts - (2 * 24 * 60 * 60 * 1000),
+            "direction": "inbound",
+            "state": "hangup",
+            "duration": 120000,
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir, \
+                patch.object(webhook_server.sms_approval, "DB_PATH", Path(temp_dir) / "approvals.db"), \
+                patch.object(webhook_server, "DIALPAD_AUTO_REPLY_ENABLED", True), \
+                patch.object(webhook_server, "DIALPAD_AUTO_REPLY_SALES_LINE", "4155201316"), \
+                patch.object(webhook_server, "OPENCLAW_HOOKS_CALL_ENABLED", True), \
+                patch.object(webhook_server, "OPENCLAW_HOOKS_TOKEN", "token-123"), \
+                patch.object(
+                    webhook_server,
+                    "lookup_contact_enrichment",
+                    return_value={
+                        "contact_name": None,
+                        "first_name": None,
+                        "last_name": None,
+                        "company": None,
+                        "job_title": None,
+                        "status": "not_found",
+                        "degraded": False,
+                        "degraded_reason": None,
+                    },
+                ), \
+                patch.object(webhook_server, "_fetch_recent_calls_around", return_value=[recent_call]), \
+                patch.object(
+                    webhook_server,
+                    "send_to_openclaw_hooks",
+                    side_effect=lambda normalized_event, line_display=None: (
+                        hook_calls.append({"normalized_event": normalized_event, "line_display": line_display}) or
+                        (True, "http_200")
+                    ),
+                ), \
+                patch.object(
+                    webhook_server,
+                    "send_to_telegram",
+                    side_effect=lambda text, **_kwargs: telegram_messages.append(text) or True,
+                ):
+            payload = {
+                "direction": "inbound",
+                "call_direction": "inbound",
+                "call_missed": True,
+                "call_id": "call-123",
+                "from_number": "+14322083277",
+                "to_number": "+14155201316",
+                "date_started": event_ts,
+                "contact": {"name": "Payload Person"},
+            }
+            handler, status = _build_handler(payload)
+            webhook_server.DialpadWebhookHandler.handle_call_webhook(handler)
+
+        response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+        first_contact = hook_calls[0]["normalized_event"]["first_contact"]
+        inbound_context = hook_calls[0]["normalized_event"]["inbound_context"]
+        self.assertEqual(status["code"], 200)
+        self.assertEqual(first_contact["identityState"], "payload_contact")
+        self.assertFalse(first_contact["knownContact"])
+        self.assertEqual(inbound_context["contactName"], "Payload Person")
+        self.assertEqual(inbound_context["identityConfidence"], "low")
+        self.assertFalse(inbound_context["contextDraftAllowed"])
+        self.assertNotIn("exact_phone_match", inbound_context["evidence"])
+        self.assertEqual(response["auto_reply_status"], "not_eligible")
+        self.assertIsNone(response["auto_reply_draft_id"])
+        self.assertIn("Inbound context", telegram_messages[0])
+        self.assertNotIn("SMS approval draft", telegram_messages[0])
+
 
 class VoicemailWebhookHandlerTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

Payload-only Dialpad contact names now stay display-only instead of being promoted to verified identity. This prevents webhook `contact.name` or cached names from creating `knownContact=true`, `identityConfidence=high`, exact-phone evidence, or context-aware approval drafts without a verified contact lookup.

## Why

Codex review on #74 correctly flagged that payload names could masquerade as resolved contacts. The patch keeps these names useful for operator context while preserving the safety boundary: only exact phone-verified lookups can authorize known-contact context drafts.

## Verification

- `python -m pytest tests/test_webhook_hooks.py tests/test_webhook_server.py tests/test_sender_enrichment.py` (96 passed)
- `python -m pytest` (192 passed)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-111827?logo=openai&logoColor=white)
