### PR TITLE
fix(sms): catch stripped multidigit currency

### DIFF
--- a/bin/send_sms.py
+++ b/bin/send_sms.py
@@ -99,7 +99,12 @@ def resolve_message_text(args: argparse.Namespace) -> tuple[str, str]:
 
 def suspicious_currency_reasons(message_text: str) -> list[str]:
     checks = [
-        (r"(?<!\S),\d{3}\b", "comma-prefixed amount like ',035'"),
+        (r"(?<!\S),\d{3}\b", "amount with stripped leading currency like ',035'"),
+        (
+            r"(?i)\b(?:amount|buyout|cost|credit|discount|financing|payment|price|quote|total)"
+            r"\s*(?::|=|-|is|was|of|for|at)?\s*(?<![$\d])\d{1,3},\d{3}\b",
+            "currency-context amount with stripped leading currency like '0,035' or '20,035'",
+        ),
         (r"(?i)(?:about|around|roughly|approx(?:imately)?|~)\s*\d{1,3}\s+(?:less|more|off|credit)\b", "currency word with bare number"),
         (r"~\d{2,4}\s*-\s*\d{2,4}\s*/\s*month\b", "monthly range missing currency symbol"),
         (r"\bcurrent\s+\d{2,4}\s*/\s*month\b", "current monthly amount missing currency symbol"),

--- a/tests/test_json_contract.py
+++ b/tests/test_json_contract.py
@@ -142,6 +142,58 @@ class JsonContractTests(unittest.TestCase):
         self.assertEqual(parsed["error"]["code"], "invalid_argument")
         self.assertIn("stripped currency", parsed["error"]["message"])
 
+    def test_send_sms_blocks_suspicious_multidigit_stripped_currency(self):
+        with patch("send_sms.require_generated_cli"), \
+                patch("send_sms.resolve_sender", return_value=("+14155201316", "--from")), \
+                patch("send_sms.run_generated_json") as run_generated_json, \
+                patch("send_sms.require_api_key"):
+            code, out, err = self._run(
+                send_sms,
+                [
+                    "bin/send_sms.py",
+                    "--to",
+                    "+14155550111",
+                    "--message",
+                    "Your lease buyout: 0,035 after discount.",
+                    "--from",
+                    "+14155201316",
+                    "--json",
+                ],
+            )
+
+        self.assertEqual(code, 2)
+        self.assertEqual(err, "")
+        run_generated_json.assert_not_called()
+        parsed = self._parse(out)
+        self._assert_error(parsed, "send_sms.send")
+        self.assertEqual(parsed["error"]["code"], "invalid_argument")
+
+    def test_send_sms_blocks_suspicious_large_stripped_currency(self):
+        with patch("send_sms.require_generated_cli"), \
+                patch("send_sms.resolve_sender", return_value=("+14155201316", "--from")), \
+                patch("send_sms.run_generated_json") as run_generated_json, \
+                patch("send_sms.require_api_key"):
+            code, out, err = self._run(
+                send_sms,
+                [
+                    "bin/send_sms.py",
+                    "--to",
+                    "+14155550111",
+                    "--message",
+                    "Your lease buyout: 20,035 after discount.",
+                    "--from",
+                    "+14155201316",
+                    "--json",
+                ],
+            )
+
+        self.assertEqual(code, 2)
+        self.assertEqual(err, "")
+        run_generated_json.assert_not_called()
+        parsed = self._parse(out)
+        self._assert_error(parsed, "send_sms.send")
+        self.assertEqual(parsed["error"]["code"], "invalid_argument")
+
     def test_send_sms_allows_valid_currency(self):
         with patch("send_sms.require_generated_cli"), \
                 patch("send_sms.resolve_sender", return_value=("+14155201316", "--from")), \
@@ -155,6 +207,78 @@ class JsonContractTests(unittest.TestCase):
                     "+14155550111",
                     "--message",
                     "Your lease buyout: $7,035. Financing: ~$145-156/month. That's about $50 LESS than your current $199/month lease.",
+                    "--from",
+                    "+14155201316",
+                    "--json",
+                ],
+            )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(err, "")
+        run_generated_json.assert_called_once()
+        self._assert_success(self._parse(out), "send_sms.send")
+
+    def test_send_sms_allows_usd_prefixed_currency(self):
+        with patch("send_sms.require_generated_cli"), \
+                patch("send_sms.resolve_sender", return_value=("+14155201316", "--from")), \
+                patch("send_sms.run_generated_json", return_value={"id": "msg-usd", "message_status": "pending"}) as run_generated_json, \
+                patch("send_sms.require_api_key"):
+            code, out, err = self._run(
+                send_sms,
+                [
+                    "bin/send_sms.py",
+                    "--to",
+                    "+14155550111",
+                    "--message",
+                    "Quote is USD 20,035 after discount.",
+                    "--from",
+                    "+14155201316",
+                    "--json",
+                ],
+            )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(err, "")
+        run_generated_json.assert_called_once()
+        self._assert_success(self._parse(out), "send_sms.send")
+
+    def test_send_sms_allows_non_currency_thousands(self):
+        with patch("send_sms.require_generated_cli"), \
+                patch("send_sms.resolve_sender", return_value=("+14155201316", "--from")), \
+                patch("send_sms.run_generated_json", return_value={"id": "msg-5", "message_status": "pending"}) as run_generated_json, \
+                patch("send_sms.require_api_key"):
+            code, out, err = self._run(
+                send_sms,
+                [
+                    "bin/send_sms.py",
+                    "--to",
+                    "+14155550111",
+                    "--message",
+                    "We had 1,000 attendees and 2,500 check-ins this month.",
+                    "--from",
+                    "+14155201316",
+                    "--json",
+                ],
+            )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(err, "")
+        run_generated_json.assert_called_once()
+        self._assert_success(self._parse(out), "send_sms.send")
+
+    def test_send_sms_allows_non_currency_lease_and_monthly_thousands(self):
+        with patch("send_sms.require_generated_cli"), \
+                patch("send_sms.resolve_sender", return_value=("+14155201316", "--from")), \
+                patch("send_sms.run_generated_json", return_value={"id": "msg-6", "message_status": "pending"}) as run_generated_json, \
+                patch("send_sms.require_api_key"):
+            code, out, err = self._run(
+                send_sms,
+                [
+                    "bin/send_sms.py",
+                    "--to",
+                    "+14155550111",
+                    "--message",
+                    "Your lease includes 10,000 annual miles and monthly allowance is 1,000 minutes.",
                     "--from",
                     "+14155201316",
                     "--json",


### PR DESCRIPTION
## What
- Narrows and extends the suspicious-currency preflight for Dialpad SMS sends.
- Blocks stripped shell-expansion amounts like `0,035` and `20,035` when they appear next to explicit amount labels such as buyout, price, total, or financing.
- Keeps ordinary non-currency thousands text allowed, such as `1,000 attendees`, lease mileage, monthly minute allowances, and explicit `USD 20,035` amounts.

## Why
The first guard caught the exact Stormie-style `,035` incident but missed `$10,035 -> 0,035` and larger `$120,035 -> 20,035` shell-expansion failures. This follow-up keeps the guard focused on stronger currency contexts so ordinary thousands-formatted counts are not blocked.

## Tests
- `python3 -m pytest tests/test_json_contract.py tests/test_send_sms_group_intro.py tests/test_sender_enrichment.py -q`
- `python3 bin/send_sms.py --to +12488500769 --message "Your lease buyout: 20,035 after discount." --from +14155201316 --dry-run --json | jq '.ok'`
- `python3 bin/send_sms.py --to +12488500769 --message "We had 20,035 attendees this month." --from +14155201316 --dry-run --json | jq '.ok'`
- `python3 bin/send_sms.py --to +12488500769 --message "Your lease includes 10,000 annual miles and monthly allowance is 1,000 minutes." --from +14155201316 --dry-run --json | jq '.ok'`
- `python3 bin/send_sms.py --to +12488500769 --message "Quote is USD 20,035 after discount." --from +14155201316 --dry-run --json | jq '.ok'`
- `codex review --base main` after fixes: no discrete correctness issue found.

## AI Assistance
- AI-assisted implementation and code review.
- Testing level: focused unit tests plus direct dry-run CLI reproductions.
- I understand this code.
