### PR TITLE
fix(sms): suppress generic fallback drafts on active threads

### DIFF
--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -1477,6 +1477,16 @@ def _generic_fallback_draft_allowed(normalized_event, first_contact):
     return (normalized_event.get("event_type") or "sms") in {"sms", "missed_call"}
 
 
+def _has_fresh_prior_sms_context(inbound_context):
+    """True when the inbound SMS is part of an active prior SMS thread."""
+    if not isinstance(inbound_context, dict):
+        return False
+    if (inbound_context.get("eventType") or "sms") != "sms":
+        return False
+    recency = inbound_context.get("recency") or {}
+    return recency.get("state") == "fresh" and recency.get("source") == "local_sms_history"
+
+
 def build_inbound_context(normalized_event, sender_enrichment=None, line_display=None, recent_context=None):
     """Build operator-facing identity, provenance, and draft-safety context."""
     sender_enrichment = sender_enrichment or {}
@@ -1538,9 +1548,7 @@ def build_inbound_context(normalized_event, sender_enrichment=None, line_display
         and identity_confidence == "high"
         and recency["state"] == "fresh"
     )
-    generic_draft_allowed = _generic_fallback_draft_allowed(normalized_event, first_contact)
-
-    return {
+    context = {
         "identityState": identity_state,
         "identityConfidence": identity_confidence,
         "knownContact": known_contact,
@@ -1552,11 +1560,16 @@ def build_inbound_context(normalized_event, sender_enrichment=None, line_display
         "evidence": sorted(set(evidence)),
         "recency": recency,
         "contextDraftAllowed": context_draft_allowed,
-        "genericDraftAllowed": generic_draft_allowed,
-        "draftMode": "context_aware" if context_draft_allowed else (
-            "deterministic_fallback" if generic_draft_allowed else "none"
-        ),
     }
+    generic_draft_allowed = (
+        _generic_fallback_draft_allowed(normalized_event, first_contact)
+        and not _has_fresh_prior_sms_context(context)
+    )
+    context["genericDraftAllowed"] = generic_draft_allowed
+    context["draftMode"] = "context_aware" if context_draft_allowed else (
+        "deterministic_fallback" if generic_draft_allowed else "none"
+    )
+    return context
 
 
 def _extract_call_history_row(call):
@@ -1941,13 +1954,23 @@ def should_send_proactive_reply(normalized_event, sender_enrichment=None, line_d
 
     inbound_context = normalized_event.get("inbound_context")
     if inbound_context is None:
+        recent_context = None
+        if (normalized_event.get("event_type") or "sms") == "sms":
+            recent_context = lookup_recent_sms_context(
+                normalized_event.get("sender_number"),
+                current_dialpad_id=normalized_event.get("message_id"),
+                current_timestamp_ms=_parse_timestamp_ms(normalized_event.get("timestamp")),
+            )
         inbound_context = build_inbound_context(
             normalized_event,
             sender_enrichment=sender_enrichment,
             line_display=line_display,
+            recent_context=recent_context,
         )
     if inbound_context.get("contextDraftAllowed"):
         return True
+    if _has_fresh_prior_sms_context(inbound_context):
+        return False
 
     return _generic_fallback_draft_allowed(normalized_event, first_contact)
 

--- a/tests/test_sender_enrichment.py
+++ b/tests/test_sender_enrichment.py
@@ -504,6 +504,101 @@ def test_inbound_sales_sms_creates_generic_draft_for_payload_contact(monkeypatch
     assert "approval draft created (generic fallback)" in telegram_messages[0]
 
 
+def test_low_confidence_reply_in_active_thread_does_not_create_generic_draft(monkeypatch, tmp_path):
+    sms_db = tmp_path / "sms.db"
+    approval_db = tmp_path / "approvals.db"
+    monkeypatch.setattr(webhook_server, "WEBHOOK_SECRET", "")
+    monkeypatch.setattr(webhook_server, "DIALPAD_AUTO_REPLY_ENABLED", True)
+    monkeypatch.setattr(webhook_server, "DIALPAD_AUTO_REPLY_SALES_LINE", "4155201316")
+    monkeypatch.setattr(webhook_server.sms_approval, "DB_PATH", approval_db)
+    monkeypatch.setattr(sms_sqlite, "DB_PATH", sms_db)
+    monkeypatch.setattr(
+        webhook_server,
+        "handle_sms_webhook",
+        lambda _data: {"stored": True, "message": {"contact_name": "Gabriela Valle"}},
+    )
+    monkeypatch.setattr(
+        webhook_server,
+        "lookup_contact_enrichment",
+        lambda _number: {
+            "contact_name": None,
+            "first_name": None,
+            "last_name": None,
+            "company": None,
+            "job_title": None,
+            "status": "not_found",
+            "degraded": False,
+            "degraded_reason": None,
+        },
+    )
+    now_ms = 1760000000000
+    conn = sms_sqlite.init_db()
+    try:
+        sms_sqlite.store_message(
+            conn,
+            {
+                "id": 2001,
+                "direction": "outbound",
+                "from_number": "+14155201316",
+                "to_number": ["+15109125052"],
+                "text": "You can grab a time here: bysha.pe/book-demo",
+                "created_date": now_ms - 5 * 60 * 1000,
+                "contact": {"name": "Gabriela Valle"},
+            },
+            is_new=False,
+        )
+    finally:
+        conn.close()
+
+    telegram_messages = []
+    hook_calls = []
+    sms_calls = []
+    monkeypatch.setattr(webhook_server, "DIALPAD_SMS_TELEGRAM_NOTIFY", True)
+    monkeypatch.setattr(webhook_server, "send_to_telegram", lambda text, **_kwargs: telegram_messages.append(text) or True)
+    monkeypatch.setattr(
+        webhook_server,
+        "send_sms_to_openclaw_hooks",
+        lambda normalized_sms, line_display=None: (
+            hook_calls.append({"normalized_sms": normalized_sms, "line_display": line_display}) or
+            (True, "http_200")
+        ),
+    )
+    monkeypatch.setattr(
+        webhook_server,
+        "dialpad_send_sms",
+        lambda *args, **kwargs: sms_calls.append((args, kwargs)) or {"id": "msg-1"},
+    )
+
+    payload = {
+        "id": 2002,
+        "direction": "inbound",
+        "from_number": "+15109125052",
+        "to_number": ["+14155201316"],
+        "text": "The link doesn't work",
+        "created_date": now_ms,
+        "contact": {"name": "Gabriela Valle"},
+    }
+    handler, status = _build_handler(payload)
+    webhook_server.DialpadWebhookHandler.handle_webhook(handler)
+
+    response = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    normalized_sms = hook_calls[0]["normalized_sms"]
+    inbound_context = normalized_sms["inbound_context"]
+    assert status["code"] == 200
+    assert sms_calls == []
+    assert inbound_context["identityConfidence"] == "low"
+    assert inbound_context["recency"]["state"] == "fresh"
+    assert "local_sms_history" in inbound_context["evidence"]
+    assert inbound_context["genericDraftAllowed"] is False
+    assert inbound_context["draftMode"] == "none"
+    assert normalized_sms["auto_reply"]["draftCreated"] is False
+    assert response["auto_reply_status"] == "not_eligible"
+    assert response["auto_reply_draft_id"] is None
+    assert "SMS approval draft" not in telegram_messages[0]
+    assert "no approval draft (not\\_eligible)" in telegram_messages[0]
+    assert "thanks for reaching ShapeScale for Business Sales" not in telegram_messages[0]
+
+
 def test_known_recent_sales_sms_creates_context_approval_draft(monkeypatch, tmp_path):
     sms_db = tmp_path / "sms.db"
     approval_db = tmp_path / "approvals.db"
@@ -1223,6 +1318,49 @@ def test_should_send_proactive_reply_allows_payload_contact_sms_generic_draft(mo
     }
 
     assert webhook_server.should_send_proactive_reply(normalized_event) is True
+
+
+def test_should_send_proactive_reply_suppresses_generic_draft_for_active_thread(monkeypatch, tmp_path):
+    sms_db = tmp_path / "sms.db"
+    monkeypatch.setattr(webhook_server, "DIALPAD_AUTO_REPLY_ENABLED", True)
+    monkeypatch.setattr(webhook_server, "DIALPAD_AUTO_REPLY_SALES_LINE", "4155201316")
+    monkeypatch.setattr(sms_sqlite, "DB_PATH", sms_db)
+    now_ms = 1760000000000
+    conn = sms_sqlite.init_db()
+    try:
+        sms_sqlite.store_message(
+            conn,
+            {
+                "id": "prior-outbound",
+                "direction": "outbound",
+                "from_number": "+14155201316",
+                "to_number": ["+15109125052"],
+                "text": "You can grab a time here: bysha.pe/book-demo",
+                "created_date": now_ms - 5 * 60 * 1000,
+            },
+            is_new=False,
+        )
+    finally:
+        conn.close()
+
+    normalized_event = {
+        "event_type": "sms",
+        "message_id": "current-inbound",
+        "timestamp": now_ms,
+        "sender_number": "+15109125052",
+        "recipient_number": "+14155201316",
+        "first_contact": {
+            "knownContact": False,
+            "needsDraftReply": True,
+            "lookup": {
+                "status": "payload_contact",
+                "degraded": False,
+                "degradedReason": None,
+            },
+        },
+    }
+
+    assert webhook_server.should_send_proactive_reply(normalized_event) is False
 
 
 def test_inbound_telegram_escapes_markdown_content(monkeypatch):


### PR DESCRIPTION
What
- Suppress deterministic generic SMS approval drafts when fresh local SMS history shows the inbound is part of an active thread.
- Preserve generic fallback drafts for true first-contact low-confidence Sales SMS.
- Preserve context-aware drafts for known/high-confidence active threads.
- Add regression coverage for webhook handling and direct eligibility checks.

Why
A reply like "The link doesn't work" in an active SMS conversation was being treated as low-confidence first-contact fallback, so Telegram always showed the same canned draft regardless of sender content. That is misleading and too easy to approve accidentally.

Tests
- python3 -m pytest tests/test_sender_enrichment.py::test_low_confidence_reply_in_active_thread_does_not_create_generic_draft tests/test_sender_enrichment.py::test_inbound_sales_sms_creates_generic_draft_for_payload_contact tests/test_sender_enrichment.py::test_known_recent_sales_sms_creates_context_approval_draft -q
- python3 -m pytest tests/test_sender_enrichment.py::test_should_send_proactive_reply_suppresses_generic_draft_for_active_thread tests/test_sender_enrichment.py::test_should_send_proactive_reply_allows_payload_contact_sms_generic_draft tests/test_sender_enrichment.py::test_low_confidence_reply_in_active_thread_does_not_create_generic_draft -q
- python3 -m pytest tests/test_sender_enrichment.py tests/test_webhook_server.py tests/test_webhook_hooks.py -q
- codex review --base origin/main

AI Assistance
Used OpenAI Codex for implementation, debugging, tests, and local review. Testing level: focused webhook/sender-enrichment regression suite plus local Codex review. I understand this code.