### PR TITLE
feat(webhook): ACK-first async draft generation + SMS idempotency (PR2, U5+U6)

### DIFF
--- a/scripts/sms_approval.py
+++ b/scripts/sms_approval.py
@@ -135,7 +135,10 @@ def init_db(path: Path | None = None) -> sqlite3.Connection:
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(db_path)
     conn.execute("PRAGMA busy_timeout=5000")  # serialize concurrent webhook-thread writers
-    conn.execute("PRAGMA journal_mode=WAL")
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")  # best-effort; busy_timeout provides the serialization
+    except sqlite3.OperationalError:
+        pass
     conn.row_factory = sqlite3.Row
     conn.execute(
         """

--- a/scripts/sms_approval.py
+++ b/scripts/sms_approval.py
@@ -134,6 +134,8 @@ def init_db(path: Path | None = None) -> sqlite3.Connection:
     db_path = path or DB_PATH
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout=5000")  # serialize concurrent webhook-thread writers
+    conn.execute("PRAGMA journal_mode=WAL")
     conn.row_factory = sqlite3.Row
     conn.execute(
         """

--- a/scripts/sms_sqlite.py
+++ b/scripts/sms_sqlite.py
@@ -49,7 +49,10 @@ def init_db() -> sqlite3.Connection:
     DB_PATH.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(DB_PATH)
     conn.execute("PRAGMA busy_timeout=5000")  # serialize concurrent webhook-thread writers
-    conn.execute("PRAGMA journal_mode=WAL")
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")  # best-effort; busy_timeout provides the serialization
+    except sqlite3.OperationalError:
+        pass
     conn.row_factory = sqlite3.Row
     
     # Main messages table

--- a/scripts/sms_sqlite.py
+++ b/scripts/sms_sqlite.py
@@ -48,6 +48,8 @@ def init_db() -> sqlite3.Connection:
     """Initialize the database with schema"""
     DB_PATH.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(DB_PATH)
+    conn.execute("PRAGMA busy_timeout=5000")  # serialize concurrent webhook-thread writers
+    conn.execute("PRAGMA journal_mode=WAL")
     conn.row_factory = sqlite3.Row
     
     # Main messages table

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -1262,6 +1262,22 @@ def build_missed_call_dedupe_key(data, resolved_context):
     return f"missed-call:fingerprint:{sender_number or 'unknown'}:{recipient_number or 'unknown'}:{bucket}"
 
 
+def _apply_sqlite_concurrency_pragmas(conn):
+    """Make a connection safe for concurrent webhook threads sharing sms_approvals.db.
+
+    busy_timeout is mandatory — it serializes writers so concurrent claims/draft
+    writes wait instead of raising "database is locked". WAL is a best-effort
+    optimization: setting journal_mode needs a brief header lock that can contend
+    on a fresh/hot DB, so a failure to enable it must not fail the connection (and
+    therefore must not make a dedupe claim fail open)."""
+    conn.execute("PRAGMA busy_timeout=5000")
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+    except sqlite3.OperationalError:
+        pass
+    return conn
+
+
 def _missed_call_dedupe_db_path():
     if sms_approval is not None and getattr(sms_approval, "DB_PATH", None):
         return Path(sms_approval.DB_PATH)
@@ -1272,8 +1288,7 @@ def _init_missed_call_dedupe_db(db_path=None):
     path = Path(db_path) if db_path is not None else _missed_call_dedupe_db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(path)
-    conn.execute("PRAGMA busy_timeout=5000")  # shares sms_approvals.db with concurrent webhook threads
-    conn.execute("PRAGMA journal_mode=WAL")
+    _apply_sqlite_concurrency_pragmas(conn)
     conn.execute(
         f"""
         CREATE TABLE IF NOT EXISTS {MISSED_CALL_DEDUPE_TABLE} (
@@ -1340,8 +1355,7 @@ def _init_sms_dedupe_db(db_path=None):
     path = Path(db_path) if db_path is not None else _sms_dedupe_db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(path)
-    conn.execute("PRAGMA busy_timeout=5000")  # tolerate concurrent webhook threads
-    conn.execute("PRAGMA journal_mode=WAL")
+    _apply_sqlite_concurrency_pragmas(conn)
     conn.execute(
         f"""
         CREATE TABLE IF NOT EXISTS {SMS_DEDUPE_TABLE} (

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -50,7 +50,7 @@ import urllib.request
 import urllib.parse
 import urllib.error
 from datetime import datetime
-from http.server import HTTPServer, BaseHTTPRequestHandler
+from http.server import ThreadingHTTPServer, HTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
 
 # Add skill directory to path for local imports
@@ -1338,6 +1338,7 @@ def _init_sms_dedupe_db(db_path=None):
     path = Path(db_path) if db_path is not None else _sms_dedupe_db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(path)
+    conn.execute("PRAGMA busy_timeout=5000")  # tolerate concurrent webhook threads
     conn.execute(
         f"""
         CREATE TABLE IF NOT EXISTS {SMS_DEDUPE_TABLE} (
@@ -3174,6 +3175,28 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(json.dumps(payload).encode())
 
+    def _ack_webhook_200(self, *, stored=True, duplicate=False):
+        """ACK Dialpad with a complete 200 before slow processing (ACK-first).
+
+        Dialpad only needs receipt acknowledgement; draft generation, hook
+        delivery, and Telegram notification run after this returns. Each request
+        runs on its own thread (ThreadingHTTPServer), so post-ACK work never
+        blocks other requests or delays this ACK — eliminating the retry storms a
+        24s inline draft lookup would otherwise cause. Content-Length + flush let
+        Dialpad treat the response as complete immediately."""
+        body = json.dumps(
+            {"status": "ok", "stored": stored, "processing": "duplicate" if duplicate else "async"}
+        ).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+        try:
+            self.wfile.flush()
+        except Exception:  # noqa: BLE001 - ACK already written; flush is best-effort.
+            pass
+
     def read_json_body(self, endpoint_label):
         """Read a bounded JSON request body."""
         max_body_size = 1024 * 1024
@@ -3327,6 +3350,22 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
         except Exception as e:
             print(f"❌ Storage error: {e}")
             self.send_error(500, f"Storage error: {e}")
+            return
+
+        # ACK-first: acknowledge Dialpad now, then run the slow inbound processing
+        # (enrichment, draft generation, hooks, Telegram) below. Claim the inbound
+        # message_id first so a Dialpad retry of an already-processed message ACKs
+        # 200 without re-running those side effects (plan U5/U6).
+        duplicate_inbound = False
+        if direction == "inbound":
+            inbound_message_id = data.get("message_id") or data.get("id")
+            duplicate_inbound = claim_sms_webhook_event(inbound_message_id).get("duplicate", False)
+        self._ack_webhook_200(stored=True, duplicate=duplicate_inbound)
+        if duplicate_inbound:
+            print(
+                f"   ♻️  Duplicate inbound SMS message_id="
+                f"{data.get('message_id') or data.get('id')} — skipping reprocessing"
+            )
             return
 
         # Forward inbound SMS to OpenClaw hooks (non-sensitive only)
@@ -3546,38 +3585,7 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                     f"({sender_enrichment.get('degraded_reason')})"
                 )
         print()
-
-        # Always return 200 OK (graceful degradation)
-        # Webhook succeeded even if hook forwarding failed
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.end_headers()
-        response = {
-            "status": "ok",
-            "stored": True,
-            "hook_forwarded": hook_sent if direction == "inbound" else None,
-            "hook_status": hook_status if direction == "inbound" else None,
-            "inbound_alert_eligible": (
-                inbound_alert_decision.get("eligible") if direction == "inbound" else None
-            ),
-            "inbound_alert_reason": (
-                inbound_alert_decision.get("reason_code") if direction == "inbound" else None
-            ),
-            "telegram_status": telegram_status if direction == "inbound" else None,
-            "auto_reply_sent": auto_reply_sent if direction == "inbound" else None,
-            "auto_reply_status": auto_reply_status if direction == "inbound" else None,
-            "auto_reply_draft_id": auto_reply_draft_id if direction == "inbound" else None,
-            "sender_enrichment_degraded": (
-                sender_enrichment.get("degraded") if direction == "inbound" else None
-            ),
-            "sender_enrichment_degraded_reason": (
-                sender_enrichment.get("degraded_reason") if direction == "inbound" else None
-            ),
-            "sender_enrichment_status": (
-                sender_enrichment.get("status") if direction == "inbound" else None
-            ),
-        }
-        self.wfile.write(json.dumps(response).encode())
+        # 200 ACK was already sent (ACK-first) right after storage above.
 
     def handle_call_webhook(self):
         """Handle /webhook/dialpad-call endpoint - missed call notifications"""
@@ -3969,7 +3977,10 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
 
 def main():
     """Start the webhook server"""
-    server = HTTPServer(("0.0.0.0", PORT), DialpadWebhookHandler)
+    # ThreadingHTTPServer: each request runs on its own thread so the ACK-first
+    # handlers' post-ACK work (draft generation, hooks, Telegram) never blocks or
+    # delays other inbound webhooks.
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), DialpadWebhookHandler)
 
     log_line("=" * 60)
     print("🚀 Dialpad SMS Webhook Server (OpenClaw Hooks)")

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -1278,6 +1278,39 @@ def _apply_sqlite_concurrency_pragmas(conn):
     return conn
 
 
+def _claim_dedupe_row(conn, table, retention_ms, key, timestamp_ms):
+    """Atomically claim `key` in a dedupe `table`; return True if this is the first
+    claim (new row), False if it is a duplicate. Prunes rows past the retention
+    window. The single source of the INSERT-OR-IGNORE claim transaction shared by
+    the SMS and missed-call dedupe paths; the caller owns the connection lifecycle
+    and the fail-open wrapper."""
+    conn.execute(
+        f"DELETE FROM {table} WHERE first_seen_at_ms < ?",
+        (timestamp_ms - retention_ms,),
+    )
+    cursor = conn.execute(
+        f"""
+        INSERT OR IGNORE INTO {table}
+            (dedupe_key, first_seen_at_ms, last_seen_at_ms, duplicate_count)
+        VALUES (?, ?, ?, 0)
+        """,
+        (key, timestamp_ms, timestamp_ms),
+    )
+    if cursor.rowcount == 1:
+        conn.commit()
+        return True
+    conn.execute(
+        f"""
+        UPDATE {table}
+        SET last_seen_at_ms = ?, duplicate_count = duplicate_count + 1
+        WHERE dedupe_key = ?
+        """,
+        (timestamp_ms, key),
+    )
+    conn.commit()
+    return False
+
+
 def _missed_call_dedupe_db_path():
     if sms_approval is not None and getattr(sms_approval, "DB_PATH", None):
         return Path(sms_approval.DB_PATH)
@@ -1313,33 +1346,14 @@ def claim_missed_call_notification(dedupe_key, *, db_path=None, now_ms=None):
     try:
         conn = _init_missed_call_dedupe_db(db_path=db_path)
         try:
-            conn.execute(
-                f"DELETE FROM {MISSED_CALL_DEDUPE_TABLE} WHERE first_seen_at_ms < ?",
-                (timestamp_ms - MISSED_CALL_DEDUPE_RETENTION_MS,),
+            claimed = _claim_dedupe_row(
+                conn, MISSED_CALL_DEDUPE_TABLE, MISSED_CALL_DEDUPE_RETENTION_MS, key, timestamp_ms
             )
-            cursor = conn.execute(
-                f"""
-                INSERT OR IGNORE INTO {MISSED_CALL_DEDUPE_TABLE}
-                    (dedupe_key, first_seen_at_ms, last_seen_at_ms, duplicate_count)
-                VALUES (?, ?, ?, 0)
-                """,
-                (key, timestamp_ms, timestamp_ms),
-            )
-            if cursor.rowcount == 1:
-                conn.commit()
-                return {"claimed": True, "duplicate": False, "key": key, "status": "claimed"}
-            conn.execute(
-                f"""
-                UPDATE {MISSED_CALL_DEDUPE_TABLE}
-                SET last_seen_at_ms = ?, duplicate_count = duplicate_count + 1
-                WHERE dedupe_key = ?
-                """,
-                (timestamp_ms, key),
-            )
-            conn.commit()
-            return {"claimed": False, "duplicate": True, "key": key, "status": "duplicate"}
         finally:
             conn.close()
+        if claimed:
+            return {"claimed": True, "duplicate": False, "key": key, "status": "claimed"}
+        return {"claimed": False, "duplicate": True, "key": key, "status": "duplicate"}
     except Exception as exc:  # noqa: BLE001 - webhook notifications should fail open.
         print(f"⚠️  Missed-call dedupe unavailable ({type(exc).__name__})")
         return {"claimed": True, "duplicate": False, "key": key, "status": "dedupe_unavailable"}
@@ -1407,33 +1421,12 @@ def claim_sms_webhook_event(message_id, *, db_path=None, now_ms=None):
     try:
         conn = _init_sms_dedupe_db(db_path=db_path)
         try:
-            conn.execute(
-                f"DELETE FROM {SMS_DEDUPE_TABLE} WHERE first_seen_at_ms < ?",
-                (timestamp_ms - SMS_DEDUPE_RETENTION_MS,),
-            )
-            cursor = conn.execute(
-                f"""
-                INSERT OR IGNORE INTO {SMS_DEDUPE_TABLE}
-                    (dedupe_key, first_seen_at_ms, last_seen_at_ms, duplicate_count)
-                VALUES (?, ?, ?, 0)
-                """,
-                (key, timestamp_ms, timestamp_ms),
-            )
-            if cursor.rowcount == 1:
-                conn.commit()
-                return {"claimed": True, "duplicate": False, "key": key, "status": "claimed"}
-            conn.execute(
-                f"""
-                UPDATE {SMS_DEDUPE_TABLE}
-                SET last_seen_at_ms = ?, duplicate_count = duplicate_count + 1
-                WHERE dedupe_key = ?
-                """,
-                (timestamp_ms, key),
-            )
-            conn.commit()
-            return {"claimed": False, "duplicate": True, "key": key, "status": "duplicate"}
+            claimed = _claim_dedupe_row(conn, SMS_DEDUPE_TABLE, SMS_DEDUPE_RETENTION_MS, key, timestamp_ms)
         finally:
             conn.close()
+        if claimed:
+            return {"claimed": True, "duplicate": False, "key": key, "status": "claimed"}
+        return {"claimed": False, "duplicate": True, "key": key, "status": "duplicate"}
     except Exception as exc:  # noqa: BLE001 - webhook dedupe must fail open.
         print(f"⚠️  SMS dedupe unavailable ({type(exc).__name__})")
         return {"claimed": True, "duplicate": False, "key": key, "status": "dedupe_unavailable"}
@@ -3442,8 +3435,10 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
         """Side-effect processing that runs AFTER the 200 ACK (ACK-first).
 
         Enrichment, draft generation, OpenClaw hooks, and Telegram. Any raise
-        propagates to the caller, which releases the dedupe claim so a Dialpad
-        retry can recover rather than being suppressed as a duplicate."""
+        propagates to the caller, which logs it and KEEPS the dedupe claim: a
+        post-ACK failure may be after a draft/hook/Telegram card already fired, so
+        replaying via a Dialpad retry would duplicate user-visible output. The
+        message stays stored; only the auto-draft may be missing."""
         # Forward inbound SMS to OpenClaw hooks (non-sensitive only)
         hook_sent = False
         hook_status = None

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -145,6 +145,9 @@ MISSED_CALL_DEDUPE_TABLE = "missed_call_webhook_events"
 MISSED_CALL_DEDUPE_FALLBACK_BUCKET_MS = 60 * 1000
 MISSED_CALL_DEDUPE_RETENTION_MS = 7 * 24 * 60 * 60 * 1000
 
+SMS_DEDUPE_TABLE = "sms_webhook_events"
+SMS_DEDUPE_RETENTION_MS = 7 * 24 * 60 * 60 * 1000
+
 TELEGRAM_STATUS_SENT = "sent"
 TELEGRAM_STATUS_FILTERED = "filtered"
 TELEGRAM_STATUS_NOT_APPLICABLE = "not_applicable"
@@ -1322,6 +1325,80 @@ def claim_missed_call_notification(dedupe_key, *, db_path=None, now_ms=None):
             conn.close()
     except Exception as exc:  # noqa: BLE001 - webhook notifications should fail open.
         print(f"⚠️  Missed-call dedupe unavailable ({type(exc).__name__})")
+        return {"claimed": True, "duplicate": False, "key": key, "status": "dedupe_unavailable"}
+
+
+def _sms_dedupe_db_path():
+    if sms_approval is not None and getattr(sms_approval, "DB_PATH", None):
+        return Path(sms_approval.DB_PATH)
+    return Path(os.environ.get("DIALPAD_SMS_DEDUPE_DB", "/home/art/clawd/logs/sms_approvals.db"))
+
+
+def _init_sms_dedupe_db(db_path=None):
+    path = Path(db_path) if db_path is not None else _sms_dedupe_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {SMS_DEDUPE_TABLE} (
+            dedupe_key TEXT PRIMARY KEY,
+            first_seen_at_ms INTEGER NOT NULL,
+            last_seen_at_ms INTEGER NOT NULL,
+            duplicate_count INTEGER NOT NULL DEFAULT 0
+        )
+        """
+    )
+    conn.commit()
+    return conn
+
+
+def claim_sms_webhook_event(message_id, *, db_path=None, now_ms=None):
+    """Atomically claim an inbound SMS webhook event by Dialpad message_id, failing open.
+
+    Mirrors claim_missed_call_notification: the first claim for a message_id returns
+    claimed=True; a Dialpad retry of the same message returns duplicate=True so the
+    handler can ACK 200 without re-running side effects (draft creation, hook
+    delivery). Fails open if storage is unavailable so the webhook never blocks on
+    dedupe. Pair with the ACK-first async path so a slow ACK / retry cannot create a
+    duplicate draft (plan U5/U6).
+    """
+    key = _clean_identifier(message_id)
+    if not key:
+        return {"claimed": True, "duplicate": False, "key": None, "status": "key_missing"}
+
+    timestamp_ms = _now_ms() if now_ms is None else now_ms
+    try:
+        conn = _init_sms_dedupe_db(db_path=db_path)
+        try:
+            conn.execute(
+                f"DELETE FROM {SMS_DEDUPE_TABLE} WHERE first_seen_at_ms < ?",
+                (timestamp_ms - SMS_DEDUPE_RETENTION_MS,),
+            )
+            cursor = conn.execute(
+                f"""
+                INSERT OR IGNORE INTO {SMS_DEDUPE_TABLE}
+                    (dedupe_key, first_seen_at_ms, last_seen_at_ms, duplicate_count)
+                VALUES (?, ?, ?, 0)
+                """,
+                (key, timestamp_ms, timestamp_ms),
+            )
+            if cursor.rowcount == 1:
+                conn.commit()
+                return {"claimed": True, "duplicate": False, "key": key, "status": "claimed"}
+            conn.execute(
+                f"""
+                UPDATE {SMS_DEDUPE_TABLE}
+                SET last_seen_at_ms = ?, duplicate_count = duplicate_count + 1
+                WHERE dedupe_key = ?
+                """,
+                (timestamp_ms, key),
+            )
+            conn.commit()
+            return {"claimed": False, "duplicate": True, "key": key, "status": "duplicate"}
+        finally:
+            conn.close()
+    except Exception as exc:  # noqa: BLE001 - webhook dedupe must fail open.
+        print(f"⚠️  SMS dedupe unavailable ({type(exc).__name__})")
         return {"claimed": True, "duplicate": False, "key": key, "status": "dedupe_unavailable"}
 
 

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -1272,6 +1272,8 @@ def _init_missed_call_dedupe_db(db_path=None):
     path = Path(db_path) if db_path is not None else _missed_call_dedupe_db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(path)
+    conn.execute("PRAGMA busy_timeout=5000")  # shares sms_approvals.db with concurrent webhook threads
+    conn.execute("PRAGMA journal_mode=WAL")
     conn.execute(
         f"""
         CREATE TABLE IF NOT EXISTS {MISSED_CALL_DEDUPE_TABLE} (
@@ -3411,11 +3413,14 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                 data, result, from_num, to_num, text, direction, notification_type, timestamp, auth_source
             )
         except Exception as exc:  # noqa: BLE001 - 200 already sent; never crash the thread.
-            print(
-                f"❌ Post-ACK inbound processing failed ({type(exc).__name__}) — "
-                "releasing dedupe claim so a Dialpad retry can recover"
-            )
-            release_sms_webhook_event(inbound_dedupe_key)
+            # Do NOT release the dedupe claim here. By this point storage + the 200
+            # ACK have succeeded and user-visible side effects (draft, OpenClaw
+            # hook, Telegram review card) may already have fired. Releasing would
+            # let a Dialpad retry replay them — duplicate operator cards / duplicate
+            # customer SMS — which the product-security invariant forbids. Accept
+            # the rarer partial-processing gap: the inbound is stored, only the
+            # auto-draft may be missing. Redacted log (no payload PII).
+            print(f"❌ Post-ACK inbound processing failed ({type(exc).__name__}); stored, not retried")
 
     def _process_inbound_post_ack(
         self, data, result, from_num, to_num, text, direction, notification_type, timestamp, auth_source

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -1339,6 +1339,7 @@ def _init_sms_dedupe_db(db_path=None):
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(path)
     conn.execute("PRAGMA busy_timeout=5000")  # tolerate concurrent webhook threads
+    conn.execute("PRAGMA journal_mode=WAL")
     conn.execute(
         f"""
         CREATE TABLE IF NOT EXISTS {SMS_DEDUPE_TABLE} (
@@ -1351,6 +1352,25 @@ def _init_sms_dedupe_db(db_path=None):
     )
     conn.commit()
     return conn
+
+
+def sms_dedupe_key(data):
+    """Stable idempotency key for an inbound SMS webhook payload.
+
+    Prefers the Dialpad message_id (fallback id). When neither is present —
+    Dialpad ships payload variants that can omit the top-level id — synthesize a
+    deterministic key from sender/recipient/timestamp/text so retries still
+    dedupe instead of failing open (mirrors build_missed_call_dedupe_key)."""
+    message_id = data.get("message_id") or data.get("id")
+    if _clean_identifier(message_id):
+        return message_id
+    parts = [
+        str(first_value(data.get("from_number")) or ""),
+        str(first_value(data.get("to_number")) or ""),
+        str(data.get("created_date") or data.get("timestamp") or data.get("date") or ""),
+        hashlib.sha256((extract_message_text(data) or "").encode("utf-8")).hexdigest()[:16],
+    ]
+    return "sms-synth:" + "|".join(parts)
 
 
 def claim_sms_webhook_event(message_id, *, db_path=None, now_ms=None):
@@ -3358,14 +3378,11 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
         # 200 without re-running those side effects (plan U5/U6).
         duplicate_inbound = False
         if direction == "inbound":
-            inbound_message_id = data.get("message_id") or data.get("id")
-            duplicate_inbound = claim_sms_webhook_event(inbound_message_id).get("duplicate", False)
+            inbound_dedupe_key = sms_dedupe_key(data)
+            duplicate_inbound = claim_sms_webhook_event(inbound_dedupe_key).get("duplicate", False)
         self._ack_webhook_200(stored=True, duplicate=duplicate_inbound)
         if duplicate_inbound:
-            print(
-                f"   ♻️  Duplicate inbound SMS message_id="
-                f"{data.get('message_id') or data.get('id')} — skipping reprocessing"
-            )
+            print(f"   ♻️  Duplicate inbound SMS — skipping reprocessing")
             return
 
         # Forward inbound SMS to OpenClaw hooks (non-sensitive only)

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -1423,6 +1423,24 @@ def claim_sms_webhook_event(message_id, *, db_path=None, now_ms=None):
         return {"claimed": True, "duplicate": False, "key": key, "status": "dedupe_unavailable"}
 
 
+def release_sms_webhook_event(dedupe_key, *, db_path=None):
+    """Release a previously-claimed SMS dedupe key so a Dialpad retry can be
+    reprocessed. Called when intake fails after the claim (storage error or a
+    post-ACK processing exception). Best-effort; never raises; no-op on empty key."""
+    key = _clean_identifier(dedupe_key)
+    if not key:
+        return
+    try:
+        conn = _init_sms_dedupe_db(db_path=db_path)
+        try:
+            conn.execute(f"DELETE FROM {SMS_DEDUPE_TABLE} WHERE dedupe_key = ?", (key,))
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception as exc:  # noqa: BLE001 - rollback is best-effort.
+        print(f"⚠️  SMS dedupe release failed ({type(exc).__name__})")
+
+
 def _extract_payload_contact_name(data):
     """Extract a Dialpad-provided contact display name from webhook payloads."""
     contact = data.get("contact")
@@ -3357,6 +3375,18 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
         text = extract_message_text(data)
         notification_type = classify_inbound_notification(data) if direction == "inbound" else "not_inbound"
 
+        # ACK-first idempotent intake: claim the inbound BEFORE storage so a
+        # Dialpad retry short-circuits before ANY side effect (storage, draft,
+        # hooks, Telegram) re-fires. The claim is released on any intake failure
+        # so a retry can still recover the message (plan U5/U6).
+        inbound_dedupe_key = None
+        if direction == "inbound":
+            inbound_dedupe_key = sms_dedupe_key(data)
+            if claim_sms_webhook_event(inbound_dedupe_key).get("duplicate", False):
+                self._ack_webhook_200(stored=True, duplicate=True)
+                print("   ♻️  Duplicate inbound SMS — skipping reprocessing")
+                return
+
         # Store message in SQLite
         try:
             result = handle_sms_webhook(data)
@@ -3364,27 +3394,37 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
 
             if not stored:
                 print(f"⚠️  Failed to store message: {result.get('error', 'Unknown error')}")
+                release_sms_webhook_event(inbound_dedupe_key)
                 self.send_error(500, "Storage failed")
                 return
 
         except Exception as e:
             print(f"❌ Storage error: {e}")
+            release_sms_webhook_event(inbound_dedupe_key)
             self.send_error(500, f"Storage error: {e}")
             return
 
-        # ACK-first: acknowledge Dialpad now, then run the slow inbound processing
-        # (enrichment, draft generation, hooks, Telegram) below. Claim the inbound
-        # message_id first so a Dialpad retry of an already-processed message ACKs
-        # 200 without re-running those side effects (plan U5/U6).
-        duplicate_inbound = False
-        if direction == "inbound":
-            inbound_dedupe_key = sms_dedupe_key(data)
-            duplicate_inbound = claim_sms_webhook_event(inbound_dedupe_key).get("duplicate", False)
-        self._ack_webhook_200(stored=True, duplicate=duplicate_inbound)
-        if duplicate_inbound:
-            print(f"   ♻️  Duplicate inbound SMS — skipping reprocessing")
-            return
+        # ACK Dialpad now; the slow side-effect processing runs after this 200.
+        self._ack_webhook_200(stored=True, duplicate=False)
+        try:
+            self._process_inbound_post_ack(
+                data, result, from_num, to_num, text, direction, notification_type, timestamp, auth_source
+            )
+        except Exception as exc:  # noqa: BLE001 - 200 already sent; never crash the thread.
+            print(
+                f"❌ Post-ACK inbound processing failed ({type(exc).__name__}) — "
+                "releasing dedupe claim so a Dialpad retry can recover"
+            )
+            release_sms_webhook_event(inbound_dedupe_key)
 
+    def _process_inbound_post_ack(
+        self, data, result, from_num, to_num, text, direction, notification_type, timestamp, auth_source
+    ):
+        """Side-effect processing that runs AFTER the 200 ACK (ACK-first).
+
+        Enrichment, draft generation, OpenClaw hooks, and Telegram. Any raise
+        propagates to the caller, which releases the dedupe claim so a Dialpad
+        retry can recover rather than being suppressed as a duplicate."""
         # Forward inbound SMS to OpenClaw hooks (non-sensitive only)
         hook_sent = False
         hook_status = None
@@ -3602,7 +3642,6 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                     f"({sender_enrichment.get('degraded_reason')})"
                 )
         print()
-        # 200 ACK was already sent (ACK-first) right after storage above.
 
     def handle_call_webhook(self):
         """Handle /webhook/dialpad-call endpoint - missed call notifications"""

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -1397,7 +1397,14 @@ def sms_dedupe_key(data):
     parts = [
         str(first_value(data.get("from_number")) or ""),
         str(first_value(data.get("to_number")) or ""),
-        str(data.get("created_date") or data.get("timestamp") or data.get("date") or ""),
+        str(
+            data.get("created_date")
+            or data.get("event_timestamp")
+            or data.get("date_created")
+            or data.get("timestamp")
+            or data.get("date")
+            or ""
+        ),
         hashlib.sha256((extract_message_text(data) or "").encode("utf-8")).hexdigest()[:16],
     ]
     return "sms-synth:" + "|".join(parts)
@@ -3414,7 +3421,14 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
             return
 
         # ACK Dialpad now; the slow side-effect processing runs after this 200.
-        self._ack_webhook_200(stored=True, duplicate=False)
+        try:
+            self._ack_webhook_200(stored=True, duplicate=False)
+        except Exception:  # noqa: BLE001 - client disconnected mid-ACK
+            # Dialpad never received the 200 and will retry; that retry hits the
+            # duplicate branch (claim is held) and gets a clean 200. Process now so
+            # the inbound still gets its side effects exactly once instead of being
+            # silently suppressed by the retry's duplicate short-circuit.
+            print("⚠️  ACK write failed (client disconnect); processing inbound anyway")
         try:
             self._process_inbound_post_ack(
                 data, result, from_num, to_num, text, direction, notification_type, timestamp, auth_source

--- a/tests/test_sms_idempotency.py
+++ b/tests/test_sms_idempotency.py
@@ -113,6 +113,19 @@ class SmsDedupeKeyTests(unittest.TestCase):
         self.assertTrue(k1.startswith("sms-synth:"))
         self.assertEqual(k1, k2)  # deterministic -> retries of an id-less payload dedupe
 
+    def test_synth_key_uses_all_recognized_timestamp_fields(self):
+        # event_timestamp and date_created are recognized SMS timestamp fields;
+        # distinct times must yield distinct keys so id-less messages don't collide.
+        base = {"from_number": "+1", "to_number": "+2", "text": "ok"}
+        self.assertNotEqual(
+            ws.sms_dedupe_key({**base, "event_timestamp": "2026-06-19T09:00:00Z"}),
+            ws.sms_dedupe_key({**base, "event_timestamp": "2026-06-19T09:05:00Z"}),
+        )
+        self.assertNotEqual(
+            ws.sms_dedupe_key({**base, "date_created": "t1"}),
+            ws.sms_dedupe_key({**base, "date_created": "t2"}),
+        )
+
     def test_synthesized_key_differs_by_text(self):
         base = {"from_number": "+1", "to_number": "+2", "created_date": "t"}
         self.assertNotEqual(

--- a/tests/test_sms_idempotency.py
+++ b/tests/test_sms_idempotency.py
@@ -43,6 +43,36 @@ class ClaimSmsWebhookEventTests(unittest.TestCase):
         claimed = [r for r in results if r["claimed"] and not r["duplicate"]]
         self.assertEqual(len(claimed), 1)
 
+    def test_at_most_once_under_concurrency(self):
+        # ThreadingHTTPServer means concurrent retries hit claim() on separate
+        # threads/connections. INSERT OR IGNORE + busy_timeout must still yield
+        # exactly one winner and zero raised exceptions.
+        import threading
+        results = []
+        errors = []
+        lock = threading.Lock()
+
+        def worker():
+            try:
+                r = ws.claim_sms_webhook_event("concurrent-1", db_path=self.db)
+            except Exception as exc:  # noqa: BLE001 - record, don't swallow silently
+                with lock:
+                    errors.append(exc)
+                return
+            with lock:
+                results.append(r)
+
+        threads = [threading.Thread(target=worker) for _ in range(12)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(errors, [])
+        winners = [r for r in results if r["claimed"] and not r["duplicate"]]
+        self.assertEqual(len(winners), 1)
+        self.assertEqual(len(results), 12)
+
     def test_missing_message_id_fails_open(self):
         for bad in ("", None):
             r = self.claim(bad)

--- a/tests/test_sms_idempotency.py
+++ b/tests/test_sms_idempotency.py
@@ -69,9 +69,14 @@ class ClaimSmsWebhookEventTests(unittest.TestCase):
             t.join()
 
         self.assertEqual(errors, [])
-        winners = [r for r in results if r["claimed"] and not r["duplicate"]]
-        self.assertEqual(len(winners), 1)
         self.assertEqual(len(results), 12)
+        # exactly one real claim; the rest are duplicates. No fail-opens
+        # (dedupe_unavailable) should occur under busy_timeout serialization —
+        # a fail-open here means a duplicate could slip through in production.
+        real_claims = [r for r in results if r["status"] == "claimed"]
+        self.assertEqual(len(real_claims), 1)
+        self.assertEqual([r for r in results if r["status"] == "dedupe_unavailable"], [])
+        self.assertEqual(len([r for r in results if r["duplicate"]]), 11)
 
     def test_missing_message_id_fails_open(self):
         for bad in ("", None):

--- a/tests/test_sms_idempotency.py
+++ b/tests/test_sms_idempotency.py
@@ -1,0 +1,67 @@
+"""Unit tests for SMS webhook idempotency (plan U6). Storage isolated to a temp DB."""
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import webhook_server as ws  # noqa: E402
+
+
+class ClaimSmsWebhookEventTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
+        self.db = self.tmp.name
+
+    def tearDown(self):
+        Path(self.db).unlink(missing_ok=True)
+
+    def claim(self, message_id, now_ms=1_000_000):
+        return ws.claim_sms_webhook_event(message_id, db_path=self.db, now_ms=now_ms)
+
+    def test_first_claim_then_duplicate(self):
+        first = self.claim("msg-1")
+        self.assertTrue(first["claimed"])
+        self.assertFalse(first["duplicate"])
+        self.assertEqual(first["status"], "claimed")
+
+        second = self.claim("msg-1")
+        self.assertFalse(second["claimed"])
+        self.assertTrue(second["duplicate"])
+        self.assertEqual(second["status"], "duplicate")
+
+    def test_distinct_message_ids_both_claim(self):
+        self.assertTrue(self.claim("msg-a")["claimed"])
+        self.assertTrue(self.claim("msg-b")["claimed"])
+
+    def test_at_most_once_across_many_claims(self):
+        # The delivery-correctness invariant: N deliveries of one message_id -> one claim.
+        results = [self.claim("msg-repeat") for _ in range(6)]
+        claimed = [r for r in results if r["claimed"] and not r["duplicate"]]
+        self.assertEqual(len(claimed), 1)
+
+    def test_missing_message_id_fails_open(self):
+        for bad in ("", None):
+            r = self.claim(bad)
+            self.assertTrue(r["claimed"])  # fail open: never block the webhook
+            self.assertEqual(r["status"], "key_missing")
+
+    def test_retention_purges_old_entries(self):
+        t0 = 1_000_000
+        self.assertTrue(self.claim("msg-old", now_ms=t0)["claimed"])
+        # same id after the retention window -> old row purged, claimable again
+        later = t0 + ws.SMS_DEDUPE_RETENTION_MS + 1
+        self.assertTrue(self.claim("msg-old", now_ms=later)["claimed"])
+
+    def test_fail_open_when_storage_unavailable(self):
+        # an unwritable db path must fail open (claimed=True), not raise
+        r = ws.claim_sms_webhook_event("msg-x", db_path="/proc/cannot/write/here.db", now_ms=1)
+        self.assertTrue(r["claimed"])
+        self.assertEqual(r["status"], "dedupe_unavailable")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sms_idempotency.py
+++ b/tests/test_sms_idempotency.py
@@ -63,5 +63,41 @@ class ClaimSmsWebhookEventTests(unittest.TestCase):
         self.assertEqual(r["status"], "dedupe_unavailable")
 
 
+class SmsDedupeKeyTests(unittest.TestCase):
+    def test_prefers_message_id(self):
+        self.assertEqual(ws.sms_dedupe_key({"message_id": "M1", "id": "X"}), "M1")
+
+    def test_falls_back_to_id(self):
+        self.assertEqual(ws.sms_dedupe_key({"id": "X9"}), "X9")
+
+    def test_synthesizes_stable_key_when_no_id(self):
+        payload = {"from_number": "+14155550123", "to_number": "+14155201316",
+                   "created_date": "2026-06-19T09:00:00Z", "text": "hello"}
+        k1 = ws.sms_dedupe_key(payload)
+        k2 = ws.sms_dedupe_key(dict(payload))
+        self.assertTrue(k1.startswith("sms-synth:"))
+        self.assertEqual(k1, k2)  # deterministic -> retries of an id-less payload dedupe
+
+    def test_synthesized_key_differs_by_text(self):
+        base = {"from_number": "+1", "to_number": "+2", "created_date": "t"}
+        self.assertNotEqual(
+            ws.sms_dedupe_key({**base, "text": "a"}),
+            ws.sms_dedupe_key({**base, "text": "b"}),
+        )
+
+    def test_synthesized_key_claims_and_dedupes(self):
+        payload = {"from_number": "+1", "to_number": "+2", "created_date": "t", "text": "hi"}
+        key = ws.sms_dedupe_key(payload)
+        import tempfile
+        from pathlib import Path as _Path
+        tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        tmp.close()
+        try:
+            self.assertTrue(ws.claim_sms_webhook_event(key, db_path=tmp.name)["claimed"])
+            self.assertTrue(ws.claim_sms_webhook_event(key, db_path=tmp.name)["duplicate"])
+        finally:
+            _Path(tmp.name).unlink(missing_ok=True)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_webhook_async.py
+++ b/tests/test_webhook_async.py
@@ -100,12 +100,70 @@ class AckFirstIdempotencyTests(unittest.TestCase):
             h.handle_webhook()
         self.assertEqual(self.assess.call_count, 2)
 
+    def test_ack_written_before_processing_runs(self):
+        # The ACK body must already be on the wire when processing begins.
+        handler, _ = _build_handler(_inbound("ord-1"))
+        seen = {}
+
+        def _probe(*a, **k):
+            seen["ack_len"] = len(handler.wfile.getvalue())
+            return {"eligible": False, "reason_code": "blocked", "sensitive_filtered": False,
+                    "notification_type": "inbound"}
+
+        with patch.object(ws, "assess_inbound_sms_alert_eligibility", _probe):
+            handler.handle_webhook()
+        self.assertGreater(seen.get("ack_len", 0), 0)
+
+    def test_outbound_acks_once_without_claim(self):
+        handler, status = _build_handler({
+            "direction": "outbound", "from_number": "+14155201316",
+            "to_number": "+14155550123", "text": "hi", "message_id": "out-1",
+        })
+        with patch.object(ws, "sms_approval", None):
+            handler.handle_webhook()
+        self.assertEqual(status["code"], 200)
+        self.assertIn('"processing": "async"', handler.wfile.getvalue().decode())
+
+    def test_storage_failure_sends_500_and_releases_claim(self):
+        handler, status = _build_handler(_inbound("sf-1"))
+        with patch.object(ws, "handle_sms_webhook", lambda data: {"stored": False, "error": "boom"}):
+            handler.handle_webhook()
+        self.assertEqual(status["code"], 500)  # send_error, not a 200 ACK
+        self.assertNotIn("processing", handler.wfile.getvalue().decode())  # no ACK body
+        # claim was released, so a retry of the same message is NOT a duplicate
+        again = ws.claim_sms_webhook_event(ws.sms_dedupe_key(_inbound("sf-1")), db_path=self.db)
+        self.assertTrue(again["claimed"])
+        self.assertFalse(again["duplicate"])
+
+    def test_dedupe_unavailable_still_acks_and_processes(self):
+        with patch.object(ws, "claim_sms_webhook_event",
+                          lambda key, **k: {"claimed": True, "duplicate": False, "status": "dedupe_unavailable"}):
+            handler, status = _build_handler(_inbound("fo-1"))
+            handler.handle_webhook()
+        self.assertEqual(status["code"], 200)
+        self.assertIn('"processing": "async"', handler.wfile.getvalue().decode())
+        self.assertEqual(self.assess.call_count, 1)  # fail-open -> processing runs
+
+    def test_post_ack_exception_releases_claim_for_retry(self):
+        # A post-ACK failure must release the claim so a Dialpad retry recovers.
+        handler, status = _build_handler(_inbound("pa-1"))
+        with patch.object(ws, "assess_inbound_sms_alert_eligibility",
+                          MagicMock(side_effect=RuntimeError("boom"))):
+            handler.handle_webhook()  # must not raise; 200 already sent
+        self.assertEqual(status["code"], 200)
+        again = ws.claim_sms_webhook_event(ws.sms_dedupe_key(_inbound("pa-1")), db_path=self.db)
+        self.assertTrue(again["claimed"])
+        self.assertFalse(again["duplicate"])
+
 
 class ServerConfigTests(unittest.TestCase):
-    def test_uses_threading_http_server(self):
-        # ACK-first relies on per-request threads so post-ACK work never blocks.
-        from http.server import ThreadingHTTPServer
-        self.assertIs(ws.ThreadingHTTPServer, ThreadingHTTPServer)
+    def test_main_uses_threading_http_server(self):
+        # ACK-first relies on per-request threads -> main() must instantiate
+        # ThreadingHTTPServer, not the single-threaded HTTPServer.
+        import inspect
+        src = inspect.getsource(ws.main)
+        self.assertIn("ThreadingHTTPServer(", src)
+        self.assertNotIn("= HTTPServer(", src)
 
 
 if __name__ == "__main__":

--- a/tests/test_webhook_async.py
+++ b/tests/test_webhook_async.py
@@ -1,0 +1,112 @@
+"""Handler-level tests for ACK-first + SMS idempotency (plan U5/U6).
+
+Verifies the inbound webhook acknowledges Dialpad with a 200 before the slow
+side-effectful processing, and that a duplicate Dialpad message_id ACKs without
+re-running that processing.
+"""
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import webhook_server as ws  # noqa: E402
+
+
+def _build_handler(payload):
+    raw = json.dumps(payload).encode("utf-8")
+    handler = object.__new__(ws.DialpadWebhookHandler)
+    handler.headers = {"Content-Length": str(len(raw))}
+    handler.rfile = io.BytesIO(raw)
+    handler.wfile = io.BytesIO()
+    handler.client_address = ("127.0.0.1", 12345)
+    status = {"code": None}
+    handler.send_response = lambda code: status.__setitem__("code", code)
+    handler.send_header = lambda *_: None
+    handler.end_headers = lambda: None
+    handler.send_error = lambda code, *_: status.__setitem__("code", code)
+    return handler, status
+
+
+def _inbound(message_id):
+    return {
+        "direction": "inbound",
+        "from_number": "+14155550123",
+        "to_number": "+14155201316",
+        "text": "hi there",
+        "message_id": message_id,
+    }
+
+
+class AckFirstIdempotencyTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
+        self.db = self.tmp.name
+        # eligibility is the first processing step after the ACK -> use it as the
+        # "did processing run?" probe. Return a non-eligible decision to keep the
+        # downstream path minimal.
+        self.assess = MagicMock(return_value={
+            "eligible": False,
+            "reason_code": "blocked_test",
+            "sensitive_filtered": False,
+            "notification_type": "inbound",
+        })
+        self.patchers = [
+            patch.object(ws, "verify_webhook_auth", lambda *a, **k: (True, "test")),
+            patch.object(ws, "handle_sms_webhook", lambda data: {"stored": True, "message": {}}),
+            patch.object(ws, "lookup_contact_enrichment", lambda n: {"contact_name": None, "status": "not_found"}),
+            patch.object(ws, "apply_payload_contact_fallback", lambda enr, data: enr),
+            patch.object(ws, "invalidate_pending_sms_drafts", lambda **k: None),
+            patch.object(ws, "send_to_telegram", lambda *a, **k: None),
+            patch.object(ws, "assess_inbound_sms_alert_eligibility", self.assess),
+            patch.object(ws, "_sms_dedupe_db_path", lambda: Path(self.db)),
+        ]
+        for p in self.patchers:
+            p.start()
+
+    def tearDown(self):
+        for p in self.patchers:
+            p.stop()
+        Path(self.db).unlink(missing_ok=True)
+
+    def test_new_message_acks_async_and_runs_processing(self):
+        handler, status = _build_handler(_inbound("msg-1"))
+        handler.handle_webhook()
+        self.assertEqual(status["code"], 200)
+        self.assertIn('"processing": "async"', handler.wfile.getvalue().decode())
+        self.assertEqual(self.assess.call_count, 1)  # processing ran
+
+    def test_duplicate_message_acks_without_reprocessing(self):
+        first, _ = _build_handler(_inbound("dup-1"))
+        first.handle_webhook()
+        self.assertEqual(self.assess.call_count, 1)
+
+        second, status = _build_handler(_inbound("dup-1"))
+        second.handle_webhook()
+        self.assertEqual(status["code"], 200)
+        self.assertIn('"processing": "duplicate"', second.wfile.getvalue().decode())
+        # processing must NOT run again for the duplicate -> still 1
+        self.assertEqual(self.assess.call_count, 1)
+
+    def test_distinct_messages_both_process(self):
+        for mid in ("a", "b"):
+            h, _ = _build_handler(_inbound(mid))
+            h.handle_webhook()
+        self.assertEqual(self.assess.call_count, 2)
+
+
+class ServerConfigTests(unittest.TestCase):
+    def test_uses_threading_http_server(self):
+        # ACK-first relies on per-request threads so post-ACK work never blocks.
+        from http.server import ThreadingHTTPServer
+        self.assertIs(ws.ThreadingHTTPServer, ThreadingHTTPServer)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_webhook_async.py
+++ b/tests/test_webhook_async.py
@@ -144,16 +144,17 @@ class AckFirstIdempotencyTests(unittest.TestCase):
         self.assertIn('"processing": "async"', handler.wfile.getvalue().decode())
         self.assertEqual(self.assess.call_count, 1)  # fail-open -> processing runs
 
-    def test_post_ack_exception_releases_claim_for_retry(self):
-        # A post-ACK failure must release the claim so a Dialpad retry recovers.
+    def test_post_ack_exception_keeps_claim_to_prevent_replay(self):
+        # Invariant: never replay user-visible output. A post-ACK failure (which
+        # may be AFTER a draft/hook/Telegram card already fired) must NOT release
+        # the claim, so a Dialpad retry is suppressed rather than re-emitting.
         handler, status = _build_handler(_inbound("pa-1"))
         with patch.object(ws, "assess_inbound_sms_alert_eligibility",
                           MagicMock(side_effect=RuntimeError("boom"))):
             handler.handle_webhook()  # must not raise; 200 already sent
         self.assertEqual(status["code"], 200)
         again = ws.claim_sms_webhook_event(ws.sms_dedupe_key(_inbound("pa-1")), db_path=self.db)
-        self.assertTrue(again["claimed"])
-        self.assertFalse(again["duplicate"])
+        self.assertTrue(again["duplicate"])  # claim kept -> retry suppressed (no replay)
 
 
 class ServerConfigTests(unittest.TestCase):

--- a/tests/test_webhook_async.py
+++ b/tests/test_webhook_async.py
@@ -157,6 +157,16 @@ class AckFirstIdempotencyTests(unittest.TestCase):
         self.assertTrue(again["duplicate"])  # claim kept -> retry suppressed (no replay)
 
 
+    def test_ack_write_failure_still_processes(self):
+        # If Dialpad disconnects mid-ACK, the write raises — the handler must still
+        # process (side effects once); Dialpad's retry hits the duplicate branch.
+        handler, _ = _build_handler(_inbound("ackfail-1"))
+        with patch.object(handler, "_ack_webhook_200",
+                          MagicMock(side_effect=BrokenPipeError("client gone"))):
+            handler.handle_webhook()  # must not raise
+        self.assertEqual(self.assess.call_count, 1)
+
+
 class ServerConfigTests(unittest.TestCase):
     def test_main_uses_threading_http_server(self):
         # ACK-first relies on per-request threads -> main() must instantiate


### PR DESCRIPTION
## What

PR2 of the Dialpad enrichment program (plan `docs/plans/2026-06-18-001-...`, units **U5 + U6**): the delivery-safety prerequisite for un-gating the rich draft modes (PR3).

- **ACK-first**: the inbound SMS webhook now sends Dialpad its 200 immediately after storage, then runs the slow side-effect processing (enrichment, up-to-24s draft generation, OpenClaw hooks, Telegram) afterward — extracted into `_process_inbound_post_ack`.
- **ThreadingHTTPServer**: each request on its own thread, so post-ACK work never blocks or delays other webhooks.
- **SMS idempotency**: `claim_sms_webhook_event(sms_dedupe_key(data))` is claimed **before storage**; a Dialpad retry ACKs 200 and short-circuits before any side effect re-fires. `sms_dedupe_key` synthesizes a key when `message_id` is absent.
- **DB concurrency**: `busy_timeout` (+ best-effort WAL) on every `sms_approvals.db`/`sms.db` writer so concurrent threads serialize instead of raising "database is locked".

## Why

Without this, un-gating the context-command lookups (PR3) would run up to 24s inline on the single-threaded server, blocking the webhook and triggering Dialpad retry storms (and duplicate drafts). This makes draft generation safe to run on every inbound.

## Scope

SMS inbound handler. Missed-call/voicemail handlers already dedupe and get the ThreadingHTTPServer + pragma benefits; their ACK-first restructure is a follow-up. No un-gating here (that's PR3) — behavior for the existing high-confidence path is unchanged except for being async.

## Review

Ran `ce-correctness-reviewer` + `ce-adversarial-reviewer`, three fix rounds:
- **r1**: DB `busy_timeout`/WAL pragmas; dedupe fallback key for id-less payloads.
- **r2**: hoist claim above storage (no storage double-fire on retry); extract post-ACK processing; strengthened tests.
- **r3**: re-review caught that a post-ACK *rollback* could **replay user-visible output** (duplicate operator cards / customer SMS) — removed it; on post-ACK failure the claim is **kept** (prefer a rare silent gap over any replay, per the never-replay invariant). Added missed-call dedupe pragmas. Made WAL best-effort after the concurrency test exposed claims failing open under WAL-set lock contention.

## Residual risks (documented, not blocking — for reviewer awareness)

- **Partial-processing gap**: a post-ACK exception leaves the message stored but possibly without an auto-draft (no retry, to avoid replay). Operator still sees the inbound via normal channels.
- **SIGKILL window**: a process kill between the ACK and post-ACK processing loses that message's auto-draft (claim held, no Dialpad retry). Rare; undocumented in runbook yet.
- **OpenClaw hook delivery has no idempotency key** — out of scope here; flagged for a future fix at the hook boundary.
- **`sms_dedupe_key` collision** only if a payload lacks `message_id` AND all timestamp fields AND has identical text — extremely rare.

## Tests

```
python3 -m unittest discover -s tests -p 'test_*.py'   # 246 tests, stable across repeated full-suite runs
```
New: `tests/test_sms_idempotency.py`, `tests/test_webhook_async.py`. Cover ACK-before-processing ordering, at-most-once under 12 concurrent threads (0/20 flaky after the WAL fix), fail-open still ACKs+processes, outbound ACKs once, storage-failure → 500 + claim released, post-ACK failure keeps the claim (no replay), dedupe fallback key.

## AI Assistance

Built and reviewed autonomously via the `/loop` runbook (ce-work + adversarial/correctness review rounds) with Claude Opus 4.8; human merge gate at CP1.

[size/exempt: 550 LOC, ~200 of which are tests; single-purpose delivery-safety change]
