### PR TITLE
feat(dialpad): Attio CRM + calendar context adapters (S1 Phase A)

### DIFF
--- a/docs/brainstorms/2026-06-18-s1-wire-enrichment-paths-requirements.md
+++ b/docs/brainstorms/2026-06-18-s1-wire-enrichment-paths-requirements.md
@@ -1,0 +1,70 @@
+# Requirements — S1: Wire the dead enrichment/draft paths in the Dialpad auto-responder
+
+**Date:** 2026-06-18
+**Scope tier:** Standard
+**Source idea:** S1 in `docs/ideation/2026-06-18-dialpad-auto-response-enrichment.md`
+**Component:** `scripts/webhook_server.py` (standalone Dialpad webhook server)
+
+## Problem
+
+The auto-responder already implements three richer draft modes — CRM-aware, calendar-aware, and QMD-knowledge — but every inbound SMS falls back to a generic template (`"thanks for reaching ShapeScale for Business Sales…"`). Two causes:
+
+1. The context commands those modes call (`DIALPAD_CRM_CONTEXT_COMMAND`, `DIALPAD_CALENDAR_CONTEXT_COMMAND`, `DIALPAD_QMD_COMMAND`) are unset/unverified, so the modes fail closed.
+2. Even with the commands set, the rich path is gated by `_high_confidence_sales_context_allowed()` (`webhook_server.py:2203-2210`): it only runs for a **known, high-confidence Dialpad contact**. The "super generic" complaint is mostly about *unknown* senders, who are routed to the generic fallback before Attio is ever consulted.
+
+## Outcome
+
+For any inbound SMS on the sales line, the operator-facing approval draft contains real context — Attio company/deal/stage/last-note, a relevant QMD/ShapeScale answer, and (when available) the person's upcoming demo time — instead of boilerplate. A wrong identity match is made visible to the operator, not hidden. Auto-send behavior is unchanged.
+
+## In scope
+
+1. **Attio CRM adapter** — a standalone CLI invoked as `<cmd> "<phone> <name> <company>"`, returning JSON `{usable, status, basis, summary, deal, stage, company, owner}` per the contract at `webhook_server.py:2174-2180, 2254-2275`. Looks up the Attio record by phone (primary) / name. Built as a reusable CLI so **S2** can call it as a cascade stage.
+2. **QMD leg** — confirm `qmd` is reachable from the webhook's runtime environment, set `DIALPAD_QMD_COMMAND`, and fix PATH/HOME if the subprocess can't find it. Expected to be configuration + environment, not new code. Contract: `<cmd> search "<query>"` → stdout with `@@` snippet markers (`webhook_server.py:2043-2114`).
+3. **Calendar adapter** — a standalone CLI invoked as `<cmd> "<name> <company> <deal> <timestamp>"`, returning `{usable, status, basis, summary|title, startsInMinutes}` per `webhook_server.py:2300-2314`. **Source order: Calendly primary** (matched by email), **Attio deal demo-date attribute as fallback** for phone-only inbound where no email is resolved.
+4. **Un-gate the lookups into the draft lane** — run the CRM/QMD/calendar lookups in the operator-approval draft path for medium/unknown-confidence senders, not only the `identityConfidence == "high"` known-contact path. Generic fallback fires only when all applicable adapters return `usable == false`.
+5. **Provenance line in the draft** — the operator-facing draft carries the match basis inline (e.g., `↳ Attio: +1415… → Acme Corp · stage: Demo Booked · matched on phone`) so the operator can sanity-check before approving.
+6. **Wiring** — set the three env vars + any API secrets in `.env` / the host secret store, restart `dialpad-webhook.service`. `DIALPAD_QMD_COMMAND` must be an **absolute path** (`/home/art/.local/bin/qmd`) — see resolved finding 3.
+7. **Move draft generation off the webhook ACK path** *(forced by the un-gate — see resolved finding 1)*. Today `create_proactive_reply_draft()` runs the up-to-3×8s lookups **inline before** `send_response(200)` (`webhook_server.py:3329` before `:3475`); un-gating makes that run on every inbound, blocking the ACK for up to 24s when Dialpad expects ~5s. Required change: ACK 200 immediately, generate + store the draft in a background thread, and make the work **idempotent** on the Dialpad event id so a Dialpad retry (triggered by a slow ACK) cannot create a duplicate draft or duplicate send. This is the delivery-correctness invariant for the change; auto-send behavior itself stays as-is (S4).
+
+## Out of scope (downstream — must not conflict)
+
+- **S2** — full phone-first identity resolver (Gmail/Granola, Apollo, reverse-phone, caching, confidence scoring). S1's Attio adapter is the reusable first stage of that cascade; S1 does **not** build the cascade or rewrite identity confidence.
+- **S4** — confidence-gated auto-send. Auto-send remains exactly as today (gated). Un-gating affects only the human-approval draft lane.
+- **S5** routing + Attio write-back · **S3** segmented customer/prospect templates · **S6** approval-DB eval loop.
+- No rewrite of the Dialpad contact-lookup identity scorer; S1 bypasses the gate for the draft lane only.
+
+## Key decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| How far to reach past the identity gate | Un-gate lookups into the **human-approval draft lane** only | Surfaces context on most inbound now without acting unattended on a possibly-wrong match; keeps S2/S4 seams clean |
+| Uncertain Attio match | **Enrich + label** with provenance inline; operator catches bad matches | Preserves human-in-the-loop; avoids silently dropping useful context |
+| Calendar source | **Calendly primary, Attio deal demo-date fallback** | Calendly keys on email; Attio fallback covers phone-only inbound |
+| Adapter form | Standalone CLIs, **no live-OpenClaw dependency** | The webhook is a standalone systemd service; must not depend on the gateway being up |
+| Auto-send | **Unchanged** | Owned by S4 |
+
+## Resolved de-risk findings (2026-06-18)
+
+1. **RESOLVED — draft generation IS on the ACK path** (`webhook_server.py:3329` runs before `:3475`), up to 24s inline (3×8s timeouts), no threading. Dialpad expects ~5s and will time out → retry. Un-gating exposes this on every inbound, so the async refactor + idempotency is now **required scope (item 7)**, not an assumption.
+2. **UNVERIFIABLE — Attio demo-date attribute not confirmed.** The claude.ai Attio MCP is returning **401** (token broken/expired); the standard `deals` object returned 0 rows, so ShapeScale's pipeline is likely a **custom object or a List**, not `deals`. First implementation step must discover, via the Attio REST API with a valid key: (a) the correct pipeline object/list slug, (b) the demo-date attribute slug for the calendar fallback. **Also: rotate the exposed Attio MCP token.**
+3. **RESOLVED — `qmd` is not on the systemd service PATH.** Binary is at `/home/art/.local/bin/qmd` (→ `~/.bun/bin/qmd`); the unit's PATH is the nix-store systemd bin only. Fix is concrete: set `DIALPAD_QMD_COMMAND=/home/art/.local/bin/qmd` in `.env`. (Today it fails closed to `"unavailable"`, so no crash — just no knowledge.)
+
+## Remaining assumptions (planning verifies)
+
+4. **Attio search-by-phone hit rate** is unknown. If most inbound senders aren't in Attio, the CRM/calendar legs no-op for them and QMD carries enrichment — still an improvement over boilerplate.
+5. The un-gate is a **code change** to mode-selection in `webhook_server.py` (run rich lookups in the draft branch; retain generic fallback when all unusable), not a pure config change.
+6. A **dedicated Attio API key** is available for the webhook env (the adapter calls Attio REST directly, not via the broken/unreachable claude.ai Attio MCP).
+
+## Success criteria
+
+- A known Attio contact texting the sales line produces an operator draft containing real company/stage/last-note + a relevant QMD answer + a provenance line — verified on a real or replayed inbound message.
+- An unknown sender asking a pricing/booking/product question gets a real QMD-grounded answer in the draft instead of the generic template.
+- When all three adapters return unusable, the generic fallback still fires unchanged (no regression for true cold/unknown contacts with no question match).
+- No change to auto-send behavior; the webhook does not gain a hard dependency on OpenClaw/AlphaClaw being up.
+
+## Open questions for planning
+
+- Exact insertion point for the un-gate in the mode-selection block (`webhook_server.py:2337-2393, 2504-2559`) that runs the rich lookups in the draft lane while preserving the existing high-confidence auto-path.
+- Whether the three lookups should run concurrently to stay within a latency budget.
+- Calendly API: which auth/credential and which endpoint resolves a scheduled event by invitee email.
+- Where the provenance line is rendered so it reaches the operator (Telegram approval card) but is stripped from the customer-facing send text.

--- a/docs/ideation/2026-06-18-dialpad-auto-response-enrichment.md
+++ b/docs/ideation/2026-06-18-dialpad-auto-response-enrichment.md
@@ -1,0 +1,102 @@
+# Ideation — Dialpad inbound auto-response: enrichment, branching, routing
+
+**Date:** 2026-06-18
+**Subject:** Improve the Dialpad inbound-message auto-responder (AlphaClaw/OpenClaw) so it identifies the sender, branches customer-vs-prospect, drafts grounded replies, auto-sends at high confidence, and routes sales vs work.
+**Mode:** repo-grounded against `~/projects/skills/work/dialpad/` + AlphaClaw state.
+**Output:** markdown (no `docs/ideation/` HTML convention in this repo; markdown is grep-able and fits the rg/Obsidian workflow).
+
+---
+
+## The reframe (read this first)
+
+Three findings from grounding overturn the premise of the request:
+
+1. **The "super generic" problem is mostly a wiring gap, not a missing feature.** `webhook_server.py` already implements *three* draft modes: generic fallback, QMD-knowledge "rich reply," and a **CRM-aware / calendar-aware** draft. The richer modes **fail closed to the generic template** because `DIALPAD_CRM_CONTEXT_COMMAND`, `DIALPAD_CALENDAR_CONTEXT_COMMAND` are unset in `.env` and `DIALPAD_QMD_COMMAND` is unverified. You are not building enrichment from zero — you are filling in commands the code already calls.
+
+2. **Apollo is the *last* enrichment step, not the first.** Apollo's match endpoint cannot enrich by phone number — it needs email or name+domain. Inbound SMS gives you only a phone. So "look up Apollo.io" can't lead the cascade. The phone→person wall is the real engineering problem, and the cheap/accurate signal lives in systems you already own (Attio, Gmail, Dialpad history, Granola), not Apollo.
+
+3. **Your eval dataset already exists.** `sms_approvals.db` logs every generated draft and the operator's approve/edit/reject + final sent text. Generated-vs-sent diff is free labeled ground truth. "Have a subagent analyze the traces" → the asset isn't Opik (not wired), it's the approval log.
+
+---
+
+## Grounding (verified, with pointers)
+
+- **Ingress:** standalone Python HTTP server, `webhook_server.py:3207` (`POST /webhook/dialpad`), port 8888, systemd `dialpad-webhook.service`. **Not** routed through OpenClaw — hooks disabled (`openclaw.json:1963` `"enabled": false`).
+- **Storage:** `~/clawd/logs/sms.db` + `~/niemand/logs/sms.db` (messages, FTS5); `~/clawd/logs/sms_approvals.db` (drafts, status, fingerprint, metadata).
+- **Draft modes:** generic fallback `webhook_server.py:1998-2012`; rich/QMD `:2434-2501`; CRM/calendar-aware `:2337-2393` (both context commands **unset** → fail closed).
+- **Contact lookup:** `lookup_contact_enrichment() :460-520` — **Dialpad API only**. No Attio, Apollo, web, or email. No auto contact create on inbound.
+- **Routing:** default → Telegram group `-1003882776023` (no topics); priority phones → Sales/Command Center group `-1003744039348` topic 2. No sales-vs-work split.
+- **Send gate:** draft-for-review. Approval via Telegram buttons or `bin/approve_sms_draft.py` + operator token; bot/agent actors rejected. (`DIALPAD_AUTO_REPLY_ENABLED=1` governs draft creation, not unattended send.)
+- **Telemetry:** no Opik traces flowing (`opik-trace-analytics` skill installed, not wired). Session jsonl + the two SQLite DBs + `/tmp/openclaw/openclaw-*.log`.
+- **Volume:** ~5–10 inbound SMS/day; ~60–70% trigger a draft.
+
+### API feasibility (the constraints that shape design)
+- **Dialpad:** CONFIRMED — SMS event webhooks (`from_number`, `contact.id`, `contact.name`, `text`); `POST /api/v2/sms/send`; contact create `POST /api/v2/contacts` / update `PATCH .../{id}`. **No notes/metadata field on contacts** → canonical enrichment store must be Attio, not Dialpad. Company-wide 20 req/sec.
+- **Apollo:** `POST /api/v1/people/match` by **email or name+domain only** — *no phone input*. Phone *reveal* is async (webhook, minutes), ~9+ credits (~$1.80+) per full enrich.
+- **Reverse-phone (Numverify/Zyla/Searchbug):** cheap but **low accuracy on business/VOIP numbers** — last-resort tail, not a primary.
+
+---
+
+## Candidates generated → critiqued (28 → 6 survivors)
+
+**Merged/rejected (with reasons):**
+- *Reverse-phone & web-search as primary identification* — rejected as standalone: low hit rate on business numbers, noisy, costs credits for weak signal. Survives only as the cascade tail in **S2**.
+- *Granola/meeting-history, last-touchpoint recency, per-segment templates, intent-classifier expansion* — folded into **S3** (all are "richer context for the branch").
+- *Mirror inbound to Attio timeline* — folded into **S5** write-back.
+- *Standalone Opik wiring* — demoted; the approval-DB eval (**S6**) is the higher-value version of "analyze the traces."
+- *Enrichment cache, time-boxed auto-send, safe-intent allowlist* — sub-components folded into **S2**/**S4**.
+
+The six survivors below cover all five axes.
+
+---
+
+## Survivors (ranked)
+
+### S1 — Wire the dead enrichment paths *(do this first; hours, not weeks)*
+**Axis:** generation plumbing. **Leverage: highest. Effort: lowest. Confidence: high.**
+The CRM-aware and calendar-aware draft modes already exist and call out to `DIALPAD_CRM_CONTEXT_COMMAND` / `DIALPAD_CALENDAR_CONTEXT_COMMAND`; QMD rich-reply calls `DIALPAD_QMD_COMMAND`. All three are unset/unverified, so every richer draft collapses to "thanks for reaching out, we'll follow up." Write a thin `attio-context <phone|email>` CLI that returns the JSON shape the code expects, confirm `qmd` runs in the webhook's environment, set the env vars, restart the service. This alone removes most of the "generic" complaint before any new architecture exists. **Risk:** the existing context-command contract may be thin/underspecified — verify the expected JSON schema in `_run_context_command` before writing the adapter.
+
+### S2 — Phone-first identity resolver with a cheap→expensive cascade and provenance
+**Axis:** sender identification. **Leverage: high (it's the backbone). Effort: medium. Confidence: high.**
+Design around the phone→person wall. Cascade, short-circuit on a confident hit, cache by phone (avoid re-paying Apollo):
+1. Dialpad contact (already have it)
+2. **Attio search by phone** (your CRM is the best first source)
+3. **Gmail / Granola history** by phone or any associated email ("look up my email" — this is the cheap, high-signal step)
+4. **Apollo match** — *only once an email/name is resolved* by 1–3
+5. Reverse-phone / web search — last resort, flagged low-confidence
+Emit `{identity, confidence, sources[]}` so downstream branching and the auto-send gate can reason about *how* the person was identified. **Corrects the original instinct that Apollo leads** — it's step 4, gated on steps 1–3 producing an email.
+
+### S3 — Customer-vs-prospect branching off Attio deal state, answered from QMD
+**Axis:** response generation. **Leverage: high (the headline feature). Effort: medium. Confidence: medium-high. Depends on S1+S2.**
+Once identity resolves, branch on Attio deal stage → {customer, prospect-with-demo, prospect-cold, churned}, pull the **latest deal note**, classify the inbound intent, and answer the actual question from QMD/ShapeScale knowledge. A customer asking pricing gets a different draft than a cold prospect; someone who did a demo last week gets "following up from your demo." This is the visible payoff of S1+S2. **Risk:** template sprawl — keep segments to ~4 and let QMD carry the specifics rather than hand-writing every variant.
+
+### S4 — Confidence-gated auto-send with a risk classifier + shadow-mode graduation
+**Axis:** auto-send gating. **Leverage: high (it's the safety spine). Effort: medium. Confidence: medium.**
+"Auto-send where high confidence" is only safe with an explicit gate: `confidence = f(identity_resolved, intent_classified, knowledge_match, no_risk_flags)`. A **risk classifier** hard-blocks pricing/legal/complaint/negotiation from *ever* auto-sending. Only deterministic safe intents (resend booking link, business hours, "got your message") are auto-send candidates — and only **after shadow mode**: run S1–S3 draft-only for a few weeks, measure operator edit rate per intent from `sms_approvals.db`, graduate an intent to auto-send when its edit rate drops below threshold. Without this, auto-send is reckless on your own sales line. **This is the gate that makes the user's auto-send ask defensible.**
+
+### S5 — Route by Dialpad *line*, not content; write enrichment back to Attio
+**Axis:** routing + contact write-back. **Leverage: medium-high. Effort: low-medium. Confidence: high. Semi-independent — can run in parallel with S2/S3.**
+Two clean wins:
+- **Routing:** key the sales-vs-work split on *which Dialpad number received the message* (sales line `+14155201316` vs your personal/work line), not on content classification. Deterministic, no misrouting. Sales line → sales topic + auto-responder; work line → work topic, responder off (or a different one). Create the two Telegram topics and map line→topic. This is the "create another Dialpad topic" idea, done the reliable way.
+- **Write-back:** on enrichment, create/update the Dialpad contact (name/company/title) for caller-ID, but write the **canonical** enrichment + "inbound SMS received" event to **Attio** (Dialpad contacts have no metadata field). Attio becomes the source of truth; Dialpad just gets a readable name.
+
+### S6 — Turn `sms_approvals.db` into an eval + weekly pulse
+**Axis:** observability/feedback. **Leverage: medium (underpins everything). Effort: low-medium. Confidence: high. Stand up early.**
+Every operator edit is labeled data: generated draft vs final sent text = quality signal. Build (a) an eval that computes edit distance + categorizes failure modes per intent, and (b) a weekly pulse: volume, auto-send rate, edit rate, top failing intents/segments. This is what tells you S1–S4 are working and *where* they fail, and it's the data that lets S4 graduate intents safely. Optionally wire the installed `opik-trace-analytics` skill for live tracing, but the approval DB is the cheaper, already-populated win.
+
+---
+
+## Suggested sequencing
+
+| Order | Item | Why now |
+|---|---|---|
+| 1 | **S1** + S5 routing | Quick wins; S1 removes most of the perceived problem today; routing is deterministic and independent |
+| 2 | **S6** | Stand up measurement before changing generation, so you can prove improvement |
+| 3 | **S2** | The identity backbone everything richer depends on |
+| 4 | **S3** | The headline branching feature, once identity + plumbing exist |
+| 5 | **S4** | Graduate to auto-send only after S6 shows low edit rates |
+
+## Riskiest assumptions to validate before planning
+- The `_run_context_command` JSON contract (S1) — confirm the exact shape before writing the Attio adapter.
+- Attio search-by-phone hit rate on inbound senders (S2) — if most senders aren't in Attio, S3's branch leans on Gmail/Apollo more than expected.
+- That `qmd` is reachable from the webhook's systemd environment (S1) — PATH/HOME issues are likely given the AlphaClaw/systemd-user PATH history on this host.

--- a/docs/plans/2026-06-18-001-feat-dialpad-enrichment-wiring-plan.md
+++ b/docs/plans/2026-06-18-001-feat-dialpad-enrichment-wiring-plan.md
@@ -1,0 +1,252 @@
+---
+title: "feat: Wire Dialpad enrichment draft modes with async + idempotency (S1)"
+type: feat
+date: 2026-06-18
+origin: docs/brainstorms/2026-06-18-s1-wire-enrichment-paths-requirements.md
+depth: deep
+---
+
+# feat: Wire Dialpad enrichment draft modes with async + idempotency (S1)
+
+## Summary
+
+The Dialpad auto-responder already implements three richer draft modes (Attio CRM, QMD knowledge, Calendly/Attio calendar) but they fail closed to a generic template because the context commands are unset and the rich path is gated behind high-confidence known contacts. This plan wires the three context-command adapters, un-gates them into the operator-approval draft lane so they fire for any sales-line inbound, and — because un-gating would otherwise block the single-threaded webhook for up to 24s per message — moves draft generation off the HTTP ACK path with SMS idempotency to prevent duplicate drafts on Dialpad retries. Auto-send behavior is unchanged; S2–S6 stay clean downstream seams.
+
+---
+
+## Problem Frame
+
+Inbound SMS on the sales line produces boilerplate ("thanks for reaching ShapeScale for Business Sales…") even though `webhook_server.py` has CRM-aware, calendar-aware, and QMD-knowledge draft builders. Two root causes (verified in origin de-risk):
+
+1. `DIALPAD_CRM_CONTEXT_COMMAND`, `DIALPAD_CALENDAR_CONTEXT_COMMAND` are unset and `DIALPAD_QMD_COMMAND` resolves to a bare `qmd` not on the service PATH, so all three modes return `{"usable": false}`.
+2. Even wired, the rich modes only run inside `_high_confidence_sales_context_allowed()` (`scripts/webhook_server.py:2203`), which requires a high-confidence **known** Dialpad contact — excluding the unknown senders that generate most of the "generic" complaint.
+
+Un-gating these lookups is the fix, but it is unsafe today: draft generation runs **inline before the 200 ACK** (`scripts/webhook_server.py:3329` precedes `:3475`) with up to 24s of subprocess work (3×8s), on a **single-threaded `HTTPServer`** (`scripts/webhook_server.py:3895`). Un-gating would block the whole server on every inbound and trigger Dialpad retries. So the async refactor and SMS idempotency are in-scope prerequisites, not optional polish.
+
+---
+
+## Requirements
+
+Traced from origin `docs/brainstorms/2026-06-18-s1-wire-enrichment-paths-requirements.md`:
+
+- **R1** — Attio CRM adapter: standalone CLI, input `"<phone> <name> <company>"`, output `{usable, status, basis, summary, deal, stage, company, owner}`; built reusably for S2.
+- **R2** — QMD leg reachable: `DIALPAD_QMD_COMMAND=/home/art/.local/bin/qmd`, verified from the service environment.
+- **R3** — Calendar adapter: input `"<name> <company> <deal> <timestamp>"`, output `{usable, status, basis, summary|title, startsInMinutes}`; Attio deal demo-date as the reliable path, Calendly best-effort.
+- **R4** — Un-gate: rich lookups run in the approval-draft lane at medium/unknown confidence; generic fallback only when all applicable adapters return unusable.
+- **R5** — Provenance: operator-facing draft carries the match basis; customer-facing send text does not.
+- **R6** — Draft generation off the ACK path with idempotency on the Dialpad event id (no duplicate draft/send on retry).
+- **R7** — Wiring: env vars + dedicated API keys set; service restarted. No hard dependency on OpenClaw/AlphaClaw being up.
+
+**Success criteria:** known Attio contact → draft with real company/stage/last-note + QMD answer + provenance line (verified on a replayed inbound); unknown sender asking pricing/booking/product → real QMD answer, not boilerplate; all adapters unusable → generic fallback fires unchanged; no auto-send regression.
+
+---
+
+## Key Technical Decisions
+
+- **KTD1 — In-process background worker, ACK-first, `ThreadingHTTPServer`; no external queue.** The handler validates, persists the inbound to `sms.db`, claims idempotency, ACKs 200, and enqueues draft generation to an in-process worker. `HTTPServer`→`ThreadingHTTPServer` stops one request from blocking others. A durable queue (Redis/BullMQ) is rejected for S1: ~5–10 msgs/day, the inbound is already persisted first so a lost job is recoverable, and adding a broker dependency contradicts "no dependency on external services being up." *(see origin: R6)*
+- **KTD2 — SMS idempotency mirrors the missed-call dedup.** A new `sms_webhook_events` table + atomic claim, parallel to `missed_call_webhook_events` / `claim_missed_call_notification` (`scripts/webhook_server.py:1274,1286`), keyed on `message_id` (fallback `id`, `scripts/webhook_server.py:1882`). Claim happens before enqueue so a Dialpad retry is a no-op.
+- **KTD3 — Provenance lives in `metadata_json`, not `draft_text`.** The draft metadata dict already carries `crm_context`/`calendar_context` (`scripts/webhook_server.py:2860`); add a human-readable `provenance` key and render it on the Telegram approval card. `draft_text` (customer-facing) is untouched. No schema migration. *(see origin: R5)*
+- **KTD4 — Adapters are standalone CLIs calling REST directly.** Attio and Calendly are reached via their REST APIs with dedicated keys (`ATTIO_API_KEY`, `CALENDLY_API_KEY`), mirroring `DIALPAD_API_KEY = os.environ.get(...)` (`scripts/webhook_server.py:97`). Not via the claude.ai Attio MCP (down, 401). The Attio adapter is a clean module so S2 can call it as a cascade stage.
+- **KTD5 — Calendar reliability via Attio deal demo-date.** The adapter resolves `startsInMinutes` from the Attio deal's demo-date attribute first; Calendly (`/users/me` → `/scheduled_events?invitee_email=…&status=active`) is attempted only when an email is known and is best-effort, since its email-filter behavior is unconfirmed. *(see origin: R3)*
+- **KTD6 — Production wiring is gated behind the async refactor.** The context-command env vars are not enabled in the live service until U5+U6 land, because even the pre-existing high-confidence path runs the lookups inline. Adapters are built and tested via their CLIs independently in the meantime.
+
+---
+
+## High-Level Technical Design
+
+Inbound SMS lifecycle after this change:
+
+```mermaid
+sequenceDiagram
+    participant DP as Dialpad
+    participant H as Webhook handler (ThreadingHTTPServer)
+    participant DB as sms.db / sms_webhook_events
+    participant W as Background draft worker
+    participant AD as Adapters (Attio / qmd / calendar)
+    participant AP as sms_approvals.db + Telegram card
+
+    DP->>H: POST /webhook/dialpad (message_id)
+    H->>DB: persist inbound + claim message_id (idempotent)
+    alt already claimed (retry)
+        H-->>DP: 200 OK (no-op)
+    else first time
+        H-->>DP: 200 OK (immediate, <1s)
+        H->>W: enqueue draft job
+        W->>AD: CRM / QMD / calendar lookups (up to 3×8s)
+        AD-->>W: {usable, ...} per adapter
+        W->>AP: create draft (enriched or generic) + provenance in metadata
+        AP-->>AP: operator approves (auto-send unchanged)
+    end
+```
+
+Draft-mode selection inside the worker (un-gated):
+
+```mermaid
+flowchart TD
+    A[Draft job] --> B{Any adapter usable?}
+    B -->|CRM usable| C[Contextual draft + provenance]
+    B -->|QMD usable| D[Knowledge answer + provenance]
+    B -->|Calendar usable| E[Meeting-logistics draft + provenance]
+    B -->|none usable| F[Generic fallback — unchanged]
+    C --> G[Store draft]
+    D --> G
+    E --> G
+    F --> G
+```
+
+---
+
+## Implementation Units
+
+### U1. Discover the real Attio pipeline schema — DONE (2026-06-18)
+
+**Goal:** Pin the exact Attio object/attribute slugs the CRM and calendar adapters depend on.
+**Requirements:** R1, R3.
+**Dependencies:** none.
+**Files:** `docs/reference/attio-schema.md` (written).
+**Outcome:** Validated `ATTIO_API_KEY` against the live REST API. The pipeline is the **standard `deals` object** (the "0 rows" was the MCP 401, not a custom object — wrong assumption retired). Confirmed slugs: `name`, `stage`, `owner`, `associated_company`, `associated_people`, `value`, `demo_scheduled_at` (calendar fallback). Phone→person→deal resolution path documented (phone lives on `people`, not `deals`). See `docs/reference/attio-schema.md`.
+
+### U2. Attio CRM context adapter (standalone CLI)
+
+**Goal:** A CLI that resolves a sender to Attio CRM context for the CRM-aware draft mode, reusable by S2.
+**Requirements:** R1.
+**Dependencies:** U1.
+**Files:** `scripts/adapters/attio_context.py` (new), `scripts/adapters/__init__.py` (new if needed), `tests/test_attio_context.py` (new).
+**Approach:** Accept the query as the final CLI arg (`"<phone> <name> <company>"`, matching `_run_context_command` at `scripts/webhook_server.py:2138`). Normalize the phone, search Attio by phone (primary) then name, map the matched record to `{usable, status, basis, summary, deal, stage, company, owner}` using U1's slugs, and include the demo-date when present so U3 can reuse it. Emit JSON on stdout. Fail closed to `{"usable": false, "status": ...}` on no-match, auth error, or timeout. Keep Attio access in a thin client function S2 can import.
+**Patterns to follow:** existing context-command output contract (`scripts/webhook_server.py:2174`); `customer_safe_knowledge_text()` filtering expectations for `summary`.
+**Test scenarios:**
+- Known phone in Attio → JSON with `usable:true` and populated company/stage/owner.
+- Unknown phone → `{usable:false, status:"not_found"}`, exit 0.
+- Name fallback when phone misses but name matches.
+- Attio 401/500 → `{usable:false, status:"degraded"}`, no stack trace on stdout.
+- Network timeout → fails closed within the adapter's own timeout (< the 8s `DIALPAD_CONTEXT_LOOKUP_TIMEOUT_SECONDS`).
+- Phone normalization: `+1 (415) 520-1316` and `4155201316` resolve identically.
+- `summary` passes the customer-safe filter (no URLs/paths/metadata leakage).
+
+### U3. Calendar context adapter (standalone CLI)
+
+**Goal:** Resolve an upcoming demo time for the calendar-aware draft mode.
+**Requirements:** R3.
+**Dependencies:** U1, U2.
+**Files:** `scripts/adapters/calendar_context.py` (new), `tests/test_calendar_context.py` (new).
+**Approach:** Accept `"<name> <company> <deal> <timestamp>"` as the final CLI arg. Resolve `startsInMinutes` from the **Attio deal demo-date attribute** first (reliable path via U2's client). Attempt Calendly only when an email is resolvable: `GET /users/me` → org URI → `GET /scheduled_events?organization=…&invitee_email=…&status=active&min_start_time=now`, reading `start_time`. Treat Calendly as best-effort — its `invitee_email` filter behavior is unconfirmed (see Risks). Output `{usable, status, basis, summary|title, startsInMinutes}`; fail closed otherwise.
+**Patterns to follow:** U2 adapter structure and output contract; calendar contract at `scripts/webhook_server.py:2300`.
+**Test scenarios:**
+- Attio deal has demo-date in the future → `usable:true`, correct `startsInMinutes`.
+- No demo-date, Calendly returns an active event for the email → `usable:true` from Calendly.
+- No demo-date, no email → `{usable:false}`.
+- Past/cancelled event → `{usable:false}` (not surfaced as upcoming).
+- Calendly auth/endpoint failure → falls back to Attio-only result, no crash.
+- `startsInMinutes` is a scalar, not a dict/list (matches `scripts/webhook_server.py:2300` parsing).
+
+### U4. QMD knowledge wiring + reachability
+
+**Goal:** Make the QMD knowledge lookup actually resolve from the service environment.
+**Requirements:** R2.
+**Dependencies:** none.
+**Files:** `.env` (add `DIALPAD_QMD_COMMAND=/home/art/.local/bin/qmd`).
+**Approach:** Set the absolute path so `subprocess.run(["/home/art/.local/bin/qmd","search",…])` resolves under the systemd unit's nix-store-only PATH. No code change — the bare `qmd` default at `scripts/webhook_server.py:118` is the only gap.
+**Test scenarios:**
+- Integration: an inbound product/pricing question, run through the (un-gated) draft path, yields a draft containing a QMD-sourced answer rather than the generic template. Covers the QMD half of R4's success criteria.
+- qmd binary unavailable → existing graceful `{usable:false,status:"unavailable"}` path still holds (no regression).
+**Verification:** From a shell matching the service environment, `qmd search` returns usable output; a replayed product-question inbound produces a knowledge-backed draft.
+
+### U5. ACK-first async draft generation
+
+**Goal:** Stop draft generation from blocking the webhook ACK and the single-threaded server.
+**Requirements:** R6.
+**Dependencies:** none (lands before U7 enables un-gate in production).
+**Files:** `scripts/webhook_server.py` (handler + server setup + new worker), `tests/test_webhook_async.py` (new).
+**Approach:** Switch `HTTPServer`→`ThreadingHTTPServer` (`scripts/webhook_server.py:3895`). In the SMS handler, persist the inbound and send the 200 ACK *before* draft generation; move `create_proactive_reply_draft()` (`scripts/webhook_server.py:3329`) into a background worker (a small daemon worker thread consuming an in-process queue, or a bounded `ThreadPoolExecutor`). Worker exceptions are logged and isolated — never crash the server or the handler. Preserve current ordering guarantees (a draft still supersedes a prior draft for the same thread via `create_replacement_draft`).
+**Execution note:** Start with a failing integration test asserting the ACK returns before draft generation completes.
+**Test scenarios:**
+- ACK returns in well under the worst-case lookup time while draft generation is still running (assert timing/ordering with a slow-adapter stub).
+- Draft is still created after the ACK (poll `sms_approvals.db`).
+- Worker raises mid-job → server stays up, next inbound still processed.
+- Two inbounds arrive close together → both processed, server not serialized for 24s (Covers the single-thread regression).
+- Existing high-confidence inline behavior still produces the same draft output (characterization).
+
+### U6. SMS webhook idempotency
+
+**Goal:** A Dialpad retry of the same message cannot create a duplicate draft or send.
+**Requirements:** R6.
+**Dependencies:** U5.
+**Files:** `scripts/webhook_server.py` (claim before enqueue), `scripts/sms_approval.py` or the existing dedup module (new `sms_webhook_events` table + claim function), `tests/test_sms_idempotency.py` (new).
+**Approach:** Add an `sms_webhook_events` table and an atomic `claim_sms_webhook_event(message_id)` mirroring `missed_call_webhook_events` / `claim_missed_call_notification` (`scripts/webhook_server.py:1274,1286`). Key on `message_id` (fallback `id`, `scripts/webhook_server.py:1882`). Claim in the handler before enqueueing the draft job; an already-claimed message ACKs 200 and does nothing else.
+**Execution note:** This is the delivery-correctness invariant — the test asserts at-most-once draft creation per `message_id`, not just that the claim function runs.
+**Test scenarios:**
+- Same `message_id` delivered twice → exactly one draft created.
+- Two different `message_id`s → two distinct drafts.
+- Concurrent claims of the same `message_id` (two threads) → exactly one wins (atomicity).
+- Missing `message_id`, present `id` → dedup keys on `id`.
+- Claim persists across a worker restart (table-backed, not in-memory).
+
+### U7. Un-gate rich lookups into the draft lane + provenance
+
+**Goal:** Run CRM/QMD/calendar enrichment for any sales-line inbound (not just high-confidence known contacts), with operator-visible provenance.
+**Requirements:** R4, R5.
+**Dependencies:** U2, U3, U4, U5, U6.
+**Files:** `scripts/webhook_server.py` (mode-selection at `:2337`–`:2393`, `:2504`–`:2559`; draft metadata at `:2860`), Telegram approval-card rendering, `tests/test_draft_ungate.py` (new).
+**Approach:** In the worker's draft-mode selection, attempt the CRM/QMD/calendar lookups in the approval-draft path regardless of `identityConfidence`, choosing the richest usable result and falling back to generic only when all applicable adapters return unusable. Build a human-readable provenance string (e.g., `Attio: +1415… → Acme · stage: Demo Booked · matched on phone`) and store it under a `provenance` key in the draft `metadata` dict (`scripts/webhook_server.py:2860`); render it on the operator's Telegram approval card. Do **not** add it to `draft_text`. Leave `_high_confidence_sales_context_allowed()` and the auto-send/high-confidence path untouched.
+**Test scenarios:**
+- Known Attio contact (medium confidence, not gated as "high") → enriched draft with company/stage + provenance.
+- Unknown sender with a pricing question → QMD answer in draft, not boilerplate. Covers R4.
+- All three adapters unusable → generic fallback fires, byte-identical to today. Covers the no-regression criterion.
+- Provenance string present in `metadata_json` and on the approval card, absent from `draft_text` (customer send text). Covers R5.
+- Auto-send / high-confidence path output unchanged (characterization) — un-gate touches only the draft lane.
+- One adapter usable, others fail → draft built from the usable one; provenance reflects which source fired.
+
+### U8. Secrets, env wiring, and deploy
+
+**Goal:** Turn the wired pipeline on in the live service safely.
+**Requirements:** R7.
+**Dependencies:** U2, U3, U4, U5, U6, U7.
+**Files:** `.env` (context-command vars), `~/.config/systemd/user/secrets.conf` (API keys), `systemd/dialpad-webhook.service` (only if an explicit PATH/key reference is needed).
+**Approach:** Add `ATTIO_API_KEY` and `CALENDLY_API_KEY` to the secret store (never literal in `.env`), and set `DIALPAD_CRM_CONTEXT_COMMAND`, `DIALPAD_CALENDAR_CONTEXT_COMMAND`, and `DIALPAD_QMD_COMMAND` in `.env` to invoke the new adapters/qmd by absolute path. Restart `dialpad-webhook.service`. Per KTD6, do not enable the two context-command vars until U5+U6 are merged. Confirm the service has no hard dependency on OpenClaw being up.
+**Test scenarios:** Test expectation: none — configuration/deploy. Verification is the end-to-end replay below.
+**Verification:** A replayed real inbound (known Attio contact, and an unknown product-question sender) produces enriched operator drafts with provenance; the service restarts cleanly; ACK latency stays low under a burst of replayed inbounds.
+
+---
+
+## Phased Delivery
+
+- **Phase A — Enrichment sources:** U1 → U2 → U3, and U4 (parallel). Buildable/testable via CLIs without touching the live webhook.
+- **Phase B — Delivery safety:** U5 → U6. Must land before un-gate goes live.
+- **Phase C — Integration:** U7, then U8. U7 depends on A+B; U8 flips production on.
+
+---
+
+## Risks & Mitigations
+
+- **Calendly `invitee_email` filtering unconfirmed (R3).** Mitigation: KTD5 makes the Attio deal demo-date the reliable path; Calendly is best-effort and its failure degrades to Attio-only, not a broken leg. Verify the exact Calendly call sequence at implementation time against the live API.
+- ~~**Attio pipeline is a custom object/list, not `deals`.**~~ RESOLVED in U1: it is the standard `deals` object; slugs confirmed in `docs/reference/attio-schema.md`. Key is present in `secrets.conf`.
+- **In-process worker loses a draft job on crash/restart (KTD1).** Mitigation: the inbound is persisted to `sms.db` before ACK, so a lost job is recoverable; a future reconciliation pass (S6 territory) can re-derive missed drafts. Acceptable at ~5–10 msgs/day.
+- **Un-gating increases external API call volume.** Each inbound now triggers up to three lookups. At current volume this is negligible, but adapters must enforce their own sub-8s timeouts so a slow API cannot stall the worker queue.
+- **ThreadingHTTPServer + shared SQLite.** Concurrent worker threads writing `sms.db`/`sms_approvals.db` must use per-thread connections or serialized writes; verify the existing DB access is thread-safe or wrap it.
+- **Exposed Attio MCP token (from de-risk).** Out of band but related: rotate the leaked claude.ai Attio MCP token; it is unrelated to the dedicated `ATTIO_API_KEY` this plan introduces.
+
+---
+
+## Scope Boundaries
+
+**In scope:** the three adapters, qmd wiring, the un-gate into the draft lane, provenance, the ACK-first async refactor, SMS idempotency, and deploy.
+
+### Deferred to Follow-Up Work
+- **S2** — full phone-first identity cascade (Gmail/Granola, Apollo, reverse-phone), caching, and confidence scoring. The U2 Attio adapter is built to be reused as its first stage.
+- **S3** — segmented customer/prospect draft templates.
+- **S4** — confidence-gated auto-send. Auto-send behavior is unchanged here.
+- **S5** — line-based sales/work routing and Attio write-back.
+- **S6** — approval-DB eval loop and a reconciliation pass for lost worker jobs.
+
+### Outside this change
+- Rewriting the Dialpad identity/confidence scorer — the un-gate bypasses the gate for the draft lane only.
+- Introducing a durable external queue/broker (rejected in KTD1).
+
+---
+
+## Sources & Research
+
+- Origin requirements: `docs/brainstorms/2026-06-18-s1-wire-enrichment-paths-requirements.md`
+- Ideation: `docs/ideation/2026-06-18-dialpad-auto-response-enrichment.md`
+- Code contracts and gates: `scripts/webhook_server.py` (`:97, :118, :1274, :1286, :1882, :2138, :2174, :2203, :2300, :2337, :2504, :2860, :3329, :3475, :3895`), `scripts/sms_approval.py` (`:140, :220, :426`).
+- Calendly API v2: PAT Bearer auth; `/users/me` → `/scheduled_events?invitee_email=…&status=active&min_start_time=…`, `start_time` field (https://developer.calendly.com/api-docs/reference). `invitee_email` direct-filter behavior unconfirmed.

--- a/docs/reference/attio-schema.md
+++ b/docs/reference/attio-schema.md
@@ -1,0 +1,50 @@
+# Attio schema reference (for Dialpad enrichment adapters — S1/U1)
+
+Discovered 2026-06-18 against the live Attio REST API (`https://api.attio.com/v2`) using
+`ATTIO_API_KEY` from `~/.config/systemd/user/secrets.conf`. The claude.ai Attio MCP was
+returning 401 at discovery time — do not rely on it; the adapters call REST directly.
+
+## Correction to the plan assumption
+
+The pipeline is the **standard `deals` object** (object_id `bd6e5162-47bf-46ac-81fb-632ee877cd6a`),
+NOT a custom object or List. The earlier "0 rows on `deals`" was solely the MCP's broken token,
+not an empty/absent object. KTD5 / U1's "likely a custom object/list" assumption is retired.
+
+## Objects present
+
+`subscriptions, workspaces, people, users, orders, companies, deals, test_projects, locations`
+
+## `deals` attribute slugs the adapters use
+
+| Need | Slug | Type |
+|---|---|---|
+| Deal name | `name` | text |
+| Stage (customer vs prospect signal) | `stage` | status |
+| Owner | `owner` | actor-reference |
+| Company link | `associated_company` | record-reference |
+| People link | `associated_people` | record-reference |
+| Deal value | `value` | currency |
+| Primary interest | `primary_interest` | select |
+| Lead priority | `ai_lead_priority` | select |
+| **Demo date (calendar fallback, precise)** | `demo_scheduled_at` | timestamp |
+| Demo date (date-only variant) | `demo_scheduled_date` | date |
+| Demo lifecycle | `demo_booked_at`, `demo_completed_at`, `demo_no_show_at`, `demo_canceled_at` | timestamp |
+| Last outreach | `last_outreach_at` | date |
+
+## Phone → person → deal resolution (U2 path)
+
+Inbound SMS gives only a phone number. Phone numbers live on the **`people`** object, not on
+`deals`. Resolution for the CRM adapter:
+
+1. Search `people` by phone number (people standard `phone_numbers` attribute).
+2. From the matched person, follow to their associated deal (via the deal's `associated_people`
+   record-reference, or the person's deals back-reference).
+3. Map the deal's `stage` / `owner` / `associated_company` / `name` / `value` into the CRM
+   context contract, and surface `demo_scheduled_at` for the calendar adapter (U3) to reuse.
+
+If no person matches the phone, the adapter returns `{usable: false, status: "not_found"}`.
+
+## Auth
+
+`Authorization: Bearer ${ATTIO_API_KEY}` (64-char token). `ATTIO_WORKSPACE_ID` and
+`ATTIO_ACCESS_TOKEN` also exist in secrets.conf if needed.

--- a/docs/reference/enrichment-adapters.md
+++ b/docs/reference/enrichment-adapters.md
@@ -1,0 +1,56 @@
+# Enrichment context adapters (S1)
+
+Standalone context-command adapters that feed the CRM-aware, calendar-aware, and
+QMD-knowledge draft modes in `scripts/webhook_server.py`. Each is invoked as a
+subprocess: the webhook appends the query as a single final CLI arg and reads a
+JSON object from stdout (contract: `lookup_sales_crm_context` /
+`lookup_sales_calendar_context` / `lookup_shapescale_knowledge`).
+
+| Adapter | File | Query in | JSON out |
+|---|---|---|---|
+| Attio CRM | `scripts/adapters/attio_context.py` | `"<phone> <name> <company>"` | `{usable, status, basis, summary, deal, stage, company, owner}` |
+| Calendar | `scripts/adapters/calendar_context.py` | `"<name> <company> <deal> <timestamp>"` | `{usable, status, basis, summary, startsInMinutes}` |
+| QMD | existing `qmd` binary (no adapter) | `search "<query>"` | `@@`-delimited snippet |
+
+All adapters fail closed (`{"usable": false, ...}`) and exit 0 on any miss, auth
+error, or timeout — the webhook treats a non-zero exit as failure.
+
+## Secrets (already present in `~/.config/systemd/user/secrets.conf`)
+
+- `ATTIO_API_KEY` — Attio REST bearer token (the adapter calls Attio directly, not the MCP).
+- `CALENDLY_API_KEY` — Calendly personal access token (best-effort calendar fallback).
+
+## Env wiring — apply at deploy time (U8), NOT yet
+
+> **Sequencing (plan KTD6):** do **not** enable `DIALPAD_CRM_CONTEXT_COMMAND` or
+> `DIALPAD_CALENDAR_CONTEXT_COMMAND` in the live `.env` until the async draft
+> refactor (U5) and SMS idempotency (U6) ship. The webhook runs draft generation
+> inline before the ACK on a single-threaded server; enabling these adds up to
+> 8s/call of inline work and would block the webhook. `.env` is gitignored, so
+> these lines are a deploy action, not a committed change.
+
+```sh
+# scripts/adapters invoked by absolute path (systemd PATH is nix-store only)
+DIALPAD_QMD_COMMAND=/home/art/.local/bin/qmd
+DIALPAD_CRM_CONTEXT_COMMAND=/home/linuxbrew/.linuxbrew/bin/python3 /home/art/projects/skills/work/dialpad/scripts/adapters/attio_context.py
+DIALPAD_CALENDAR_CONTEXT_COMMAND=/home/linuxbrew/.linuxbrew/bin/python3 /home/art/projects/skills/work/dialpad/scripts/adapters/calendar_context.py
+# adapters read ATTIO_API_KEY / CALENDLY_API_KEY from the service environment
+```
+
+The `qmd` fix alone (absolute path) is safe to land earlier than CRM/calendar —
+it repairs an existing call that currently `FileNotFoundError`s — but still adds
+latency to the high-confidence inline path, so prefer applying all three together
+after async lands.
+
+## Reuse by S2
+
+`attio_context.find_person_by_phone`, `find_person_by_email`, and
+`deal_for_person` are the reusable Attio client for the S2 phone-first identity
+resolver. Keep them import-safe and side-effect-free.
+
+## Tests
+
+`tests/test_attio_context.py`, `tests/test_calendar_context.py` — HTTP layer
+fully mocked (no live API calls). Run: `python3 -m unittest tests.test_attio_context tests.test_calendar_context`.
+A guarded live smoke against real Attio was run during U2 and confirmed a real
+sender resolves to company/deal/stage.

--- a/scripts/adapters/__init__.py
+++ b/scripts/adapters/__init__.py
@@ -1,0 +1,7 @@
+"""Standalone context-command adapters for the Dialpad auto-responder.
+
+Each adapter is invoked by webhook_server.py as a `DIALPAD_*_CONTEXT_COMMAND`
+subprocess: the query arrives as a single final CLI arg and the adapter emits a
+JSON object on stdout matching the contract in
+`lookup_sales_crm_context` / `lookup_sales_calendar_context`.
+"""

--- a/scripts/adapters/attio_context.py
+++ b/scripts/adapters/attio_context.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Attio CRM context adapter for the Dialpad auto-responder (S1/U2).
+
+Resolves an inbound sender to compact Attio CRM context for the CRM-aware draft
+mode in ``webhook_server.py``. Wired as a context command:
+
+    DIALPAD_CRM_CONTEXT_COMMAND="/abs/python3 /abs/scripts/adapters/attio_context.py"
+
+The webhook appends the query as a single final CLI arg, space-joined:
+
+    "<sender_number> <name> <company>"
+
+Emits a JSON object on stdout matching the contract consumed by
+``lookup_sales_crm_context``:
+
+    {"usable": true, "status": "ok", "basis": "attio",
+     "summary": "...", "deal": "...", "stage": "...",
+     "company": "...", "owner": null}
+
+On any miss or error it emits ``{"usable": false, "status": "..."}`` and exits 0
+(the webhook treats a non-zero exit as failure). It never raises to the caller.
+
+The resolution helpers (``find_person_by_phone``, ``find_person_by_email``,
+``deal_for_person``) are the reusable Attio client for the S2 phone-first
+identity resolver — keep them import-safe and side-effect-free.
+
+Schema reference: docs/reference/attio-schema.md
+"""
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+ATTIO_BASE = os.environ.get("ATTIO_API_BASE", "https://api.attio.com/v2").rstrip("/")
+HTTP_TIMEOUT = float(os.environ.get("ATTIO_HTTP_TIMEOUT_SECONDS", "2.5"))
+
+# E.164-ish: leading + or digit, then digits/separators. The sender_number the
+# webhook passes first is the reliable lookup key; name/company are hints only.
+_PHONE_RE = re.compile(r"^\+?\d[\d()\-.\s]{5,}$")
+_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _clean(text):
+    """Strip control chars and collapse whitespace on CRM-sourced strings.
+
+    Defense in depth: these values can reach a customer-facing SMS draft. The
+    webhook also applies customer_safe_knowledge_text downstream, but the adapter
+    does not rely on that alone.
+    """
+    if not isinstance(text, str):
+        return text
+    return " ".join(_CONTROL_RE.sub(" ", text).split()) or None
+
+
+def _normalize_phone(token):
+    """Reduce a phone token to '+' + digits so it matches Attio's E.164 storage."""
+    digits = re.sub(r"\D", "", token or "")
+    return ("+" + digits) if str(token).strip().startswith("+") else digits
+
+
+class AttioError(Exception):
+    """Raised on an Attio API/transport failure. Adapters fail closed on it."""
+
+
+def _api_key():
+    return os.environ.get("ATTIO_API_KEY", "")
+
+
+def _request(method, path, body=None):
+    if not _api_key():
+        raise AttioError("missing_api_key")
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(
+        f"{ATTIO_BASE}{path}",
+        data=data,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {_api_key()}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+            return json.loads(resp.read().decode("utf-8") or "{}")
+    except urllib.error.HTTPError as exc:
+        raise AttioError(f"http_{exc.code}") from exc
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError) as exc:
+        raise AttioError("network") from exc
+
+
+def _query_records(object_slug, filt, limit=1):
+    body = {"limit": limit}
+    if filt:
+        body["filter"] = filt
+    return _request("POST", f"/objects/{object_slug}/records/query", body).get("data") or []
+
+
+def get_record(object_slug, record_id):
+    """GET a single record; returns the record dict or None (never raises)."""
+    if not record_id:
+        return None
+    try:
+        return _request("GET", f"/objects/{object_slug}/records/{record_id}").get("data")
+    except AttioError:
+        return None
+
+
+# --- value extraction (Attio wraps each attribute as a list of typed objects) ---
+
+def _first(values, key):
+    arr = (values or {}).get(key)
+    return arr[0] if isinstance(arr, list) and arr else None
+
+
+def _text_value(values, key):
+    item = _first(values, key)
+    if isinstance(item, dict):
+        val = item.get("value")
+        return _clean(val) if isinstance(val, str) and val.strip() else None
+    return None
+
+
+def _status_title(values, key="stage"):
+    item = _first(values, key)
+    if isinstance(item, dict):
+        status = item.get("status") or {}
+        title = status.get("title")
+        return _clean(title) if isinstance(title, str) and title.strip() else None
+    return None
+
+
+def _reference_id(values, key):
+    item = _first(values, key)
+    if isinstance(item, dict):
+        return item.get("target_record_id")
+    return None
+
+
+# --- resolution helpers (reusable by S2) ---
+
+def find_person_by_phone(phone):
+    """Return the first Attio person whose phone_numbers matches, or None."""
+    if not phone:
+        return None
+    recs = _query_records("people", {"phone_numbers": phone}, limit=1)
+    return recs[0] if recs else None
+
+
+def find_person_by_email(email):
+    """Return the first Attio person whose email_addresses matches, or None."""
+    if not email or "@" not in str(email):
+        return None
+    recs = _query_records("people", {"email_addresses": email}, limit=1)
+    return recs[0] if recs else None
+
+
+def deal_for_person(person):
+    """Return the first deal record linked via the person's associated_deals, else None."""
+    values = (person or {}).get("values") or {}
+    for ref in values.get("associated_deals") or []:
+        if not isinstance(ref, dict):
+            continue
+        deal = get_record("deals", ref.get("target_record_id"))
+        if deal:
+            return deal
+    return None
+
+
+def _company_name(deal_values):
+    return _text_value((get_record("companies", _reference_id(deal_values, "associated_company")) or {}).get("values"), "name")
+
+
+def crm_context_from_records(person, deal):
+    """Build the CRM context contract from a resolved person + deal.
+
+    Usable only when there is real CRM substance (company, deal, or stage);
+    a bare person match with no deal context returns ``{"usable": false}``.
+    """
+    deal_values = (deal or {}).get("values") or {}
+    deal_name = _text_value(deal_values, "name")
+    stage = _status_title(deal_values, "stage")
+    company = _company_name(deal_values) if deal else None
+
+    if not (company or deal_name or stage):
+        return {"usable": False, "status": "no_context"}
+
+    summary = " · ".join(
+        part for part in (
+            company,
+            f"deal: {deal_name}" if deal_name else None,
+            f"stage: {stage}" if stage else None,
+        ) if part
+    )
+    return {
+        "usable": True,
+        "status": "ok",
+        "basis": "attio",
+        "summary": summary[:300],
+        "deal": deal_name,
+        "stage": stage,
+        "company": company,
+        "owner": None,  # owner is an actor_id; name resolution needs a scope this key lacks
+    }
+
+
+def _parse_query(query):
+    """Split the space-joined query into (phone, remainder). Phone is the first token when phone-shaped."""
+    tokens = str(query or "").split()
+    if tokens and _PHONE_RE.match(tokens[0]):
+        return tokens[0], " ".join(tokens[1:])
+    return None, " ".join(tokens)
+
+
+def build_crm_context(query):
+    """Resolve the CRM context contract for a webhook context-command query."""
+    phone, _rest = _parse_query(query)
+    phone = _normalize_phone(phone) if phone else None
+    if not phone:
+        return {"usable": False, "status": "empty_query"}
+    try:
+        person = find_person_by_phone(phone)
+    except AttioError as exc:
+        return {"usable": False, "status": "degraded", "basis": "attio", "detail": str(exc)}
+    if not person:
+        return {"usable": False, "status": "not_found"}
+    try:
+        deal = deal_for_person(person)
+    except AttioError:
+        deal = None
+    return crm_context_from_records(person, deal)
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    query = argv[-1] if argv else ""
+    try:
+        result = build_crm_context(query)
+    except Exception:  # noqa: BLE001 - fail closed; the adapter must never break the webhook
+        result = {"usable": False, "status": "error"}
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/adapters/calendar_context.py
+++ b/scripts/adapters/calendar_context.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Calendar context adapter for the Dialpad auto-responder (S1/U3).
+
+Resolves an upcoming demo time for the calendar-aware draft mode. The Attio deal
+``demo_scheduled_at`` attribute is the reliable path; Calendly is best-effort and
+only fires when an invitee email is present in the query (its ``invitee_email``
+filter behavior is unconfirmed — see docs/reference/attio-schema.md and the S1
+plan). Wired as a context command:
+
+    DIALPAD_CALENDAR_CONTEXT_COMMAND="/abs/python3 /abs/scripts/adapters/calendar_context.py"
+
+Query (single final CLI arg, space-joined): "<name> <company> <deal> <timestamp>"
+Emits the contract consumed by ``lookup_sales_calendar_context``:
+
+    {"usable": true, "status": "ok", "basis": "attio",
+     "summary": "...", "startsInMinutes": 42}
+
+Only future demos are surfaced; a stale/past date returns ``{"usable": false}``.
+"""
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from urllib.parse import urlencode
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+import attio_context as attio  # noqa: E402  (sibling adapter = shared Attio client)
+
+CALENDLY_BASE = os.environ.get("CALENDLY_API_BASE", "https://api.calendly.com").rstrip("/")
+CALENDLY_TIMEOUT = float(os.environ.get("CALENDLY_HTTP_TIMEOUT_SECONDS", "2.5"))
+
+# Trailing timestamp the webhook appends (ISO 8601 or unix epoch).
+_TIMESTAMP_RE = re.compile(r"\s*(?:\d{4}-\d{2}-\d{2}[T ]\S+|\b\d{10}\b)\s*$")
+_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
+_MIN_TOKEN = 4
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+def parse_iso(value):
+    """Parse an ISO 8601 timestamp/date (Attio uses 9 fractional digits) to aware UTC, or None."""
+    if not value:
+        return None
+    text = str(value).strip().replace("Z", "+00:00")
+    text = re.sub(r"(\.\d{6})\d+", r"\1", text)  # trim sub-microsecond precision
+    for candidate in (text, text[:10]):
+        try:
+            dt = datetime.fromisoformat(candidate)
+            return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+        except ValueError:
+            continue
+    return None
+
+
+def starts_in_minutes(dt, now=None):
+    if dt is None:
+        return None
+    return int((dt - (now or _now())).total_seconds() // 60)
+
+
+def _search_token(remainder):
+    """Pick the most distinctive alphabetic token to match a deal name against."""
+    tokens = sorted(
+        (t for t in re.findall(r"[A-Za-z][A-Za-z'&]+", remainder) if len(t) >= _MIN_TOKEN),
+        key=len,
+        reverse=True,
+    )
+    return tokens[0] if tokens else None
+
+
+def _demo_timestamp(deal):
+    values = (deal or {}).get("values") or {}
+    return attio._text_value(values, "demo_scheduled_at") or attio._text_value(values, "demo_scheduled_date")
+
+
+def resolve_attio_demo(remainder, now=None):
+    """Return (startsInMinutes, summary) from a single confident Attio deal match, else (None, None).
+
+    Conservative by design: 0 or multiple name matches → not usable, so the draft
+    falls back to generic rather than guessing a meeting time.
+    """
+    token = _search_token(remainder)
+    if not token:
+        return None, None
+    try:
+        deals = attio._query_records("deals", {"name": {"$contains": token}}, limit=3)
+    except attio.AttioError:
+        return None, None
+    if len(deals) != 1:
+        return None, None
+    deal = deals[0]
+    sim = starts_in_minutes(parse_iso(_demo_timestamp(deal)), now=now)
+    if sim is None or sim < 0:
+        return None, None
+    name = attio._text_value((deal.get("values") or {}), "name") or "your demo"
+    return sim, f"Upcoming demo: {attio._clean(name)}"
+
+
+def calendly_next_event(email, now=None):
+    """Best-effort: (startsInMinutes, summary) for an invitee's next active Calendly event, else (None, None)."""
+    api_key = os.environ.get("CALENDLY_API_KEY", "")
+    if not api_key or not email:
+        return None, None
+    now = now or _now()
+
+    def _get(url):
+        req = urllib.request.Request(
+            url, headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+        )
+        with urllib.request.urlopen(req, timeout=CALENDLY_TIMEOUT) as resp:
+            return json.loads(resp.read().decode("utf-8") or "{}")
+
+    try:
+        me = _get(f"{CALENDLY_BASE}/users/me")
+        org = ((me.get("resource") or {}).get("current_organization"))
+        if not (isinstance(org, str) and org.startswith(f"{CALENDLY_BASE}/organizations/")):
+            return None, None
+        qs = urlencode({
+            "organization": org,
+            "invitee_email": email,
+            "status": "active",
+            "min_start_time": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "sort": "start_time:asc",
+            "count": 1,
+        })
+        events = _get(f"{CALENDLY_BASE}/scheduled_events?{qs}").get("collection") or []
+        if not events:
+            return None, None
+        ev = events[0]
+        sim = starts_in_minutes(parse_iso(ev.get("start_time")), now=now)
+        if sim is None or sim < 0:
+            return None, None
+        return sim, f"Upcoming demo: {attio._clean(ev.get('name')) or 'scheduled meeting'}"
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, ValueError, OSError):
+        return None, None
+
+
+def build_calendar_context(query, now=None):
+    raw = str(query or "").strip()
+    if not raw:
+        return {"usable": False, "status": "empty_query"}
+    remainder = _TIMESTAMP_RE.sub("", raw).strip()
+
+    sim, summary, basis = (*resolve_attio_demo(remainder, now=now), "attio")
+    if sim is None and os.environ.get("CALENDLY_API_KEY"):
+        email_match = _EMAIL_RE.search(remainder)
+        if email_match:
+            sim, summary = calendly_next_event(email_match.group(0), now=now)
+            basis = "calendly"
+
+    if sim is None or not summary:
+        return {"usable": False, "status": "not_found"}
+    return {"usable": True, "status": "ok", "basis": basis, "summary": summary, "startsInMinutes": sim}
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    query = argv[-1] if argv else ""
+    try:
+        result = build_calendar_context(query)
+    except Exception:  # noqa: BLE001 - fail closed; the adapter must never break the webhook
+        result = {"usable": False, "status": "error"}
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_attio_context.py
+++ b/tests/test_attio_context.py
@@ -1,0 +1,171 @@
+"""Unit tests for the Attio CRM context adapter (S1/U2). HTTP layer fully mocked."""
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+sys.path.insert(0, str(ROOT / "scripts" / "adapters"))
+
+import attio_context as attio  # noqa: E402
+
+
+PERSON = {
+    "id": {"record_id": "person-1"},
+    "values": {"associated_deals": [{"target_record_id": "deal-1", "target_object": "deals"}]},
+}
+DEAL = {
+    "id": {"record_id": "deal-1"},
+    "values": {
+        "name": [{"value": "Acme (Inbound Demo Request)", "attribute_type": "text"}],
+        "stage": [{"status": {"title": "Demo Booked"}}],
+        "associated_company": [{"target_record_id": "co-1", "target_object": "companies"}],
+        "demo_scheduled_at": [{"value": "2026-06-20T18:30:00.000000000Z", "attribute_type": "timestamp"}],
+    },
+}
+COMPANY = {"id": {"record_id": "co-1"}, "values": {"name": [{"value": "Acme Corp", "attribute_type": "text"}]}}
+
+
+def fake_request(method, path, body=None):
+    if method == "POST" and path == "/objects/people/records/query":
+        return {"data": [PERSON]}
+    if method == "GET" and path == "/objects/deals/records/deal-1":
+        return {"data": DEAL}
+    if method == "GET" and path == "/objects/companies/records/co-1":
+        return {"data": COMPANY}
+    return {"data": []}
+
+
+class ParseQueryTests(unittest.TestCase):
+    def test_extracts_e164_phone_as_first_token(self):
+        phone, rest = attio._parse_query("+14155201316 John Doe Acme Corp")
+        self.assertEqual(phone, "+14155201316")
+        self.assertEqual(rest, "John Doe Acme Corp")
+
+    def test_no_phone_when_first_token_is_name(self):
+        phone, rest = attio._parse_query("John Doe Acme")
+        self.assertIsNone(phone)
+        self.assertEqual(rest, "John Doe Acme")
+
+    def test_empty_query(self):
+        self.assertEqual(attio._parse_query(""), (None, ""))
+
+
+class ValueExtractionTests(unittest.TestCase):
+    def test_text_value(self):
+        self.assertEqual(attio._text_value(DEAL["values"], "name"), "Acme (Inbound Demo Request)")
+        self.assertIsNone(attio._text_value(DEAL["values"], "missing"))
+
+    def test_status_title(self):
+        self.assertEqual(attio._status_title(DEAL["values"], "stage"), "Demo Booked")
+        self.assertIsNone(attio._status_title({}, "stage"))
+
+    def test_reference_id(self):
+        self.assertEqual(attio._reference_id(DEAL["values"], "associated_company"), "co-1")
+
+
+class CrmContextFromRecordsTests(unittest.TestCase):
+    def test_usable_with_deal(self):
+        with patch.object(attio, "_request", side_effect=fake_request):
+            ctx = attio.crm_context_from_records(PERSON, DEAL)
+        self.assertTrue(ctx["usable"])
+        self.assertEqual(ctx["company"], "Acme Corp")
+        self.assertEqual(ctx["deal"], "Acme (Inbound Demo Request)")
+        self.assertEqual(ctx["stage"], "Demo Booked")
+        self.assertIn("Acme Corp", ctx["summary"])
+        self.assertIn("stage: Demo Booked", ctx["summary"])
+        self.assertIsNone(ctx["owner"])
+
+    def test_person_without_deal_is_not_usable(self):
+        ctx = attio.crm_context_from_records(PERSON, None)
+        self.assertFalse(ctx["usable"])
+        self.assertEqual(ctx["status"], "no_context")
+
+
+class BuildCrmContextTests(unittest.TestCase):
+    def test_happy_path(self):
+        with patch.object(attio, "_request", side_effect=fake_request):
+            ctx = attio.build_crm_context("+14155201316 John Doe Acme")
+        self.assertTrue(ctx["usable"])
+        self.assertEqual(ctx["basis"], "attio")
+        self.assertEqual(ctx["company"], "Acme Corp")
+
+    def test_empty_query(self):
+        ctx = attio.build_crm_context("")
+        self.assertFalse(ctx["usable"])
+        self.assertEqual(ctx["status"], "empty_query")
+
+    def test_not_found(self):
+        with patch.object(attio, "_request", side_effect=lambda *a, **k: {"data": []}):
+            ctx = attio.build_crm_context("+14155551234 Nobody")
+        self.assertFalse(ctx["usable"])
+        self.assertEqual(ctx["status"], "not_found")
+
+    def test_api_error_fails_closed_degraded(self):
+        with patch.object(attio, "_request", side_effect=attio.AttioError("http_500")):
+            ctx = attio.build_crm_context("+14155551234 Someone")
+        self.assertFalse(ctx["usable"])
+        self.assertEqual(ctx["status"], "degraded")
+
+    def test_missing_api_key_raises_attio_error(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with self.assertRaises(attio.AttioError):
+                attio._request("GET", "/objects/people/records/x")
+
+    def test_cli_emits_json_and_exits_zero(self):
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with patch.object(attio, "_request", side_effect=fake_request), redirect_stdout(buf):
+            rc = attio.main(["+14155201316 John Doe Acme"])
+        self.assertEqual(rc, 0)
+        payload = json.loads(buf.getvalue())
+        self.assertTrue(payload["usable"])
+
+
+class HardeningTests(unittest.TestCase):
+    def test_normalize_phone(self):
+        self.assertEqual(attio._normalize_phone("+1 (415) 520-1316"), "+14155201316")
+        self.assertEqual(attio._normalize_phone("4155201316"), "4155201316")
+
+    def test_clean_strips_control_chars_and_collapses_whitespace(self):
+        self.assertEqual(attio._clean("Acme\n\x00 Corp  Inc"), "Acme Corp Inc")
+        self.assertIsNone(attio._clean("\x00\n  "))
+
+    def test_text_value_sanitizes(self):
+        values = {"name": [{"value": "Evil\nDeal\x07", "attribute_type": "text"}]}
+        self.assertEqual(attio._text_value(values, "name"), "Evil Deal")
+
+    def test_malformed_associated_deals_fails_closed(self):
+        person = {"id": {"record_id": "p"}, "values": {"associated_deals": [None, "str", {"target_record_id": None}]}}
+        with patch.object(attio, "_request", side_effect=lambda m, p, b=None: {"data": [person]}):
+            ctx = attio.build_crm_context("+14155201316 Name")
+        self.assertFalse(ctx["usable"])  # no crash on non-dict refs
+
+    def test_find_person_by_email_rejects_non_email(self):
+        self.assertIsNone(attio.find_person_by_email("not-an-email"))
+
+    def test_main_exits_zero_on_internal_exception(self):
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with patch.object(attio, "build_crm_context", side_effect=RuntimeError("boom")), redirect_stdout(buf):
+            rc = attio.main(["anything"])
+        self.assertEqual(rc, 0)
+        self.assertFalse(json.loads(buf.getvalue())["usable"])
+
+    def test_secret_never_appears_in_output(self):
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with patch.dict("os.environ", {"ATTIO_API_KEY": "SENTINEL-SECRET-123"}), \
+             patch.object(attio, "_request", side_effect=attio.AttioError("http_403")), \
+             redirect_stdout(buf):
+            attio.main(["+14155201316 Name"])
+        self.assertNotIn("SENTINEL-SECRET-123", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_calendar_context.py
+++ b/tests/test_calendar_context.py
@@ -1,0 +1,204 @@
+"""Unit tests for the calendar context adapter (S1/U3). HTTP layer fully mocked."""
+import json
+import sys
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+sys.path.insert(0, str(ROOT / "scripts" / "adapters"))
+
+import attio_context as attio  # noqa: E402
+import calendar_context as cal  # noqa: E402
+
+NOW = datetime(2026, 6, 20, 18, 0, 0, tzinfo=timezone.utc)
+
+DEAL = {
+    "id": {"record_id": "deal-1"},
+    "values": {
+        "name": [{"value": "Synergy Wellness (Inbound Demo Request)", "attribute_type": "text"}],
+        "demo_scheduled_at": [{"value": "2026-06-20T18:30:00.000000000Z", "attribute_type": "timestamp"}],
+    },
+}
+PAST_DEAL = {
+    "id": {"record_id": "deal-2"},
+    "values": {
+        "name": [{"value": "Old Deal", "attribute_type": "text"}],
+        "demo_scheduled_at": [{"value": "2026-06-19T10:00:00.000000000Z", "attribute_type": "timestamp"}],
+    },
+}
+
+
+class TimeHelpersTests(unittest.TestCase):
+    def test_parse_iso_trims_nanoseconds(self):
+        dt = cal.parse_iso("2026-06-20T18:30:00.000000000Z")
+        self.assertEqual(dt, datetime(2026, 6, 20, 18, 30, tzinfo=timezone.utc))
+
+    def test_parse_iso_date_only(self):
+        self.assertEqual(cal.parse_iso("2026-06-20"), datetime(2026, 6, 20, tzinfo=timezone.utc))
+
+    def test_parse_iso_invalid(self):
+        self.assertIsNone(cal.parse_iso("not-a-date"))
+
+    def test_starts_in_minutes(self):
+        self.assertEqual(cal.starts_in_minutes(datetime(2026, 6, 20, 18, 30, tzinfo=timezone.utc), now=NOW), 30)
+        self.assertIsNone(cal.starts_in_minutes(None, now=NOW))
+
+    def test_search_token_picks_longest(self):
+        self.assertEqual(cal._search_token("John Doe Acme Synergy"), "Synergy")
+        self.assertIsNone(cal._search_token("a b c"))
+
+
+class ResolveAttioDemoTests(unittest.TestCase):
+    def test_single_future_match(self):
+        with patch.object(attio, "_query_records", return_value=[DEAL]):
+            sim, summary = cal.resolve_attio_demo("Synergy Wellness", now=NOW)
+        self.assertEqual(sim, 30)
+        self.assertIn("Synergy Wellness", summary)
+
+    def test_ambiguous_match_not_usable(self):
+        with patch.object(attio, "_query_records", return_value=[DEAL, PAST_DEAL]):
+            self.assertEqual(cal.resolve_attio_demo("Demo", now=NOW), (None, None))
+
+    def test_no_match(self):
+        with patch.object(attio, "_query_records", return_value=[]):
+            self.assertEqual(cal.resolve_attio_demo("Synergy", now=NOW), (None, None))
+
+    def test_past_demo_not_surfaced(self):
+        with patch.object(attio, "_query_records", return_value=[PAST_DEAL]):
+            self.assertEqual(cal.resolve_attio_demo("Old", now=NOW), (None, None))
+
+    def test_api_error_fails_closed(self):
+        with patch.object(attio, "_query_records", side_effect=attio.AttioError("network")):
+            self.assertEqual(cal.resolve_attio_demo("Synergy", now=NOW), (None, None))
+
+
+class BuildCalendarContextTests(unittest.TestCase):
+    def test_attio_path_strips_timestamp(self):
+        with patch.object(attio, "_query_records", return_value=[DEAL]):
+            ctx = cal.build_calendar_context("Jane Synergy Wellness 2026-06-20T17:00:00Z", now=NOW)
+        self.assertTrue(ctx["usable"])
+        self.assertEqual(ctx["basis"], "attio")
+        self.assertEqual(ctx["startsInMinutes"], 30)
+
+    def test_empty_query(self):
+        ctx = cal.build_calendar_context("", now=NOW)
+        self.assertFalse(ctx["usable"])
+        self.assertEqual(ctx["status"], "empty_query")
+
+    def test_not_found(self):
+        with patch.object(attio, "_query_records", return_value=[]):
+            ctx = cal.build_calendar_context("Nobody Unknown", now=NOW)
+        self.assertFalse(ctx["usable"])
+        self.assertEqual(ctx["status"], "not_found")
+
+
+class CalendlyBestEffortTests(unittest.TestCase):
+    def _fake_urlopen(self, payloads):
+        class FakeResp:
+            def __init__(self, payload):
+                self._p = json.dumps(payload).encode("utf-8")
+
+            def read(self):
+                return self._p
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        def opener(req, timeout=None):
+            url = req.full_url if hasattr(req, "full_url") else req
+            if "/users/me" in url:
+                return FakeResp(payloads["me"])
+            return FakeResp(payloads["events"])
+
+        return opener
+
+    def test_calendly_next_event(self):
+        payloads = {
+            "me": {"resource": {"current_organization": "https://api.calendly.com/organizations/ORG"}},
+            "events": {"collection": [{"name": "ShapeScale Demo", "start_time": "2026-06-20T18:45:00Z"}]},
+        }
+        with patch.dict("os.environ", {"CALENDLY_API_KEY": "tok"}), \
+             patch("urllib.request.urlopen", side_effect=self._fake_urlopen(payloads)):
+            sim, summary = cal.calendly_next_event("invitee@example.com", now=NOW)
+        self.assertEqual(sim, 45)
+        self.assertIn("ShapeScale Demo", summary)
+
+    def test_calendly_disabled_without_key(self):
+        with patch.dict("os.environ", {}, clear=True):
+            self.assertEqual(cal.calendly_next_event("invitee@example.com", now=NOW), (None, None))
+
+    def test_build_falls_back_to_calendly_when_email_present(self):
+        payloads = {
+            "me": {"resource": {"current_organization": "https://api.calendly.com/organizations/ORG"}},
+            "events": {"collection": [{"name": "Demo", "start_time": "2026-06-20T18:20:00Z"}]},
+        }
+        with patch.object(attio, "_query_records", return_value=[]), \
+             patch.dict("os.environ", {"CALENDLY_API_KEY": "tok"}), \
+             patch("urllib.request.urlopen", side_effect=self._fake_urlopen(payloads)):
+            ctx = cal.build_calendar_context("Jane invitee@example.com 2026-06-20T17:00:00Z", now=NOW)
+        self.assertTrue(ctx["usable"])
+        self.assertEqual(ctx["basis"], "calendly")
+        self.assertEqual(ctx["startsInMinutes"], 20)
+
+
+class HardeningTests(unittest.TestCase):
+    def test_main_exits_zero_on_internal_exception(self):
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with patch.object(cal, "build_calendar_context", side_effect=RuntimeError("boom")), redirect_stdout(buf):
+            rc = cal.main(["anything"])
+        self.assertEqual(rc, 0)
+        self.assertFalse(json.loads(buf.getvalue())["usable"])
+
+    def test_event_name_sanitized(self):
+        deal = {
+            "id": {"record_id": "d"},
+            "values": {
+                "name": [{"value": "Evil\nDemo\x00", "attribute_type": "text"}],
+                "demo_scheduled_at": [{"value": "2026-06-20T18:30:00.000000000Z"}],
+            },
+        }
+        with patch.object(attio, "_query_records", return_value=[deal]):
+            sim, summary = cal.resolve_attio_demo("Evil", now=NOW)
+        self.assertEqual(summary, "Upcoming demo: Evil Demo")
+
+    def test_calendly_rejects_unexpected_org(self):
+        payloads = {
+            "me": {"resource": {"current_organization": "https://evil.example/org"}},
+            "events": {"collection": [{"name": "x", "start_time": "2026-06-20T18:45:00Z"}]},
+        }
+        with patch.dict("os.environ", {"CALENDLY_API_KEY": "tok"}), \
+             patch("urllib.request.urlopen", side_effect=self_fake_urlopen(payloads)):
+            self.assertEqual(cal.calendly_next_event("a@b.com", now=NOW), (None, None))
+
+
+def self_fake_urlopen(payloads):
+    class FakeResp:
+        def __init__(self, payload):
+            self._p = json.dumps(payload).encode("utf-8")
+
+        def read(self):
+            return self._p
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def opener(req, timeout=None):
+        url = req.full_url if hasattr(req, "full_url") else req
+        return FakeResp(payloads["me"] if "/users/me" in url else payloads["events"])
+
+    return opener
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Phase A of S1 (wire the dead enrichment draft modes). Adds two standalone
context-command adapters that the Dialpad webhook already knows how to call but
that currently fail closed because no command is wired:

- **`scripts/adapters/attio_context.py`** — resolves an inbound sender phone →
  Attio person → associated deal, emitting `{usable, summary, deal, stage,
  company, owner}` for the CRM-aware draft. The resolution helpers are the
  reusable Attio client for the future S2 phone-first identity resolver.
- **`scripts/adapters/calendar_context.py`** — resolves an upcoming demo time
  from the Attio `demo_scheduled_at` attribute (primary) with Calendly as a
  best-effort fallback, emitting `{usable, summary, startsInMinutes}`. Only
  future demos surface.
- **`docs/reference/`** — `attio-schema.md` (the discovered Attio slugs; the
  pipeline is the standard `deals` object) and `enrichment-adapters.md` (the
  deploy-time env wiring, including the `DIALPAD_QMD_COMMAND` absolute-path fix).
- Planning trail: ideation, requirements brainstorm, and the phased plan.

## Why

The auto-responder's richer draft modes already exist but fall back to a generic
template because the context commands are unset and the rich path is gated behind
high-confidence known contacts. These adapters are the enrichment sources the
un-gate (a later PR) will run.

## Scope / what this PR deliberately does NOT do

- **No change to `webhook_server.py` request handling, threading, draft-mode
  selection, or auto-send.** The async refactor + SMS idempotency (plan U5/U6)
  and the un-gate + deploy (U7/U8) are follow-up PRs, because they modify the
  live customer-facing message path and warrant separate review.
- **Does not enable the live `.env`** — per plan KTD6, the context commands must
  not be activated before the async refactor (they run inline before the webhook
  ACK on a single-threaded server). Wiring is documented for the deploy step.

## Tests

```
python3 -m unittest tests.test_attio_context tests.test_calendar_context   # 40 tests
python3 -m unittest discover -s tests -p 'test_*.py'                        # 225 tests, all pass
```

- HTTP layer fully mocked; no live API calls in the suite.
- Covers happy paths, fail-closed contract (internal exceptions → `{"usable":
  false}`, exit 0), malformed Attio payloads, control-char sanitization,
  phone normalization, secret-not-in-stdout, and the Calendly fallback.
- A guarded live smoke against real Attio confirmed a real sender resolves to
  company/deal/stage.

## Review

Independent correctness + security reviews ran; applied fixes: top-level
fail-closed wrappers, malformed-payload guards, control-char sanitization as
defense in depth ahead of the webhook's `customer_safe_knowledge_text` filter,
phone normalization, and Calendly org validation.

Known limitation (deferred, not a bug): `deal_for_person` returns the first
associated deal without filtering for open/closed status — a re-engaging contact
with a closed deal surfaces that stage. Acceptable for S1 (operator reviews every
draft); deal-status segmentation is S3.

## AI Assistance

Authored via the ce-ideate → ce-brainstorm → ce-plan → ce-work pipeline with
Claude Opus 4.8. Attio schema discovered against the live REST API.

[size/exempt: adapters ~470 LOC; remainder is mocked tests + the planning/reference doc trail, low review burden]
