### PR TITLE
feat(webhook): un-gate enrichment into draft lane + provenance (PR3, U7)

### DIFF
--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -2449,8 +2449,18 @@ def lookup_sales_calendar_context(normalized_event, crm_context=None, sender_enr
     }
 
 
+def _draft_greeting(normalized_event, sender_enrichment):
+    """Greeting for the un-gated contextual drafts. Suppress the matched name at
+    low confidence — a reused/shared/ported number can carry a stale Dialpad
+    contact name, so 'Hi Wrong,' is a leak. Mirrors the generic fallback, which
+    already drops names at low confidence."""
+    if (normalized_event.get("inbound_context") or {}).get("identityConfidence") == "low":
+        return "there"
+    return _context_greeting(sender_enrichment, normalized_event)
+
+
 def _crm_reply_message(normalized_event, sender_enrichment, crm_context):
-    greeting = _context_greeting(sender_enrichment, normalized_event)
+    greeting = _draft_greeting(normalized_event, sender_enrichment)
     confidence = (normalized_event.get("inbound_context") or {}).get("identityConfidence")
     company = str(crm_context.get("company") or "").strip()
     # Name the matched company in the CUSTOMER-facing text ONLY at high confidence.
@@ -2464,7 +2474,7 @@ def _crm_reply_message(normalized_event, sender_enrichment, crm_context):
 
 
 def _meeting_reply_message(normalized_event, sender_enrichment, _crm_context, _calendar_context):
-    greeting = _context_greeting(sender_enrichment, normalized_event)
+    greeting = _draft_greeting(normalized_event, sender_enrichment)
     body = str(normalized_event.get("text") or "").lower()
     if re.search(r"\blate\b|\bon my way\b", body):
         return f"Hi {greeting}, no worries, thanks for letting me know. See you shortly."
@@ -2923,8 +2933,13 @@ def _build_draft_provenance(normalized_event):
         parts.append(f"Calendar: {cal.get('summary')}")
     rich = normalized_event.get("rich_reply") or {}
     rich_basis = rich.get("basis") if isinstance(rich, dict) else None
-    if isinstance(rich, dict) and rich.get("usable") and rich_basis and rich_basis not in ("attio_crm", "calendar_meeting"):
-        parts.append("QMD knowledge")
+    if isinstance(rich, dict) and rich.get("usable"):
+        # Label the source accurately — only a shapescale_knowledge reply is QMD;
+        # recent_thread_link is a prior-SMS-history link resend, not QMD.
+        if rich_basis == "shapescale_knowledge":
+            parts.append("QMD knowledge")
+        elif rich_basis == "recent_thread_link":
+            parts.append("Prior-thread link")
     return " | ".join(parts) if parts else None
 
 

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -2451,8 +2451,14 @@ def lookup_sales_calendar_context(normalized_event, crm_context=None, sender_enr
 
 def _crm_reply_message(normalized_event, sender_enrichment, crm_context):
     greeting = _context_greeting(sender_enrichment, normalized_event)
+    confidence = (normalized_event.get("inbound_context") or {}).get("identityConfidence")
     company = str(crm_context.get("company") or "").strip()
-    if company:
+    # Name the matched company in the CUSTOMER-facing text ONLY at high confidence.
+    # A low/medium-confidence Attio phone-match may be wrong (reused/ported/shared
+    # number), and naming the wrong company to a customer is a PII leak. At lower
+    # confidence the operator still sees the Attio context via the draft's
+    # provenance line and can personalize manually before approving (U7 decision).
+    if company and confidence == "high":
         return f"Hi {greeting}, thanks for the update. I have your ShapeScale conversation with {company} here and will follow up shortly."
     return f"Hi {greeting}, thanks for the update. I have your ShapeScale conversation here and will follow up shortly."
 
@@ -2910,13 +2916,14 @@ def _build_draft_provenance(normalized_event):
     crm = normalized_event.get("crm_context") or {}
     if isinstance(crm, dict) and crm.get("usable"):
         bits = [crm.get("company"), f"stage: {crm.get('stage')}" if crm.get("stage") else None]
-        detail = " · ".join(b for b in bits if b)
+        detail = " · ".join(str(b) for b in bits if b)
         parts.append(f"Attio: {detail}" if detail else "Attio: matched")
     cal = normalized_event.get("calendar_context") or {}
     if isinstance(cal, dict) and cal.get("usable") and cal.get("summary"):
         parts.append(f"Calendar: {cal.get('summary')}")
     rich = normalized_event.get("rich_reply") or {}
-    if isinstance(rich, dict) and rich.get("usable") and rich.get("basis") not in ("attio_crm", "calendar_meeting"):
+    rich_basis = rich.get("basis") if isinstance(rich, dict) else None
+    if isinstance(rich, dict) and rich.get("usable") and rich_basis and rich_basis not in ("attio_crm", "calendar_meeting"):
         parts.append("QMD knowledge")
     return " | ".join(parts) if parts else None
 

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -2332,14 +2332,17 @@ def _context_greeting(sender_enrichment, normalized_event):
     return first_name or "there"
 
 
-def _high_confidence_sales_context_allowed(normalized_event):
-    if (normalized_event.get("event_type") or "sms") != "sms":
-        return False
-    inbound_context = normalized_event.get("inbound_context") or {}
-    return bool(
-        inbound_context.get("contextDraftAllowed")
-        and inbound_context.get("identityConfidence") == "high"
-    )
+def _sales_context_draft_allowed(normalized_event):
+    """Allow CRM/calendar enrichment for the operator-approval DRAFT lane on any
+    sales-line SMS, regardless of identity confidence (plan U7 un-gate).
+
+    Drafts are always operator-reviewed — there is no unattended auto-send (that is
+    S4, not yet built) — so enriching at medium/unknown confidence is safe: a wrong
+    Attio match is caught by the operator via the draft's provenance line. The Attio
+    adapter does its own phone lookup, so a high-confidence Dialpad identity is not
+    required. Sales-line/eligibility checks already ran upstream in
+    should_send_proactive_reply before any draft is built."""
+    return (normalized_event.get("event_type") or "sms") == "sms"
 
 
 def meeting_logistics_intent(text):
@@ -2370,7 +2373,7 @@ def _compact_context_scalar(value, limit=120):
 def lookup_sales_crm_context(normalized_event, sender_enrichment=None):
     """Return compact Attio/CRM context for high-confidence Sales SMS drafts."""
     sender_enrichment = sender_enrichment or {}
-    if not _high_confidence_sales_context_allowed(normalized_event):
+    if not _sales_context_draft_allowed(normalized_event):
         return {"usable": False, "status": "not_allowed"}
 
     query_parts = [
@@ -2410,7 +2413,7 @@ def lookup_sales_crm_context(normalized_event, sender_enrichment=None):
 def lookup_sales_calendar_context(normalized_event, crm_context=None, sender_enrichment=None):
     """Return compact calendar context for meeting-logistics Sales SMS drafts."""
     sender_enrichment = sender_enrichment or {}
-    if not _high_confidence_sales_context_allowed(normalized_event):
+    if not _sales_context_draft_allowed(normalized_event):
         return {"usable": False, "status": "not_allowed"}
     if not meeting_logistics_intent(normalized_event.get("text")):
         return {"usable": False, "status": "not_applicable"}
@@ -2469,7 +2472,7 @@ def _meeting_reply_message(normalized_event, sender_enrichment, _crm_context, _c
 def build_contextual_sales_sms_reply(normalized_event, sender_enrichment=None):
     """Build CRM-aware or meeting-aware Sales SMS drafts from compact context."""
     sender_enrichment = sender_enrichment or {}
-    if not _high_confidence_sales_context_allowed(normalized_event):
+    if not _sales_context_draft_allowed(normalized_event):
         return {"usable": False, "status": "not_allowed"}
 
     crm_context = normalized_event.get("crm_context")
@@ -2898,6 +2901,26 @@ def mark_opt_out_fail_closed(customer_number, *, reason="customer_opt_out", sour
         return False
 
 
+def _build_draft_provenance(normalized_event):
+    """Operator-facing provenance for the approval card: which enrichment sources
+    fired and what they matched. NEVER added to draft_text (customer-facing) — it
+    lets the operator sanity-check a medium/low-confidence Attio match before
+    approving, which is what makes the U7 un-gate safe."""
+    parts = []
+    crm = normalized_event.get("crm_context") or {}
+    if isinstance(crm, dict) and crm.get("usable"):
+        bits = [crm.get("company"), f"stage: {crm.get('stage')}" if crm.get("stage") else None]
+        detail = " · ".join(b for b in bits if b)
+        parts.append(f"Attio: {detail}" if detail else "Attio: matched")
+    cal = normalized_event.get("calendar_context") or {}
+    if isinstance(cal, dict) and cal.get("usable") and cal.get("summary"):
+        parts.append(f"Calendar: {cal.get('summary')}")
+    rich = normalized_event.get("rich_reply") or {}
+    if isinstance(rich, dict) and rich.get("usable") and rich.get("basis") not in ("attio_crm", "calendar_meeting"):
+        parts.append("QMD knowledge")
+    return " | ".join(parts) if parts else None
+
+
 def create_proactive_reply_draft(normalized_event, sender_enrichment=None, line_display=None):
     """Create an approval-gated proactive reply draft instead of sending SMS."""
     sender_number = normalized_event.get("recipient_number")
@@ -2996,6 +3019,7 @@ def create_proactive_reply_draft(normalized_event, sender_enrichment=None, line_
                     "rich_reply": normalized_event.get("rich_reply"),
                     "crm_context": normalized_event.get("crm_context"),
                     "calendar_context": normalized_event.get("calendar_context"),
+                    "provenance": _build_draft_provenance(normalized_event),
                 },
             )
         finally:
@@ -3602,6 +3626,9 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                     auto_reply_status=auto_reply_status,
                     auto_reply_draft_created=auto_reply_draft_created,
                 )
+                provenance = _build_draft_provenance(normalized_sms)
+                if provenance:
+                    tg_text += f"\n↳ {escape_telegram_markdown(provenance)}"
                 tg_text += build_approval_review_suffix(
                     auto_reply_draft_id,
                     auto_reply_message,

--- a/tests/test_ungate_provenance.py
+++ b/tests/test_ungate_provenance.py
@@ -1,0 +1,82 @@
+"""Tests for the U7 un-gate + provenance (PR3).
+
+The CRM/calendar enrichment now runs in the operator-approval draft lane at any
+identity confidence (auto-send does not exist, so this is safe), and each draft
+carries an operator-facing provenance line — never in the customer-facing text.
+"""
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import webhook_server as ws  # noqa: E402
+
+
+class GateRelaxationTests(unittest.TestCase):
+    def test_allows_sms_at_any_confidence(self):
+        for conf in ("low", "medium", "high", None):
+            ev = {"event_type": "sms", "inbound_context": {"identityConfidence": conf}}
+            self.assertTrue(ws._sales_context_draft_allowed(ev), conf)
+
+    def test_allows_sms_with_no_inbound_context(self):
+        self.assertTrue(ws._sales_context_draft_allowed({"event_type": "sms"}))
+        self.assertTrue(ws._sales_context_draft_allowed({}))  # defaults to sms
+
+    def test_rejects_non_sms(self):
+        self.assertFalse(ws._sales_context_draft_allowed({"event_type": "missed_call"}))
+
+
+class UngatedLookupTests(unittest.TestCase):
+    def test_crm_lookup_runs_at_low_confidence(self):
+        # Before U7 this returned {"usable": False, "status": "not_allowed"}.
+        event = {
+            "event_type": "sms",
+            "sender_number": "+14155550123",
+            "inbound_context": {"identityConfidence": "low"},
+        }
+        crm_payload = {"usable": True, "basis": "attio", "summary": "Acme Corp Demo Booked",
+                       "company": "Acme Corp", "stage": "Demo Booked", "deal": "Acme", "owner": None}
+        with patch.object(ws, "_run_context_command", return_value=crm_payload):
+            ctx = ws.lookup_sales_crm_context(event, sender_enrichment={"contact_name": "Jane", "company": "Acme"})
+        self.assertTrue(ctx["usable"])
+        self.assertEqual(ctx["company"], "Acme Corp")
+
+
+class ProvenanceTests(unittest.TestCase):
+    def test_attio_provenance(self):
+        ev = {"crm_context": {"usable": True, "company": "Acme Corp", "stage": "Demo Booked"}}
+        self.assertEqual(ws._build_draft_provenance(ev), "Attio: Acme Corp · stage: Demo Booked")
+
+    def test_attio_matched_without_detail(self):
+        ev = {"crm_context": {"usable": True}}
+        self.assertEqual(ws._build_draft_provenance(ev), "Attio: matched")
+
+    def test_qmd_provenance(self):
+        ev = {"rich_reply": {"usable": True, "basis": "knowledge_backed"}}
+        self.assertEqual(ws._build_draft_provenance(ev), "QMD knowledge")
+
+    def test_calendar_and_combined(self):
+        ev = {
+            "crm_context": {"usable": True, "company": "Acme"},
+            "calendar_context": {"usable": True, "summary": "Upcoming demo: Acme"},
+        }
+        prov = ws._build_draft_provenance(ev)
+        self.assertIn("Attio: Acme", prov)
+        self.assertIn("Calendar: Upcoming demo: Acme", prov)
+
+    def test_none_when_nothing_usable(self):
+        self.assertIsNone(ws._build_draft_provenance({}))
+        self.assertIsNone(ws._build_draft_provenance({"crm_context": {"usable": False}}))
+
+    def test_crm_aware_rich_reply_not_double_counted_as_qmd(self):
+        # an attio_crm/calendar rich_reply is already reflected by crm/calendar
+        # context; it must not also show as "QMD knowledge".
+        ev = {"rich_reply": {"usable": True, "basis": "attio_crm"}}
+        self.assertIsNone(ws._build_draft_provenance(ev))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ungate_provenance.py
+++ b/tests/test_ungate_provenance.py
@@ -55,8 +55,13 @@ class ProvenanceTests(unittest.TestCase):
         self.assertEqual(ws._build_draft_provenance(ev), "Attio: matched")
 
     def test_qmd_provenance(self):
-        ev = {"rich_reply": {"usable": True, "basis": "knowledge_backed"}}
+        ev = {"rich_reply": {"usable": True, "basis": "shapescale_knowledge"}}
         self.assertEqual(ws._build_draft_provenance(ev), "QMD knowledge")
+
+    def test_recent_thread_link_not_labeled_qmd(self):
+        # link-resend from prior SMS history must not claim a QMD source
+        ev = {"rich_reply": {"usable": True, "basis": "recent_thread_link"}}
+        self.assertEqual(ws._build_draft_provenance(ev), "Prior-thread link")
 
     def test_calendar_and_combined(self):
         ev = {
@@ -101,6 +106,23 @@ class CustomerTextSafetyTests(unittest.TestCase):
     def test_low_confidence_draft_is_safe_generic_crm_line(self):
         msg = self._msg("low")
         self.assertIn("ShapeScale conversation here", msg)  # company-free
+
+    def test_greeting_suppresses_name_at_low_confidence(self):
+        crm = {"usable": True, "company": "Acme"}
+        low = ws._crm_reply_message({"inbound_context": {"identityConfidence": "low"}},
+                                    {"first_name": "Wrong"}, crm)
+        self.assertIn("Hi there,", low)
+        self.assertNotIn("Wrong", low)
+        # medium/high keep the (known-contact) name
+        med = ws._crm_reply_message({"inbound_context": {"identityConfidence": "medium"}},
+                                    {"first_name": "Jane"}, crm)
+        self.assertIn("Jane", med)
+
+    def test_meeting_greeting_suppresses_name_at_low_confidence(self):
+        ev = {"inbound_context": {"identityConfidence": "low"}, "text": "running late"}
+        msg = ws._meeting_reply_message(ev, {"first_name": "Wrong"}, {}, {})
+        self.assertIn("Hi there,", msg)
+        self.assertNotIn("Wrong", msg)
 
 
 class CalendarUngateTests(unittest.TestCase):

--- a/tests/test_ungate_provenance.py
+++ b/tests/test_ungate_provenance.py
@@ -78,5 +78,66 @@ class ProvenanceTests(unittest.TestCase):
         self.assertIsNone(ws._build_draft_provenance(ev))
 
 
+class CustomerTextSafetyTests(unittest.TestCase):
+    CRM = {"usable": True, "company": "Acme Corp", "stage": "Demo Booked"}
+
+    def _msg(self, confidence):
+        ev = {"inbound_context": {"identityConfidence": confidence}}
+        return ws._crm_reply_message(ev, {}, self.CRM)
+
+    def test_company_named_only_at_high_confidence(self):
+        self.assertIn("Acme Corp", self._msg("high"))
+        self.assertNotIn("Acme Corp", self._msg("medium"))
+        self.assertNotIn("Acme Corp", self._msg("low"))
+        self.assertNotIn("Acme Corp", self._msg(None))
+
+    def test_customer_text_never_contains_provenance_tokens(self):
+        # the operator-facing provenance tokens must never reach customer-facing text
+        for conf in ("high", "medium", "low"):
+            msg = self._msg(conf)
+            for tok in ("Attio:", "stage:", "QMD", "Calendar:", "↳"):
+                self.assertNotIn(tok, msg, f"{tok} leaked at {conf}")
+
+    def test_low_confidence_draft_is_safe_generic_crm_line(self):
+        msg = self._msg("low")
+        self.assertIn("ShapeScale conversation here", msg)  # company-free
+
+
+class CalendarUngateTests(unittest.TestCase):
+    def test_calendar_lookup_runs_at_low_confidence(self):
+        event = {"event_type": "sms", "sender_number": "+14155550123", "text": "running late",
+                 "inbound_context": {"identityConfidence": "low"}}
+        cal_payload = {"usable": True, "basis": "attio", "summary": "Upcoming demo: Acme", "startsInMinutes": 30}
+        with patch.object(ws, "_run_context_command", return_value=cal_payload):
+            ctx = ws.lookup_sales_calendar_context(
+                event, crm_context={"company": "Acme"}, sender_enrichment={"contact_name": "Jane"})
+        self.assertTrue(ctx["usable"])
+
+
+class ProvenanceRobustnessTests(unittest.TestCase):
+    def test_non_string_company_does_not_raise(self):
+        prov = ws._build_draft_provenance({"crm_context": {"usable": True, "company": 12345, "stage": 99}})
+        self.assertIn("12345", prov)
+
+    def test_basisless_rich_reply_not_labeled_qmd(self):
+        self.assertIsNone(ws._build_draft_provenance({"rich_reply": {"usable": True}}))
+
+
+class NoUnattendedSendInvariantTests(unittest.TestCase):
+    def test_send_proactive_reply_has_no_callers(self):
+        # U7's safety basis: enrichment feeds operator-approval DRAFTS only; there is
+        # no unattended auto-send. If a real caller of send_proactive_reply appears
+        # (e.g. S4) without re-gating the customer-facing enrichment, fail loudly.
+        import inspect
+        src = inspect.getsource(ws)
+        callers = [
+            line.strip() for line in src.splitlines()
+            if "send_proactive_reply(" in line
+            and "should_send_proactive_reply(" not in line
+            and not line.lstrip().startswith("def send_proactive_reply(")
+        ]
+        self.assertEqual(callers, [], f"send_proactive_reply gained a caller; re-gate U7 first: {callers}")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

PR3 / **U7**: un-gate the CRM/QMD/calendar enrichment so it runs for **every** sales-line SMS draft, not just high-confidence known contacts — the change that makes the Attio/QMD/calendar context (built in S1, made safe to run in PR2) actually reach the operator. Plus an operator-facing **provenance** line on every enriched draft.

- Gate `_high_confidence_sales_context_allowed` → `_sales_context_draft_allowed` (any sales-line SMS), used by the CRM/calendar lookups + contextual reply builder.
- `_build_draft_provenance`: which sources fired (Attio company/stage, calendar, QMD) → draft metadata + the Telegram approval card. **Never** in `draft_text`.

## Safety basis (verified by adversarial review)

There is **no unattended auto-send** — `send_proactive_reply` has zero callers; every inbound auto-reply is an operator-approval draft. So enriching at medium/unknown confidence just produces richer drafts the operator still reviews. A `NoUnattendedSendInvariantTests` test fails if `send_proactive_reply` ever gains a caller (so a future S4 can't silently make this dangerous).

## Customer-PII decision (CP4 — operator-only at low confidence)

Adversarial review caught that a wrong Attio phone-match (reused/ported/shared number) at low confidence would name **another customer's company** in the customer-facing draft text. Per the maintainer's decision: `_crm_reply_message` now names the matched company **only at high confidence**; at lower confidence the customer draft stays generic, while the operator still sees the full Attio context via the provenance line and can personalize manually. No wrong-company can reach a customer automatically.

## Review

`ce-correctness-reviewer` + `ce-adversarial-reviewer`: verified no-auto-send + no provenance leak; the HIGH customer-PII finding is resolved by the CP4 decision above; provenance robustness (non-string scalars, basis-less rich_reply) fixed.

## Residual (documented, follow-up)

- The relaxed gate runs an Attio lookup on every inbound SMS draft (was: only high-confidence). PR2 made draft-gen post-ACK so this never blocks the webhook ACK; at ~5–10/day it's negligible, but a per-phone short-cache would harden against a burst. Deferred.

## Tests

```
python3 -m unittest discover -s tests -p 'test_*.py'   # 265 tests
```
New `tests/test_ungate_provenance.py` (17): gate allows any-confidence SMS, CRM/calendar lookups run at low confidence, company named only at high confidence, no provenance tokens in customer text, malformed-provenance robustness, no-unattended-send invariant.

## AI Assistance

Built + reviewed via the `/loop` runbook with Claude Opus 4.8; the customer-PII risk was surfaced as a CP4 decision to the maintainer. Human merge gate at CP1.

[size/exempt: ~50 LOC code + ~150 tests; single-purpose un-gate]
