### PR TITLE
fix: parse Dialpad transcript lines

### DIFF
--- a/docs/plans/2026-05-21-001-fix-dialpad-lines-transcript-sync-plan.md
+++ b/docs/plans/2026-05-21-001-fix-dialpad-lines-transcript-sync-plan.md
@@ -1,0 +1,91 @@
+---
+status: active
+created: 2026-05-21
+type: fix
+---
+
+# Dialpad Lines Transcript Parsing and Runtime Sync
+
+## Problem
+
+Dialpad call `5479428721549312` returned transcript data from `GET /api/v2/transcripts/{call_id}` as a `lines` array, but the transcript wrapper only parsed string transcript fields and list fields named `utterances`, `segments`, `items`, or `transcript`. The wrapper therefore reported `available: false` and `unavailable_reason: no_transcript` even though Dialpad had transcript lines.
+
+Runtime skill copies can also drift from the source tree. The existing workspace sync command at `~/projects/skills/sync-skills.sh` is the correct deployment path because it materializes project skills into OpenClaw/AlphaClaw skill roots as real directories.
+
+## Scope Boundaries
+
+- Fix transcript parsing in this skill source tree.
+- Add regression coverage for Dialpad's `lines` response shape.
+- Run the existing workspace sync script after the source fix is verified.
+- Install a user systemd timer that runs the existing sync script nightly.
+- Do not rewrite the generated Dialpad OpenAPI CLI.
+- Do not change Attio note behavior in this patch.
+- Do not replace `sync-skills.sh` with ad hoc runtime-copy logic.
+
+## Existing Patterns
+
+- `scripts/get_transcript.py` owns response normalization for transcript payloads.
+- `tests/test_get_transcript.py` covers parser response shapes and unavailable states.
+- `bin/get_call_transcript.py` is the agent-facing wrapper and should remain transcript-only.
+- `~/projects/skills/sync-skills.sh` already syncs project skill source directories into `~/.openclaw/skills` and AlphaClaw's materialized skill root when present.
+
+## Implementation Units
+
+### U1: Parse Dialpad `lines` Transcript Payloads
+
+**Files**
+
+- Modify: `scripts/get_transcript.py`
+- Test: `tests/test_get_transcript.py`
+
+**Approach**
+
+Extend `format_transcript()` to treat `lines` as a list candidate, include `name` as a speaker field, and ignore non-transcript line types such as moments so summary fragments do not become transcript text.
+
+**Test Scenarios**
+
+- A payload with `lines` containing `type: transcript`, `name`, and `content` renders speaker-prefixed transcript text.
+- A non-transcript line in the same payload is skipped.
+- Existing payload shapes still pass unchanged.
+
+**Verification**
+
+- `python3 -m pytest tests/test_get_transcript.py tests/test_get_call_transcript_wrapper.py`
+- Live smoke command for the known call returns `available: true` from `bin/get_call_transcript.py --call-id 5479428721549312 --json`.
+
+### U2: Keep Runtime Skills Synchronized Nightly
+
+**Files**
+
+- Create live user systemd files under `~/.config/systemd/user/`.
+
+**Approach**
+
+Install a user service that executes `/home/art/projects/skills/sync-skills.sh` from `/home/art/projects/skills`, and a timer that runs nightly with persistent catch-up. Enable and start the timer with `systemctl --user`.
+
+**Test Scenarios**
+
+- `systemd-analyze verify --user` accepts the service and timer files.
+- `systemctl --user list-timers` shows the nightly sync timer after enablement.
+- A manual service start succeeds or surfaces a concrete sync failure.
+
+**Verification**
+
+- `~/projects/skills/sync-skills.sh`
+- `systemctl --user daemon-reload`
+- `systemctl --user enable --now skills-sync.timer`
+- `systemctl --user start skills-sync.service`
+- `systemctl --user status skills-sync.service --no-pager`
+- `systemctl --user list-timers skills-sync.timer --no-pager`
+
+## Risks
+
+- `sync-skills.sh` prunes managed skill roots to match project sources. This is intended behavior, but verification should confirm the Dialpad runtime copy is present after sync.
+- The workspace root is not a git repository, so live systemd files are runtime configuration rather than part of this skill PR. The code/test portion remains durable in this skill repository.
+
+## Final Verification Checklist
+
+- Focused parser tests pass.
+- The known Dialpad call now returns transcript text.
+- Runtime skill copies match the source parser after `sync-skills.sh`.
+- The nightly systemd timer is enabled and scheduled.

--- a/scripts/get_transcript.py
+++ b/scripts/get_transcript.py
@@ -29,10 +29,12 @@ def format_transcript(payload: dict[str, Any]) -> str:
         if isinstance(candidate, str) and candidate.strip():
             return candidate.strip()
 
+    list_candidate_key = None
     list_candidates = []
-    for key in ("utterances", "segments", "items", "transcript"):
+    for key in ("utterances", "segments", "items", "lines", "transcript"):
         value = payload.get(key)
         if isinstance(value, list):
+            list_candidate_key = key
             list_candidates = value
             break
 
@@ -40,6 +42,9 @@ def format_transcript(payload: dict[str, Any]) -> str:
     for item in list_candidates:
         if not isinstance(item, dict):
             continue
+        if list_candidate_key == "lines" and item.get("type") and item.get("type") != "transcript":
+            continue
+
         text = (
             item.get("text")
             or item.get("transcript")
@@ -51,6 +56,7 @@ def format_transcript(payload: dict[str, Any]) -> str:
         speaker = (
             item.get("speaker")
             or item.get("speaker_name")
+            or item.get("name")
             or item.get("participant")
             or item.get("role")
         )

--- a/tests/test_get_transcript.py
+++ b/tests/test_get_transcript.py
@@ -30,6 +30,42 @@ class GetTranscriptTests(unittest.TestCase):
             "Agent: Hello\nProspect: I have a question",
         )
 
+    def test_format_transcript_reads_dialpad_lines(self):
+        payload = {
+            "call_id": "call-123",
+            "lines": [
+                {
+                    "type": "moment",
+                    "name": "Agent",
+                    "content": "whole_call_summary_fragment",
+                },
+                {
+                    "type": "transcript",
+                    "name": "Agent",
+                    "content": "Hello.",
+                },
+                {
+                    "type": "transcript",
+                    "name": "Prospect",
+                    "content": "I have a question.",
+                },
+            ],
+        }
+
+        self.assertEqual(
+            get_transcript.format_transcript(payload),
+            "Agent: Hello.\nProspect: I have a question.",
+        )
+
+    def test_format_transcript_keeps_typed_non_line_items(self):
+        payload = {
+            "items": [
+                {"type": "message", "speaker_name": "Agent", "text": "Hello"},
+            ],
+        }
+
+        self.assertEqual(get_transcript.format_transcript(payload), "Agent: Hello")
+
     def test_get_call_transcript_returns_endpoint_transcript(self):
         def fake_api_get(path):
             if path == "/transcripts/call-123/url":


### PR DESCRIPTION
## What
- Parse Dialpad transcript payloads that arrive as `lines` arrays.
- Preserve existing typed `items` transcript parsing while filtering non-transcript Dialpad line moments.
- Add a plan artifact documenting the runtime sync path and nightly timer setup.

## Why
Dialpad returned transcript data for call `5479428721549312`, but the wrapper reported `no_transcript` because it did not parse the `lines` response shape.

## Tests
- `python3 -m pytest tests/test_get_transcript.py tests/test_get_call_transcript_wrapper.py`
- `python3 -m py_compile scripts/get_transcript.py bin/get_call_transcript.py`
- `python3 -m pytest`
- Live smoke: `bin/get_call_transcript.py --call-id 5479428721549312 --json` returned `available: true`
- Runtime sync: `~/projects/skills/sync-skills.sh`; verified source parser matches `~/.openclaw/skills/...` and AlphaClaw materialized copy

## AI Assistance
Implemented with AI assistance. Full local test suite passed. Browser testing was not applicable because this branch changes CLI parser code, tests, and a plan artifact only.

## Runtime Notes
Installed `~/.config/systemd/user/project-skills-sync.service` and `.timer` locally to run `~/projects/skills/sync-skills.sh` nightly at 03:20 with persistent catch-up. `systemctl --user` could not connect to the user bus from this shell, so enablement was applied by creating the normal `timers.target.wants` symlink; the user manager should pick it up after reload/login.
