### PR TITLE
fix(dialpad): expose SMS response history to agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ bin/list_calls.py --hours 6 --missed --json
 # Check whether a contact already has local SMS replies
 bin/list_sms_thread.py --phone "+14155551234" --json
 
+# Sync Dialpad Stats text export metadata into local SMS SQLite
+bin/sync_sms_export.py --start-date 2026-05-13 --end-date 2026-05-13 --json
+
 # Group intro (mirrored fallback)
 bin/send_group_intro.py --prospect "+14155550111" --reference "+14155550999" --confirm-share --from "+14153602954"
 
@@ -97,6 +100,7 @@ For all eligible inbound SMS and missed calls, the payload may also carry `inbou
 That pattern is CRM-agnostic: Attio is one example, but the same setup works with HubSpot, Pipedrive, Airtable, a spreadsheet, or a custom directory service downstream.
 Current-turn verification still applies: "Already sent" and "Already updated" are only valid after a fresh current-turn tool result, not from stale session memory.
 For SMS response checks, use `bin/list_sms_thread.py --phone PHONE --json` before claiming a thread has no visible reply history. The local SQLite store is the first-line operational history; Dialpad Stats export is slower and should be treated as a fallback/export path.
+For completeness after direct Dialpad UI sends or other out-of-band sends, run `bin/sync_sms_export.py` for the relevant date range. The export sync upserts previously unseen message IDs only and skips existing local messages so webhook-captured plaintext is not replaced by export metadata.
 For identity work, treat `resolved` as the only state that is safe to mutate automatically; `not_found`, `ambiguous`, and `degraded` stay draft-only until the CRM layer proves otherwise.
 When `DIALPAD_AUTO_REPLY_ENABLED` is set, first-contact inbound events to the sales line `(415) 520-1316` create a short exact-text approval draft instead of sending SMS directly. Low-confidence Sales SMS and missed calls, including payload-only contact names, may create generic approval drafts; low confidence suppresses personalization and CRM claims, not the approval-gated draft itself. Eligible Sales SMS may also create ShapeScale knowledge-backed approval drafts for obvious product, booking, link, and pricing questions; the webhook uses recent Dialpad SMS history to resolve active-thread references and uses qmd-backed ShapeScale knowledge for factual answers. If knowledge is unavailable or ambiguous, rich drafting fails closed to the existing generic, no-draft, or human-only behavior. Known contacts only get context-aware approval drafts when identity confidence is high and recent SMS/call continuity is no older than 14 days; stale or degraded context produces a brief only. Missed calls get a "sorry we missed you" draft variant; SMS and voicemail get a "we'll be in touch shortly" draft variant. Explicit opt-out language creates no draft, invalidates pending drafts for that customer, and sends only a human-only Telegram notice.
 Missed-call notifications are idempotency-gated before any approval draft, OpenClaw hook, or Telegram side effect. Dialpad can emit parent and per-user child call records for one visible department/office call; the webhook dedupes those by `entry_point_call_id` / `call_id` with a short caller-line-time fallback when IDs are absent.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ bin/make_call.py --to "+14155551234" --text "This is a test call."
 bin/list_calls.py --today --limit 20
 bin/list_calls.py --hours 6 --missed --json
 
+# Check whether a contact already has local SMS replies
+bin/list_sms_thread.py --phone "+14155551234" --json
+
 # Group intro (mirrored fallback)
 bin/send_group_intro.py --prospect "+14155550111" --reference "+14155550999" --confirm-share --from "+14153602954"
 
@@ -93,6 +96,7 @@ For first-time or unknown inbound contacts, the payload also carries a `firstCon
 For all eligible inbound SMS and missed calls, the payload may also carry `inboundContext`: a compact identity/provenance/recency brief that explains exact phone matches, Dialpad contact evidence, recent SMS/call continuity, whether a context-aware approval draft is allowed, and whether a generic fallback draft is allowed.
 That pattern is CRM-agnostic: Attio is one example, but the same setup works with HubSpot, Pipedrive, Airtable, a spreadsheet, or a custom directory service downstream.
 Current-turn verification still applies: "Already sent" and "Already updated" are only valid after a fresh current-turn tool result, not from stale session memory.
+For SMS response checks, use `bin/list_sms_thread.py --phone PHONE --json` before claiming a thread has no visible reply history. The local SQLite store is the first-line operational history; Dialpad Stats export is slower and should be treated as a fallback/export path.
 For identity work, treat `resolved` as the only state that is safe to mutate automatically; `not_found`, `ambiguous`, and `degraded` stay draft-only until the CRM layer proves otherwise.
 When `DIALPAD_AUTO_REPLY_ENABLED` is set, first-contact inbound events to the sales line `(415) 520-1316` create a short exact-text approval draft instead of sending SMS directly. Low-confidence Sales SMS and missed calls, including payload-only contact names, may create generic approval drafts; low confidence suppresses personalization and CRM claims, not the approval-gated draft itself. Eligible Sales SMS may also create ShapeScale knowledge-backed approval drafts for obvious product, booking, link, and pricing questions; the webhook uses recent Dialpad SMS history to resolve active-thread references and uses qmd-backed ShapeScale knowledge for factual answers. If knowledge is unavailable or ambiguous, rich drafting fails closed to the existing generic, no-draft, or human-only behavior. Known contacts only get context-aware approval drafts when identity confidence is high and recent SMS/call continuity is no older than 14 days; stale or degraded context produces a brief only. Missed calls get a "sorry we missed you" draft variant; SMS and voicemail get a "we'll be in touch shortly" draft variant. Explicit opt-out language creates no draft, invalidates pending drafts for that customer, and sends only a human-only Telegram notice.
 Missed-call notifications are idempotency-gated before any approval draft, OpenClaw hook, or Telegram side effect. Dialpad can emit parent and per-user child call records for one visible department/office call; the webhook dedupes those by `entry_point_call_id` / `call_id` with a short caller-line-time fallback when IDs are absent.

--- a/SKILL.md
+++ b/SKILL.md
@@ -58,6 +58,11 @@ bin/list_calls.py --hours 6 --missed --json
 bin/list_sms_thread.py --phone "+14155551234" --json
 ```
 
+**Sync Direct Dialpad SMS Sends:**
+```bash
+bin/sync_sms_export.py --start-date 2026-05-13 --end-date 2026-05-13 --json
+```
+
 **Create Contact:**
 ```bash
 bin/create_contact.py --first-name "Jane" --last-name "Doe" --phone "+14155550123" --email "jane@example.com"
@@ -87,12 +92,13 @@ bin/update_contact.py --id "contact_123" --phone "+14155550123" --job-title "VP"
 8. **Group intro:** `bin/send_group_intro.py` mirrors intro messages as two one-to-one SMS sends (`mirrored_fallback`) because true group threads are unsupported via this wrapper.
 9. **Call history:** `bin/list_calls.py` is the supported call-history command for agents. Use `--json` when downstream automation needs a deterministic response envelope.
 10. **SMS thread history:** Before saying a contact was not already messaged, run `bin/list_sms_thread.py --phone PHONE --json` and check `has_outbound` / `outbound_count`. This local SQLite history is the supported current-turn response-state check.
-11. **Create/Update Contact Behavior:** `bin/create_contact.py` upserts shared/local contacts by phone/email match (or forces create with `--allow-duplicate`). `bin/update_contact.py` updates by `--id` with partial fields.
-12. **Current-turn verification:** "Already sent" and "Already updated" are only valid after a fresh current-turn tool result, not from stale session memory. If the current turn has not verified the action yet, say that plainly and run the tool now.
-13. **Identity guardrail:** For first-contact work, soft signals like first name, area code, industry, or job title are not enough to merge or update a contact. Keep uncertain identity `draft-only` and let the CRM layer prove the match before mutating anything.
-14. **Inbound context guardrail:** Webhook `inboundContext` briefs explain identity evidence, recent SMS/call continuity, and draft basis. Low-confidence Sales SMS and missed calls may get generic approval drafts, but not personalized claims. Known contacts only get context-aware approval drafts when identity confidence is high and relevant continuity is no older than 14 days; stale or degraded context stays brief-only.
-15. **Inbound automation guardrail:** Dialpad inbound hooks may create SMS approval drafts, but they must not send customer SMS directly. Use `bin/approve_sms_draft.py` only with a real human actor id and an operator-only `DIALPAD_SMS_APPROVAL_TOKEN`; agent/bot actors are rejected by the approval ledger.
-16. **Opt-out guardrail:** Explicit opt-out language is a hard stop. Do not create override drafts or send follow-ups on those threads unless a human operator handles the conversation outside automation.
+11. **SMS export sync:** `bin/sync_sms_export.py` imports Dialpad Stats text export metadata into local SQLite for direct Dialpad UI sends and other out-of-band messages. It skips existing message IDs to preserve webhook-captured text.
+12. **Create/Update Contact Behavior:** `bin/create_contact.py` upserts shared/local contacts by phone/email match (or forces create with `--allow-duplicate`). `bin/update_contact.py` updates by `--id` with partial fields.
+13. **Current-turn verification:** "Already sent" and "Already updated" are only valid after a fresh current-turn tool result, not from stale session memory. If the current turn has not verified the action yet, say that plainly and run the tool now.
+14. **Identity guardrail:** For first-contact work, soft signals like first name, area code, industry, or job title are not enough to merge or update a contact. Keep uncertain identity `draft-only` and let the CRM layer prove the match before mutating anything.
+15. **Inbound context guardrail:** Webhook `inboundContext` briefs explain identity evidence, recent SMS/call continuity, and draft basis. Low-confidence Sales SMS and missed calls may get generic approval drafts, but not personalized claims. Known contacts only get context-aware approval drafts when identity confidence is high and relevant continuity is no older than 14 days; stale or degraded context stays brief-only.
+16. **Inbound automation guardrail:** Dialpad inbound hooks may create SMS approval drafts, but they must not send customer SMS directly. Use `bin/approve_sms_draft.py` only with a real human actor id and an operator-only `DIALPAD_SMS_APPROVAL_TOKEN`; agent/bot actors are rejected by the approval ledger.
+17. **Opt-out guardrail:** Explicit opt-out language is a hard stop. Do not create override drafts or send follow-ups on those threads unless a human operator handles the conversation outside automation.
 
 ## Reference Documentation
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -53,6 +53,11 @@ bin/list_calls.py --today --limit 20
 bin/list_calls.py --hours 6 --missed --json
 ```
 
+**Check SMS Thread History:**
+```bash
+bin/list_sms_thread.py --phone "+14155551234" --json
+```
+
 **Create Contact:**
 ```bash
 bin/create_contact.py --first-name "Jane" --last-name "Doe" --phone "+14155550123" --email "jane@example.com"
@@ -81,12 +86,13 @@ bin/update_contact.py --id "contact_123" --phone "+14155550123" --job-title "VP"
    - `--dry-run` prints sender resolution and the exact message/request preview without an API call
 8. **Group intro:** `bin/send_group_intro.py` mirrors intro messages as two one-to-one SMS sends (`mirrored_fallback`) because true group threads are unsupported via this wrapper.
 9. **Call history:** `bin/list_calls.py` is the supported call-history command for agents. Use `--json` when downstream automation needs a deterministic response envelope.
-10. **Create/Update Contact Behavior:** `bin/create_contact.py` upserts shared/local contacts by phone/email match (or forces create with `--allow-duplicate`). `bin/update_contact.py` updates by `--id` with partial fields.
-11. **Current-turn verification:** "Already sent" and "Already updated" are only valid after a fresh current-turn tool result, not from stale session memory. If the current turn has not verified the action yet, say that plainly and run the tool now.
-12. **Identity guardrail:** For first-contact work, soft signals like first name, area code, industry, or job title are not enough to merge or update a contact. Keep uncertain identity `draft-only` and let the CRM layer prove the match before mutating anything.
-13. **Inbound context guardrail:** Webhook `inboundContext` briefs explain identity evidence, recent SMS/call continuity, and draft basis. Low-confidence Sales SMS and missed calls may get generic approval drafts, but not personalized claims. Known contacts only get context-aware approval drafts when identity confidence is high and relevant continuity is no older than 14 days; stale or degraded context stays brief-only.
-14. **Inbound automation guardrail:** Dialpad inbound hooks may create SMS approval drafts, but they must not send customer SMS directly. Use `bin/approve_sms_draft.py` only with a real human actor id and an operator-only `DIALPAD_SMS_APPROVAL_TOKEN`; agent/bot actors are rejected by the approval ledger.
-15. **Opt-out guardrail:** Explicit opt-out language is a hard stop. Do not create override drafts or send follow-ups on those threads unless a human operator handles the conversation outside automation.
+10. **SMS thread history:** Before saying a contact was not already messaged, run `bin/list_sms_thread.py --phone PHONE --json` and check `has_outbound` / `outbound_count`. This local SQLite history is the supported current-turn response-state check.
+11. **Create/Update Contact Behavior:** `bin/create_contact.py` upserts shared/local contacts by phone/email match (or forces create with `--allow-duplicate`). `bin/update_contact.py` updates by `--id` with partial fields.
+12. **Current-turn verification:** "Already sent" and "Already updated" are only valid after a fresh current-turn tool result, not from stale session memory. If the current turn has not verified the action yet, say that plainly and run the tool now.
+13. **Identity guardrail:** For first-contact work, soft signals like first name, area code, industry, or job title are not enough to merge or update a contact. Keep uncertain identity `draft-only` and let the CRM layer prove the match before mutating anything.
+14. **Inbound context guardrail:** Webhook `inboundContext` briefs explain identity evidence, recent SMS/call continuity, and draft basis. Low-confidence Sales SMS and missed calls may get generic approval drafts, but not personalized claims. Known contacts only get context-aware approval drafts when identity confidence is high and relevant continuity is no older than 14 days; stale or degraded context stays brief-only.
+15. **Inbound automation guardrail:** Dialpad inbound hooks may create SMS approval drafts, but they must not send customer SMS directly. Use `bin/approve_sms_draft.py` only with a real human actor id and an operator-only `DIALPAD_SMS_APPROVAL_TOKEN`; agent/bot actors are rejected by the approval ledger.
+16. **Opt-out guardrail:** Explicit opt-out language is a hard stop. Do not create override drafts or send follow-ups on those threads unless a human operator handles the conversation outside automation.
 
 ## Reference Documentation
 

--- a/bin/_dialpad_compat.py
+++ b/bin/_dialpad_compat.py
@@ -37,6 +37,7 @@ COMMAND_IDS = {
     "create_sms_draft.create": "create_sms_draft.create",
     "approve_sms_draft.approve": "approve_sms_draft.approve",
     "list_sms_thread.list": "list_sms_thread.list",
+    "sync_sms_export.sync": "sync_sms_export.sync",
     "create_sms_webhook.create": "create_sms_webhook.create",
     "create_sms_webhook.list": "create_sms_webhook.list",
     "create_sms_webhook.delete": "create_sms_webhook.delete",

--- a/bin/_dialpad_compat.py
+++ b/bin/_dialpad_compat.py
@@ -36,6 +36,7 @@ COMMAND_IDS = {
     "send_group_intro.send": "send_group_intro.send",
     "create_sms_draft.create": "create_sms_draft.create",
     "approve_sms_draft.approve": "approve_sms_draft.approve",
+    "list_sms_thread.list": "list_sms_thread.list",
     "create_sms_webhook.create": "create_sms_webhook.create",
     "create_sms_webhook.list": "create_sms_webhook.list",
     "create_sms_webhook.delete": "create_sms_webhook.delete",

--- a/bin/export_sms.py
+++ b/bin/export_sms.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 import time
 import urllib.error
@@ -79,6 +78,25 @@ def build_payload(start_date: str | None, end_date: str | None, office_id: str |
     return payload
 
 
+def build_create_args(start_date: str | None, end_date: str | None, office_id: str | None) -> list[str]:
+    payload = build_payload(start_date, end_date, office_id)
+    args = [
+        "stats",
+        "stats.create",
+        "--export-type",
+        str(payload["export_type"]),
+        "--stat-type",
+        str(payload["stat_type"]),
+    ]
+    if "days_ago_start" in payload:
+        args.extend(["--days-ago-start", str(payload["days_ago_start"])])
+    if "days_ago_end" in payload:
+        args.extend(["--days-ago-end", str(payload["days_ago_end"])])
+    if "office_id" in payload:
+        args.extend(["--office-id", str(payload["office_id"])])
+    return args
+
+
 
 def download_file(url: str, output_path: str) -> None:
     try:
@@ -131,10 +149,9 @@ def main() -> int:
         require_generated_cli()
         require_api_key()
 
-        payload = build_payload(args.start_date, args.end_date, args.office_id)
-        created = run_generated_json(["sms", "export", "--data", json.dumps(payload)])
+        created = run_generated_json(build_create_args(args.start_date, args.end_date, args.office_id))
 
-        request_id = created.get("request_id")
+        request_id = created.get("request_id") or created.get("id")
         if not request_id:
             raise WrapperError(f"Export request did not return request_id: {created}")
 

--- a/bin/list_sms_thread.py
+++ b/bin/list_sms_thread.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Read-only wrapper for local Dialpad SMS thread history."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_PATH = str(ROOT / "scripts")
+if SCRIPTS_PATH not in sys.path:
+    sys.path.append(SCRIPTS_PATH)
+
+from _dialpad_compat import (  # noqa: E402
+    COMMAND_IDS,
+    WrapperArgumentParser,
+    WrapperError,
+    emit_success,
+    handle_wrapper_exception,
+    print_wrapper_error,
+)
+from sms_sqlite import init_db  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = WrapperArgumentParser(description="List local Dialpad SMS history for one phone number")
+    parser.add_argument("--phone", required=True, help="Contact phone number in E.164 format")
+    parser.add_argument("--limit", type=int, default=20, help="Maximum messages to return (default: 20)")
+    parser.add_argument("--json", action="store_true", help="Output JSON")
+    return parser
+
+
+def _validate_limit(value: int) -> int:
+    if value <= 0:
+        raise WrapperError("--limit must be greater than 0", code="invalid_argument", retryable=False)
+    return min(value, 100)
+
+
+def _format_timestamp(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        timestamp_ms = int(float(str(value)))
+    except (TypeError, ValueError):
+        return None
+    return datetime.fromtimestamp(timestamp_ms / 1000, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _summarize_message(message: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "dialpad_id": message.get("dialpad_id"),
+        "direction": message.get("direction"),
+        "from_number": message.get("from_number"),
+        "to_number": message.get("to_number"),
+        "contact_name": message.get("contact_name"),
+        "timestamp": message.get("timestamp"),
+        "timestamp_utc": _format_timestamp(message.get("timestamp")),
+        "message_status": message.get("message_status"),
+        "delivery_result": message.get("delivery_result"),
+        "text": message.get("text") or "",
+    }
+
+
+def load_thread_summary(conn: Any, phone: str, limit: int) -> dict[str, Any]:
+    counts_row = conn.execute(
+        """
+        SELECT
+          COUNT(*) AS count,
+          SUM(CASE WHEN direction = 'outbound' THEN 1 ELSE 0 END) AS outbound_count,
+          SUM(CASE WHEN direction = 'inbound' THEN 1 ELSE 0 END) AS inbound_count,
+          MAX(CASE WHEN direction = 'outbound' THEN timestamp ELSE NULL END) AS latest_outbound_timestamp
+        FROM messages
+        WHERE contact_number = ?
+        """,
+        (phone,),
+    ).fetchone()
+    rows = conn.execute(
+        """
+        SELECT *
+        FROM messages
+        WHERE contact_number = ?
+        ORDER BY timestamp DESC, id DESC
+        LIMIT ?
+        """,
+        (phone, limit),
+    ).fetchall()
+
+    count = int(counts_row["count"] or 0) if counts_row else 0
+    outbound_count = int(counts_row["outbound_count"] or 0) if counts_row else 0
+    inbound_count = int(counts_row["inbound_count"] or 0) if counts_row else 0
+    latest_outbound_timestamp = counts_row["latest_outbound_timestamp"] if counts_row else None
+    messages = [dict(row) for row in reversed(rows)]
+    return {
+        "phone": phone,
+        "count": count,
+        "outbound_count": outbound_count,
+        "inbound_count": inbound_count,
+        "has_outbound": outbound_count > 0,
+        "latest_outbound_timestamp": latest_outbound_timestamp,
+        "latest_outbound_timestamp_utc": _format_timestamp(latest_outbound_timestamp),
+        "messages": [_summarize_message(msg) for msg in messages],
+    }
+
+
+def main() -> int:
+    json_mode = "--json" in sys.argv
+    command = COMMAND_IDS["list_sms_thread.list"]
+    wrapper = "list_sms_thread.py"
+
+    try:
+        args = build_parser().parse_args()
+        json_mode = args.json
+        limit = _validate_limit(args.limit)
+        phone = args.phone.strip()
+        if not phone:
+            raise WrapperError("--phone is required", code="invalid_argument", retryable=False)
+
+        conn = init_db()
+        try:
+            summary = load_thread_summary(conn, phone, limit=limit)
+        finally:
+            conn.close()
+
+        if json_mode:
+            emit_success(command, wrapper, summary)
+            return 0
+
+        print(f"Thread {phone}: {summary['count']} message(s), {summary['outbound_count']} outbound")
+        for message in summary["messages"]:
+            arrow = "OUT" if message["direction"] == "outbound" else "IN"
+            when = message["timestamp_utc"] or "unknown-time"
+            text = str(message["text"])
+            preview = text[:140] + ("..." if len(text) > 140 else "")
+            print(f"[{when}] {arrow}: {preview}")
+        return 0
+    except WrapperError as err:
+        if json_mode:
+            return handle_wrapper_exception(command, wrapper, err, True)
+        print_wrapper_error(err)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/list_sms_thread.py
+++ b/bin/list_sms_thread.py
@@ -22,7 +22,7 @@ from _dialpad_compat import (  # noqa: E402
     handle_wrapper_exception,
     print_wrapper_error,
 )
-from sms_sqlite import init_db  # noqa: E402
+from sms_sqlite import filter_messages, init_db  # noqa: E402
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -92,7 +92,7 @@ def load_thread_summary(conn: Any, phone: str, limit: int) -> dict[str, Any]:
     outbound_count = int(counts_row["outbound_count"] or 0) if counts_row else 0
     inbound_count = int(counts_row["inbound_count"] or 0) if counts_row else 0
     latest_outbound_timestamp = counts_row["latest_outbound_timestamp"] if counts_row else None
-    messages = [dict(row) for row in reversed(rows)]
+    messages = filter_messages([dict(row) for row in reversed(rows)])
     return {
         "phone": phone,
         "count": count,

--- a/bin/sync_sms_export.py
+++ b/bin/sync_sms_export.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Sync Dialpad Stats text exports into local SQLite SMS history."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_PATH = str(ROOT / "scripts")
+if SCRIPTS_PATH not in sys.path:
+    sys.path.append(SCRIPTS_PATH)
+
+from _dialpad_compat import (  # noqa: E402
+    COMMAND_IDS,
+    WrapperArgumentParser,
+    WrapperError,
+    emit_success,
+    handle_wrapper_exception,
+    print_wrapper_error,
+    require_api_key,
+    require_generated_cli,
+    run_generated_json,
+)
+from export_sms import build_create_args, download_file, poll_for_completion  # noqa: E402
+from sms_sqlite import init_db, store_message  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = WrapperArgumentParser(description="Sync Dialpad text export rows into local SMS SQLite history")
+    parser.add_argument("--start-date", dest="start_date", help="Start date (YYYY-MM-DD)")
+    parser.add_argument("--end-date", dest="end_date", help="End date (YYYY-MM-DD)")
+    parser.add_argument("--office-id", dest="office_id", help="Office ID filter")
+    parser.add_argument("--input-csv", help="Import an existing Dialpad texts CSV instead of creating a new export")
+    parser.add_argument("--poll-interval", type=int, default=5, help="Polling interval seconds")
+    parser.add_argument("--timeout", type=int, default=600, help="Timeout seconds")
+    parser.add_argument("--dry-run", action="store_true", help="Parse and summarize without writing SQLite")
+    parser.add_argument("--json", action="store_true", help="Output JSON")
+    return parser
+
+
+def parse_export_timestamp(value: str | None) -> int | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    for fmt in ("%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S"):
+        try:
+            parsed = datetime.strptime(raw, fmt).replace(tzinfo=timezone.utc)
+            return int(parsed.timestamp() * 1000)
+        except ValueError:
+            continue
+    raise WrapperError(f"Invalid export date '{raw}'", code="invalid_argument", retryable=False)
+
+
+def normalize_export_direction(value: str | None) -> str | None:
+    direction = str(value or "").strip().lower()
+    if direction == "internal":
+        return "outbound"
+    if direction == "external":
+        return "inbound"
+    if direction in {"inbound", "outbound"}:
+        return direction
+    return None
+
+
+def export_row_to_webhook_payload(row: dict[str, str]) -> dict[str, Any] | None:
+    direction = normalize_export_direction(row.get("direction"))
+    if direction is None:
+        return None
+
+    message_id = str(row.get("message_id") or "").strip()
+    if not message_id:
+        return None
+
+    from_phone = str(row.get("from_phone") or "").strip()
+    to_phone = str(row.get("to_phone") or "").strip()
+    if not from_phone or not to_phone:
+        return None
+
+    contact_name = str(row.get("name") or "").strip()
+    return {
+        "id": int(message_id),
+        "direction": direction,
+        "from_number": from_phone,
+        "to_number": [to_phone],
+        "text": "",
+        "message_status": "exported",
+        "message_delivery_result": None,
+        "mms": str(row.get("mms") or "").strip().lower() in {"1", "true", "yes"},
+        "created_date": parse_export_timestamp(row.get("date")),
+        "contact": {"name": contact_name} if contact_name else {},
+    }
+
+
+def message_exists(conn: Any, dialpad_id: int) -> bool:
+    row = conn.execute("SELECT 1 FROM messages WHERE dialpad_id = ? LIMIT 1", (dialpad_id,)).fetchone()
+    return row is not None
+
+
+def import_csv(path: str, *, dry_run: bool = False) -> dict[str, int]:
+    counts = {
+        "rows": 0,
+        "imported": 0,
+        "skipped_existing": 0,
+        "skipped_invalid": 0,
+    }
+    conn = init_db()
+    try:
+        with open(path, newline="", encoding="utf-8-sig") as handle:
+            for row in csv.DictReader(handle):
+                counts["rows"] += 1
+                payload = export_row_to_webhook_payload(row)
+                if payload is None:
+                    counts["skipped_invalid"] += 1
+                    continue
+                if message_exists(conn, payload["id"]):
+                    counts["skipped_existing"] += 1
+                    continue
+                if not dry_run:
+                    store_message(conn, payload, is_new=False)
+                counts["imported"] += 1
+    finally:
+        conn.close()
+    return counts
+
+
+def create_export(args: argparse.Namespace, output_path: str) -> dict[str, Any]:
+    created = run_generated_json(build_create_args(args.start_date, args.end_date, args.office_id))
+    request_id = created.get("request_id") or created.get("id")
+    if not request_id:
+        raise WrapperError(f"Export request did not return request_id: {created}")
+
+    final_result = poll_for_completion(
+        str(request_id),
+        args.timeout,
+        args.poll_interval,
+        json_mode=True,
+    )
+    download_url = final_result.get("download_url")
+    if not download_url:
+        raise WrapperError(f"Export result did not include download_url: {final_result}")
+    download_file(str(download_url), output_path)
+    return {
+        "request_id": request_id,
+        "result": final_result,
+    }
+
+
+def main() -> int:
+    json_mode = "--json" in sys.argv
+    command = COMMAND_IDS["sync_sms_export.sync"]
+    wrapper = "sync_sms_export.py"
+
+    try:
+        args = build_parser().parse_args()
+        json_mode = args.json
+        export_info = None
+        if args.input_csv:
+            csv_path = args.input_csv
+        else:
+            require_generated_cli()
+            require_api_key()
+            with tempfile.NamedTemporaryFile(prefix="dialpad-texts-", suffix=".csv", delete=False) as temp:
+                csv_path = temp.name
+            export_info = create_export(args, csv_path)
+
+        counts = import_csv(csv_path, dry_run=args.dry_run)
+        data = {
+            **counts,
+            "dry_run": args.dry_run,
+            "input_csv": csv_path if args.input_csv else None,
+            "export": export_info,
+        }
+        if json_mode:
+            emit_success(command, wrapper, data)
+            return 0
+
+        print(
+            "SMS export sync: "
+            f"{counts['imported']} imported, "
+            f"{counts['skipped_existing']} existing, "
+            f"{counts['skipped_invalid']} invalid, "
+            f"{counts['rows']} row(s) scanned"
+        )
+        return 0
+    except WrapperError as err:
+        if json_mode:
+            return handle_wrapper_exception(command, wrapper, err, True)
+        print_wrapper_error(err)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/plans/2026-05-14-001-fix-dialpad-sms-history-visibility-plan.md
+++ b/docs/plans/2026-05-14-001-fix-dialpad-sms-history-visibility-plan.md
@@ -1,0 +1,112 @@
+---
+status: active
+created: 2026-05-14
+title: Fix Dialpad SMS History Visibility for Agents
+origin: user request in Telegram missed-call triage debugging
+---
+
+# Fix Dialpad SMS History Visibility for Agents
+
+## Problem Frame
+
+The Dialpad agent claimed it could not see whether missed-call prospects had already received SMS replies. That was false for the local operating environment: `scripts/sms_sqlite.py` has a populated message store with inbound and outbound messages. The failure came from relying on call history and the broken Stats SMS export wrapper instead of providing a stable agent-facing SMS thread lookup.
+
+## Scope
+
+In scope:
+- Make recent call JSON expose the caller phone number when Dialpad provides it.
+- Fix the SMS export wrapper so it matches the generated OpenAPI CLI contract.
+- Add a stable `bin/` wrapper for inspecting local SMS threads by phone number.
+- Document the correct response-check workflow for agents.
+
+Out of scope:
+- Changing webhook ingestion behavior.
+- Sending, drafting, or approving any SMS.
+- Backfilling missing SMS history from Dialpad exports.
+- Adding CRM/Attio triage logic.
+
+## Requirements
+
+- Agents must have a deterministic way to check whether a phone number has outbound SMS in local Dialpad history.
+- Call-history JSON must include caller phone details, not just display names.
+- SMS export must no longer fail with `Missing option '--export-type'`.
+- Existing wrapper JSON contracts must stay stable: success/error envelopes remain under `ok`, `command`, `data`, and `meta`.
+- Documentation must make the local SMS thread wrapper the first response-state check before agents claim they cannot see sent messages.
+
+## Existing Patterns
+
+- `bin/list_calls.py` is the stable agent-facing call-history wrapper and delegates to `scripts/list_calls.py`.
+- `bin/export_sms.py` uses `_dialpad_compat.run_generated_json` for generated CLI calls.
+- `scripts/sms_sqlite.py` is operator tooling for the local SMS store; it already exposes thread, search, and stats behavior.
+- `tests/test_json_contract.py` validates wrapper JSON envelopes.
+- `tests/test_list_calls.py` validates call summary normalization.
+
+## Implementation Units
+
+### U1: Expose Caller Phone in Call Summaries
+
+Files:
+- Modify: `scripts/list_calls.py`
+- Test: `tests/test_list_calls.py`
+- Test: `tests/test_json_contract.py`
+
+Approach:
+- Add a caller phone extraction helper that checks `contact.phone`, `external_number`, and `phone_number`.
+- Include `contact_phone` in `to_call_summary`.
+- Keep `contact` as the display name for backwards compatibility.
+
+Test scenarios:
+- A call with both `contact.name` and `contact.phone` returns the name in `contact` and the phone in `contact_phone`.
+- A call with no contact name but an external number still exposes that number as `contact_phone`.
+- The JSON contract test expects the new field without removing existing fields.
+
+### U2: Fix SMS Export Wrapper CLI Invocation
+
+Files:
+- Modify: `bin/export_sms.py`
+- Test: `tests/test_json_contract.py`
+
+Approach:
+- Replace the `sms export --data ...` invocation with the generated Stats CLI shape:
+  `stats stats.create --export-type records --stat-type texts`.
+- Pass date filters as `--days-ago-start` and `--days-ago-end`, preserving the existing public wrapper flags.
+- Continue polling with `stats stats.get --id`.
+
+Test scenarios:
+- `bin/export_sms.py --json` calls `run_generated_json` first with explicit `--export-type records` and `--stat-type texts`.
+- Date filters are converted to days-ago arguments.
+- Existing timeout/error JSON behavior remains unchanged.
+
+### U3: Add Agent-Facing Local SMS Thread Wrapper
+
+Files:
+- Create: `bin/list_sms_thread.py`
+- Modify: `README.md`
+- Modify: `SKILL.md`
+- Modify: `references/api-reference.md`
+- Test: `tests/test_json_contract.py`
+
+Approach:
+- Build a small wrapper around `scripts.sms_sqlite` that accepts `--phone`, `--limit`, and `--json`.
+- Return a stable JSON envelope with the phone number, message count, outbound count, inbound count, latest outbound timestamp, and bounded messages.
+- Provide text output for manual operator use.
+- Do not expose a send path; this is read-only state inspection.
+
+Test scenarios:
+- JSON success for an existing thread includes outbound counts and message summaries.
+- Empty thread returns success with `count: 0`, not an error.
+- Invalid `--limit` returns the standard wrapper error envelope.
+
+## Verification
+
+Run:
+- `python3 -m pytest tests/test_list_calls.py tests/test_json_contract.py -q`
+- `python3 -m pytest -q`
+- Manual smoke:
+  - `python3 bin/list_sms_thread.py --phone +17144763349 --json`
+  - `python3 bin/export_sms.py --start-date 2026-05-13 --end-date 2026-05-13 --json --timeout 30 --poll-interval 5`
+
+## Risks
+
+- Dialpad Stats export may complete slowly or require account permissions even after the wrapper invocation is fixed. The wrapper should report upstream failure honestly.
+- Local SQLite history only contains what webhook/storage ingestion has captured. The docs should distinguish local history from authoritative all-time Dialpad export.

--- a/references/api-reference.md
+++ b/references/api-reference.md
@@ -41,6 +41,7 @@ The OpenAPI-generated CLI (`generated/dialpad`) exposes 241 endpoints. It is the
 - `bin/send_group_intro.py` performs a mirrored fallback (`mode: mirrored_fallback`) by sending two separate one-to-one SMS messages because the wrapper does not guarantee a true group thread.
 - `bin/list_calls.py` provides agent-safe recent call history with `--hours` or `--today`, optional missed-call filtering, and `--json` for a machine-readable envelope. JSON summaries include `contact_phone` when Dialpad exposes the caller number.
 - `bin/list_sms_thread.py` provides read-only local SMS history for one phone number. Use it before claiming that a missed-call contact has no visible SMS response.
+- `bin/sync_sms_export.py` imports Dialpad Stats `texts` export metadata into local SQLite. It is the completeness path for direct Dialpad UI sends and skips existing message IDs to avoid replacing webhook-captured message text.
 - `firstContact` includes an explicit `identityState` and raw lookup status so downstream agents can keep weak matches draft-only instead of mutating a contact record too early.
 
 ```bash
@@ -50,6 +51,7 @@ bin/send_group_intro.py --prospect "+14155550111" --reference "+14155559999" --c
 bin/list_calls.py --today --limit 20
 bin/list_calls.py --hours 6 --missed --json
 bin/list_sms_thread.py --phone "+14155550111" --json
+bin/sync_sms_export.py --start-date 2026-05-13 --end-date 2026-05-13 --json
 ```
 
 ### Manual Operator CLI Examples

--- a/references/api-reference.md
+++ b/references/api-reference.md
@@ -39,7 +39,8 @@ The OpenAPI-generated CLI (`generated/dialpad`) exposes 241 endpoints. It is the
 - `--message-stdin` reads SMS text from stdin.
 - `--dry-run` shows resolved sender and the exact message payload without sending.
 - `bin/send_group_intro.py` performs a mirrored fallback (`mode: mirrored_fallback`) by sending two separate one-to-one SMS messages because the wrapper does not guarantee a true group thread.
-- `bin/list_calls.py` provides agent-safe recent call history with `--hours` or `--today`, optional missed-call filtering, and `--json` for a machine-readable envelope.
+- `bin/list_calls.py` provides agent-safe recent call history with `--hours` or `--today`, optional missed-call filtering, and `--json` for a machine-readable envelope. JSON summaries include `contact_phone` when Dialpad exposes the caller number.
+- `bin/list_sms_thread.py` provides read-only local SMS history for one phone number. Use it before claiming that a missed-call contact has no visible SMS response.
 - `firstContact` includes an explicit `identityState` and raw lookup status so downstream agents can keep weak matches draft-only instead of mutating a contact record too early.
 
 ```bash
@@ -48,6 +49,7 @@ printf '%s' 'The premium hardshell travel case is $499.' | bin/send_sms.py --to 
 bin/send_group_intro.py --prospect "+14155550111" --reference "+14155559999" --confirm-share --from "+14153602954"
 bin/list_calls.py --today --limit 20
 bin/list_calls.py --hours 6 --missed --json
+bin/list_sms_thread.py --phone "+14155550111" --json
 ```
 
 ### Manual Operator CLI Examples

--- a/scripts/list_calls.py
+++ b/scripts/list_calls.py
@@ -234,6 +234,19 @@ def get_caller(call: dict[str, Any]) -> str:
     )
 
 
+def get_caller_phone(call: dict[str, Any]) -> str | None:
+    contact = call.get("contact") or {}
+    if not isinstance(contact, dict):
+        contact = {}
+    return pick_optional_string(
+        [
+            contact.get("phone"),
+            call.get("external_number"),
+            call.get("phone_number"),
+        ]
+    )
+
+
 def get_direction(call: dict[str, Any]) -> str:
     direction = str(call.get("direction") or "").strip().lower()
     if direction in {"inbound", "outbound"}:
@@ -285,6 +298,7 @@ def to_call_summary(call: dict[str, Any]) -> dict[str, object]:
         "call_id": get_call_id(call),
         "started_at": get_started_at_iso(call),
         "contact": get_caller(call),
+        "contact_phone": get_caller_phone(call),
         "direction": get_direction(call),
         "duration_seconds": duration_seconds,
         "duration_display": format_duration(duration_seconds),

--- a/tests/test_json_contract.py
+++ b/tests/test_json_contract.py
@@ -20,6 +20,7 @@ import list_sms_thread
 import lookup_contact
 import make_call
 import send_sms
+import sync_sms_export
 import update_contact
 from _dialpad_compat import ERROR_CODES, WrapperError
 
@@ -658,6 +659,62 @@ class JsonContractTests(unittest.TestCase):
         self.assertEqual(summary["outbound_count"], 1)
         self.assertTrue(summary["has_outbound"])
         self.assertEqual(len(summary["messages"]), 5)
+
+    def test_sync_sms_export_json_dry_run_imports_export_rows(self):
+        class FakeConn:
+            def close(self):
+                pass
+
+        csv_path = Path("/tmp/test-sync-sms-export.csv")
+        csv_path.write_text(
+            '"date","message_id","name","email","target_type","target_id","sender_id","direction","to_phone","from_phone","encrypted_text","encrypted_aes_text","mms","timezone"\n'
+            '"2026-05-08 03:17:13.418699","6676061264355328","Sales","","department","6500922273529856","6500922273529856","internal","+16694009313","+14155201316","","","","UTC"\n',
+            encoding="utf-8",
+        )
+
+        with patch("sync_sms_export.init_db", return_value=FakeConn()), \
+                patch("sync_sms_export.message_exists", return_value=False), \
+                patch("sync_sms_export.store_message") as store_message:
+            code, out, err = self._run(
+                sync_sms_export,
+                ["bin/sync_sms_export.py", "--input-csv", str(csv_path), "--dry-run", "--json"],
+            )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(err, "")
+        parsed = self._parse(out)
+        self._assert_success(parsed, "sync_sms_export.sync")
+        self.assertEqual(parsed["data"]["rows"], 1)
+        self.assertEqual(parsed["data"]["imported"], 1)
+        store_message.assert_not_called()
+
+    def test_sync_sms_export_skips_existing_rows_to_preserve_webhook_text(self):
+        class FakeConn:
+            def close(self):
+                pass
+
+        csv_path = Path("/tmp/test-sync-sms-export-existing.csv")
+        csv_path.write_text(
+            '"date","message_id","name","email","target_type","target_id","sender_id","direction","to_phone","from_phone","encrypted_text","encrypted_aes_text","mms","timezone"\n'
+            '"2026-05-08 03:17:13.418699","6676061264355328","Sales","","department","6500922273529856","6500922273529856","internal","+16694009313","+14155201316","","","","UTC"\n',
+            encoding="utf-8",
+        )
+
+        with patch("sync_sms_export.init_db", return_value=FakeConn()), \
+                patch("sync_sms_export.message_exists", return_value=True), \
+                patch("sync_sms_export.store_message") as store_message:
+            code, out, err = self._run(
+                sync_sms_export,
+                ["bin/sync_sms_export.py", "--input-csv", str(csv_path), "--json"],
+            )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(err, "")
+        parsed = self._parse(out)
+        self._assert_success(parsed, "sync_sms_export.sync")
+        self.assertEqual(parsed["data"]["imported"], 0)
+        self.assertEqual(parsed["data"]["skipped_existing"], 1)
+        store_message.assert_not_called()
 
     def test_update_contact_argparse_failure_is_json_envelope(self):
         code, out, err = self._run(update_contact, ["bin/update_contact.py", "--json"])

--- a/tests/test_json_contract.py
+++ b/tests/test_json_contract.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import sqlite3
 import sys
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
+from datetime import date
 from pathlib import Path
 from unittest.mock import patch
 
@@ -14,6 +16,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "bin"))
 import create_contact
 import create_sms_webhook
 import export_sms
+import list_sms_thread
 import lookup_contact
 import make_call
 import send_sms
@@ -431,7 +434,11 @@ class JsonContractTests(unittest.TestCase):
         call_count = {"n": 0}
 
         def fake_run(cmd: list[str]):
-            if cmd[:2] == ["sms", "export"]:
+            if cmd[:2] == ["stats", "stats.create"]:
+                self.assertIn("--export-type", cmd)
+                self.assertIn("records", cmd)
+                self.assertIn("--stat-type", cmd)
+                self.assertIn("texts", cmd)
                 return {"request_id": "r1"}
             if cmd[:2] == ["stats", "stats.get"]:
                 call_count["n"] += 1
@@ -447,6 +454,43 @@ class JsonContractTests(unittest.TestCase):
         parsed = self._parse(out)
         self._assert_success(parsed, "export_sms.export")
         self.assertIn("progress", parsed["meta"])
+
+    def test_export_sms_date_filters_become_stats_cli_options(self):
+        commands = []
+
+        def fake_run(cmd: list[str]):
+            commands.append(cmd)
+            if cmd[:2] == ["stats", "stats.create"]:
+                return {"id": "r1"}
+            if cmd[:2] == ["stats", "stats.get"]:
+                return {"status": "complete"}
+            raise AssertionError(cmd)
+
+        with patch("export_sms.require_generated_cli"), \
+                patch("export_sms.require_api_key"), \
+                patch("export_sms.run_generated_json", side_effect=fake_run), \
+                patch("export_sms.date") as fake_date:
+            fake_date.today.return_value = date(2026, 5, 14)
+            code, out, err = self._run(
+                export_sms,
+                ["bin/export_sms.py", "--start-date", "2026-05-13", "--end-date", "2026-05-14", "--json"],
+            )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(err, "")
+        self._assert_success(self._parse(out), "export_sms.export")
+        self.assertEqual(commands[0], [
+            "stats",
+            "stats.create",
+            "--export-type",
+            "records",
+            "--stat-type",
+            "texts",
+            "--days-ago-start",
+            "1",
+            "--days-ago-end",
+            "0",
+        ])
 
     def test_export_sms_timeout_maps_to_timeout(self):
         with patch("export_sms.require_generated_cli"), \
@@ -467,6 +511,153 @@ class JsonContractTests(unittest.TestCase):
         parsed = self._parse(out)
         self._assert_error(parsed, "list_calls.list")
         self.assertEqual(parsed["error"]["code"], "invalid_argument")
+
+    def test_list_sms_thread_json_success_reports_outbound_state(self):
+        class FakeConn:
+            def close(self):
+                pass
+
+        messages = [
+            {
+                "dialpad_id": 1,
+                "direction": "inbound",
+                "from_number": "+14155550123",
+                "to_number": "+14155201316",
+                "contact_name": "Jane Doe",
+                "timestamp": 1770000000000,
+                "text": "Question",
+            },
+            {
+                "dialpad_id": 2,
+                "direction": "outbound",
+                "from_number": "+14155201316",
+                "to_number": "+14155550123",
+                "contact_name": "Jane Doe",
+                "timestamp": 1770000060000,
+                "message_status": "sent",
+                "delivery_result": "success",
+                "text": "Answer",
+            },
+        ]
+
+        with patch("list_sms_thread.init_db", return_value=FakeConn()), \
+                patch(
+                    "list_sms_thread.load_thread_summary",
+                    return_value={
+                        "phone": "+14155550123",
+                        "count": 2,
+                        "outbound_count": 1,
+                        "inbound_count": 1,
+                        "has_outbound": True,
+                        "latest_outbound_timestamp": 1770000060000,
+                        "latest_outbound_timestamp_utc": "2026-02-02T08:41:00Z",
+                        "messages": [list_sms_thread._summarize_message(message) for message in messages],
+                    },
+                ):
+            code, out, err = self._run(
+                list_sms_thread,
+                ["bin/list_sms_thread.py", "--phone", "+14155550123", "--json"],
+            )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(err, "")
+        parsed = self._parse(out)
+        self._assert_success(parsed, "list_sms_thread.list")
+        self.assertEqual(parsed["data"]["phone"], "+14155550123")
+        self.assertEqual(parsed["data"]["count"], 2)
+        self.assertEqual(parsed["data"]["outbound_count"], 1)
+        self.assertTrue(parsed["data"]["has_outbound"])
+
+    def test_list_sms_thread_empty_thread_is_success(self):
+        class FakeConn:
+            def close(self):
+                pass
+
+        with patch("list_sms_thread.init_db", return_value=FakeConn()), \
+                patch(
+                    "list_sms_thread.load_thread_summary",
+                    return_value={
+                        "phone": "+14155550123",
+                        "count": 0,
+                        "outbound_count": 0,
+                        "inbound_count": 0,
+                        "has_outbound": False,
+                        "latest_outbound_timestamp": None,
+                        "latest_outbound_timestamp_utc": None,
+                        "messages": [],
+                    },
+                ):
+            code, out, err = self._run(
+                list_sms_thread,
+                ["bin/list_sms_thread.py", "--phone", "+14155550123", "--json"],
+            )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(err, "")
+        parsed = self._parse(out)
+        self._assert_success(parsed, "list_sms_thread.list")
+        self.assertEqual(parsed["data"]["count"], 0)
+        self.assertFalse(parsed["data"]["has_outbound"])
+
+    def test_list_sms_thread_argparse_failure_is_json_envelope(self):
+        code, out, err = self._run(
+            list_sms_thread,
+            ["bin/list_sms_thread.py", "--phone", "+14155550123", "--limit", "0", "--json"],
+        )
+        self.assertEqual(code, 2)
+        self.assertEqual(err, "")
+        parsed = self._parse(out)
+        self._assert_error(parsed, "list_sms_thread.list")
+        self.assertEqual(parsed["error"]["code"], "invalid_argument")
+
+    def test_list_sms_thread_counts_full_thread_not_only_returned_slice(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute(
+            """
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY,
+                dialpad_id INTEGER,
+                contact_number TEXT,
+                contact_name TEXT,
+                direction TEXT,
+                from_number TEXT,
+                to_number TEXT,
+                text TEXT,
+                message_status TEXT,
+                delivery_result TEXT,
+                timestamp INTEGER
+            )
+            """
+        )
+        for idx in range(25):
+            conn.execute(
+                """
+                INSERT INTO messages (
+                    dialpad_id, contact_number, contact_name, direction,
+                    from_number, to_number, text, timestamp
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    idx + 1,
+                    "+14155550123",
+                    "Jane Doe",
+                    "outbound" if idx == 0 else "inbound",
+                    "+14155201316" if idx == 0 else "+14155550123",
+                    "+14155550123" if idx == 0 else "+14155201316",
+                    f"message {idx}",
+                    1770000000000 + idx,
+                ),
+            )
+        conn.commit()
+
+        summary = list_sms_thread.load_thread_summary(conn, "+14155550123", limit=5)
+
+        self.assertEqual(summary["count"], 25)
+        self.assertEqual(summary["outbound_count"], 1)
+        self.assertTrue(summary["has_outbound"])
+        self.assertEqual(len(summary["messages"]), 5)
 
     def test_update_contact_argparse_failure_is_json_envelope(self):
         code, out, err = self._run(update_contact, ["bin/update_contact.py", "--json"])

--- a/tests/test_json_contract.py
+++ b/tests/test_json_contract.py
@@ -660,6 +660,56 @@ class JsonContractTests(unittest.TestCase):
         self.assertTrue(summary["has_outbound"])
         self.assertEqual(len(summary["messages"]), 5)
 
+    def test_list_sms_thread_filters_messages_before_summary(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute(
+            """
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY,
+                dialpad_id INTEGER,
+                contact_number TEXT,
+                contact_name TEXT,
+                direction TEXT,
+                from_number TEXT,
+                to_number TEXT,
+                text TEXT,
+                message_status TEXT,
+                delivery_result TEXT,
+                timestamp INTEGER
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO messages (
+                dialpad_id, contact_number, contact_name, direction,
+                from_number, to_number, text, timestamp
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                1,
+                "+14155550123",
+                "Jane Doe",
+                "inbound",
+                "+14155550123",
+                "+14155201316",
+                "raw sensitive text",
+                1770000000000,
+            ),
+        )
+        conn.commit()
+
+        def redact(messages):
+            return [{**message, "text": "[redacted]"} for message in messages]
+
+        with patch("list_sms_thread.filter_messages", side_effect=redact) as filter_messages:
+            summary = list_sms_thread.load_thread_summary(conn, "+14155550123", limit=5)
+
+        filter_messages.assert_called_once()
+        self.assertEqual(summary["messages"][0]["text"], "[redacted]")
+
     def test_sync_sms_export_json_dry_run_imports_export_rows(self):
         class FakeConn:
             def close(self):

--- a/tests/test_list_calls.py
+++ b/tests/test_list_calls.py
@@ -79,7 +79,7 @@ class ListCallsTests(unittest.TestCase):
                 "duration": 65000,
                 "direction": "outbound",
                 "state": "completed",
-                "contact": {"name": "Taylor Prospect"},
+                "contact": {"name": "Taylor Prospect", "phone": "+14155550123"},
                 "entry_point_target": {"name": "Sales Line"},
                 "recording_url": "https://example.com/recording.mp3",
                 "disposition_name": "demo_scheduled",
@@ -89,6 +89,7 @@ class ListCallsTests(unittest.TestCase):
         self.assertEqual(summary["call_id"], "call-123")
         self.assertEqual(summary["started_at"], "2025-03-25T11:00:00Z")
         self.assertEqual(summary["contact"], "Taylor Prospect")
+        self.assertEqual(summary["contact_phone"], "+14155550123")
         self.assertEqual(summary["direction"], "outbound")
         self.assertEqual(summary["duration_seconds"], 65)
         self.assertEqual(summary["duration_display"], "1:05")
@@ -96,6 +97,20 @@ class ListCallsTests(unittest.TestCase):
         self.assertEqual(summary["line"], "Sales Line")
         self.assertEqual(summary["recording_url"], "https://example.com/recording.mp3")
         self.assertEqual(summary["outcome"], "demo_scheduled")
+
+    def test_to_call_summary_falls_back_to_external_number_for_contact_phone(self):
+        summary = to_call_summary(
+            {
+                "date_started": 1742900400000,
+                "duration": 0,
+                "direction": "inbound",
+                "state": "hangup",
+                "external_number": "+17276880795",
+            }
+        )
+
+        self.assertEqual(summary["contact"], "+17276880795")
+        self.assertEqual(summary["contact_phone"], "+17276880795")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What
- Adds `bin/list_sms_thread.py`, a read-only agent wrapper for checking local Dialpad SMS thread history and outbound response state.
- Exposes `contact_phone` in `bin/list_calls.py --json` call summaries so missed-call triage can map calls back to phone numbers without extra raw API inspection.
- Fixes `bin/export_sms.py` to call the generated Stats CLI with explicit `--export-type records --stat-type texts` options.
- Documents the correct current-turn SMS response-state check in README, SKILL, and API reference docs.

## Why
Missed-call triage incorrectly claimed it could not see whether contacts had already received SMS replies. The local SQLite store was populated, but agents lacked a stable wrapper and the export wrapper was broken against the generated CLI contract.

## Tests
- `python3 -m pytest tests/test_list_calls.py tests/test_json_contract.py -q` — 36 passed
- `python3 bin/list_sms_thread.py --phone +17144763349 --json | jq '{ok, data:{count:.data.count,outbound_count:.data.outbound_count,returned:(.data.messages|length),has_outbound:.data.has_outbound}}'`
- `python3 bin/export_sms.py --start-date 2026-05-13 --end-date 2026-05-13 --json --timeout 30 --poll-interval 5`
- `python3 -m pytest -q` — 223 passed

## Browser Tests
Skipped: this repo change only touches Python CLI wrappers, docs, and tests. No browser routes or frontend files are affected.

## AI Assistance
Used AI assistance for implementation, review, and test selection. Testing level: targeted wrapper tests, live Dialpad wrapper smoke checks, and full local pytest suite. I understand this code.


## Update: Export Sync
- Adds `bin/sync_sms_export.py` to import Dialpad Stats `texts` export metadata into local SQLite for direct Dialpad UI sends and other out-of-band messages.
- The sync skips existing message IDs so webhook-captured plaintext is preserved instead of overwritten by export metadata.

Additional tests:
- `python3 -m pytest tests/test_json_contract.py tests/test_list_calls.py -q` — 38 passed
- `python3 bin/sync_sms_export.py --input-csv /tmp/dialpad-texts7.Swc55w.csv --dry-run --json` — 51 rows scanned, 51 existing, 0 invalid
- `python3 -m pytest -q` — 225 passed
