### PR TITLE
fix(sms): include opt-out context in Telegram alert

### DIFF
--- a/docs/plans/2026-05-13-001-fix-opt-out-telegram-context-plan.md
+++ b/docs/plans/2026-05-13-001-fix-opt-out-telegram-context-plan.md
@@ -1,0 +1,46 @@
+---
+title: "fix: include opt-out context in Telegram alerts"
+status: active
+created: 2026-05-13
+---
+
+# Problem
+
+Inbound Dialpad SMS messages that match explicit opt-out language correctly block automation and send a human-only Telegram notice, but the notice only includes the phone number. Operators cannot see who opted out or what the inbound message said without opening Dialpad.
+
+# Scope
+
+Add contact identity and the inbound SMS body to the existing opt-out Telegram notification. Do not weaken opt-out blocking, do not create drafts for opt-out messages, and do not change outbound SMS behavior.
+
+# Requirements
+
+- Keep `filtered_opt_out` as a hard stop for automation.
+- Preserve durable opt-out persistence through `sms_approval.mark_opt_out`.
+- Send Telegram opt-out notices with:
+  - the contact display name when available, using the same display style as ordinary inbound SMS notices
+  - the phone number
+  - the inbound message text, for example `STOP`
+- Avoid sending opt-out messages to OpenClaw hooks or creating approval drafts.
+
+# Implementation Units
+
+## U1: Enrich opt-out Telegram notice
+
+Files:
+- Modify: `scripts/webhook_server.py`
+- Test: `tests/test_sender_enrichment.py`
+
+Approach:
+- Reuse the `sender_enrichment["contact_name"]` value already computed in `DialpadWebhookHandler.handle_webhook`.
+- Build the opt-out `From:` line as `Contact Name (+number)` when contact identity exists, otherwise keep the current phone-only fallback.
+- Add a `Message:` line containing escaped inbound text.
+- Keep the final human-only warning text.
+
+Test scenarios:
+- Opt-out inbound text with an enriched contact sends a Telegram notice containing the contact name, number, and exact inbound text.
+- Opt-out inbound text still returns `hook_status == "filtered_opt_out"`, creates no draft, sends no SMS, calls no OpenClaw hook, and persists opt-out state.
+
+# Verification
+
+- `python3 -m pytest tests/test_sender_enrichment.py -q`
+- Optional broader smoke: `python3 -m pytest tests/test_webhook_server.py tests/test_sender_enrichment.py -q`

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -2767,9 +2767,12 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                 )
                 telegram_status = TELEGRAM_STATUS_SENT if telegram_sms_sent else TELEGRAM_STATUS_FAILED
             elif hook_status == "filtered_opt_out":
+                contact_info = sender_enrichment.get("contact_name")
+                from_display = f"{contact_info} ({from_num})" if contact_info else str(from_num)
                 tg_text = (
                     "🛑 Dialpad SMS opt-out / human-only\n"
-                    f"From: {escape_telegram_markdown(str(from_num))}\n"
+                    f"From: {escape_telegram_markdown(from_display)}\n"
+                    f"Message: {escape_telegram_markdown(text)}\n"
                     "Automation is not allowed to send on this thread."
                 )
                 telegram_sms_sent = send_to_telegram(tg_text)

--- a/tests/test_sender_enrichment.py
+++ b/tests/test_sender_enrichment.py
@@ -607,12 +607,12 @@ def test_inbound_opt_out_blocks_hooks_sends_and_invalidates_pending_drafts(monke
         webhook_server,
         "lookup_contact_enrichment",
         lambda _number: {
-            "contact_name": None,
-            "first_name": None,
-            "last_name": None,
-            "company": None,
+            "contact_name": "Lisa Primps (The Primping Place)",
+            "first_name": "Lisa",
+            "last_name": "Primps",
+            "company": "The Primping Place",
             "job_title": None,
-            "status": "not_found",
+            "status": "resolved",
             "degraded": False,
             "degraded_reason": None,
         },
@@ -655,6 +655,8 @@ def test_inbound_opt_out_blocks_hooks_sends_and_invalidates_pending_drafts(monke
     assert response["telegram_status"] == "human_only_notified"
     assert response["auto_reply_draft_id"] is None
     assert "human-only" in telegram_messages[0]
+    assert "Lisa Primps (The Primping Place) (+14155550123)" in telegram_messages[0]
+    assert "Message: I need a real person. Please don't bother me anymore." in telegram_messages[0]
 
     conn = webhook_server.sms_approval.init_db()
     try:


### PR DESCRIPTION
## What
- Add contact identity and the inbound SMS body to Dialpad opt-out / human-only Telegram alerts.
- Keep opt-out handling fail-closed: no OpenClaw hook, no approval draft, no automated SMS.
- Add a plan artifact for the LFG pipeline run.

## Why
Operators need to see who opted out and what message triggered the block without opening Dialpad.

## Tests
- python3 -m pytest tests/test_sender_enrichment.py -q
- python3 -m pytest tests/test_webhook_server.py tests/test_sender_enrichment.py -q
- codex review --base origin/main

## AI Assistance
Used Codex to implement, review, and test this change. Testing level: targeted webhook/unit tests plus local Codex review. I understand this code.