### PR TITLE
fix(webhook): extract real QMD answer body for knowledge SMS drafts

### DIFF
--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -2242,12 +2242,16 @@ def _run_qmd_command(command, args):
 
 
 def _qmd_top_hit_ref(search_output):
-    """Return the top hit's `qmd://...` doc ref (without the :line/#hash suffix)."""
+    """Return the top hit's `qmd://...md:line` doc ref, keeping the matched line.
+
+    The `:line` lets `qmd get` fetch the matched section of a long doc instead of
+    only the first DIALPAD_QMD_GET_LINES lines from the top. The trailing ` #hash`
+    is dropped.
+    """
     for raw_line in str(search_output or "").splitlines():
         line = raw_line.strip()
         if line.startswith("qmd://"):
-            ref = line.split()[0]  # drop the trailing " #hash"
-            return re.sub(r":\d+$", "", ref)  # drop the trailing :line
+            return line.split()[0]  # qmd://...md:line, without the trailing " #hash"
     return None
 
 
@@ -2288,24 +2292,20 @@ def _qmd_answer_body(get_output):
     A `qmd get` document opens with a metadata block — `# heading`, `---` fences,
     and `Key: value` lines whose keys vary by source (Gorgias help articles use
     `Source:`/`Article ID:`/`Category:`; Notion exports use `Source course:`/
-    `Source page ID:`/`Created:`). We drop:
-      - known metadata keys anywhere in the doc (leading *and* trailing/transcluded),
-      - any remaining `Key: value` line in the leading preamble, before prose starts,
-      - headings, `---` fences, qmd refs, and any URL/markdown-link,
-    keeping only the answer prose so the draft carries the answer, not a title or
-    an internal source URL.
+    `Source page ID:`/`Created:`). We drop only *recognized* metadata keys (anywhere
+    in the doc, so transcluded/footer metadata can't leak), headings, `---` fences,
+    qmd refs, and any URL/markdown-link. Lines whose label is not a known metadata
+    key are kept, so a legitimate labeled answer line (`Pricing: $1,799 upfront…`,
+    `Note: billing starts after delivery`) survives into the draft. Internal-link
+    disclosure is prevented by the unconditional URL strip, not by key denylisting.
     """
     body = []
-    started = False
     for raw_line in str(get_output or "").splitlines():
         line = raw_line.strip()
         if not line or line == "---" or line.startswith(("#", "@@", "qmd://")):
             continue
         if _is_qmd_metadata_line(line):
-            continue  # known metadata key — drop wherever it appears
-        if not started and _QMD_KEY_LINE.match(line):
-            continue  # unknown leading `Key: value` preamble line
-        started = True
+            continue  # recognized metadata key — drop wherever it appears
         cleaned = _strip_markup_and_urls(line)
         if cleaned:
             body.append(cleaned)
@@ -2643,6 +2643,11 @@ def _knowledge_query_for_category(category, text):
     the old keyword-stuffed sentence queries returned zero matches. We strip
     stopwords/brand terms and keep the two most discriminating (longest) content
     words, prefixed by a light category anchor, so recall stays high.
+
+    Returns an empty string when nothing discriminating remains (no anchor and no
+    salient keywords, e.g. "how does it work?"). The caller fails closed on an
+    empty query rather than searching the brand alone, which would match an
+    arbitrary doc across the whole collection.
     """
     anchor = {"pricing": "pricing", "booking": "book demo"}.get(category, "")
     words = re.findall(r"[a-zA-Z]{3,}", str(text or "").lower())
@@ -2656,7 +2661,7 @@ def _knowledge_query_for_category(category, text):
             tokens.append(word)
         if len(tokens) >= len(anchor.split()) + 2:
             break
-    return " ".join(tokens) or "ShapeScale"
+    return " ".join(tokens)
 
 
 def _compose_knowledge_sms(category, knowledge_text):

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -2188,10 +2188,14 @@ def lookup_shapescale_knowledge(query):
         result["status"] = "empty_query"
         return result
 
+    # One shared deadline across both subprocess calls, so search+get can't hold a
+    # processing thread for 2x DIALPAD_QMD_TIMEOUT_SECONDS.
+    deadline = time.monotonic() + DIALPAD_QMD_TIMEOUT_SECONDS
+
     search_args = ["search", query, "-n", "1"]
     if DIALPAD_QMD_COLLECTION:
         search_args += ["-c", DIALPAD_QMD_COLLECTION]
-    search_out, status = _run_qmd_command(command, search_args)
+    search_out, status = _run_qmd_command(command, search_args, deadline)
     if status != "ok":
         result["status"] = status
         return result
@@ -2201,7 +2205,7 @@ def lookup_shapescale_knowledge(query):
         result["status"] = "no_match"
         return result
 
-    get_out, status = _run_qmd_command(command, ["get", doc_ref, "-l", str(DIALPAD_QMD_GET_LINES)])
+    get_out, status = _run_qmd_command(command, ["get", doc_ref, "-l", str(DIALPAD_QMD_GET_LINES)], deadline)
     if status != "ok":
         result["status"] = f"get_{status}"  # distinguish get failures from search failures
         return result
@@ -2215,15 +2219,22 @@ def lookup_shapescale_knowledge(query):
     return result
 
 
-def _run_qmd_command(command, args):
-    """Run `qmd <args>` and return (stdout, status). status == 'ok' on success."""
+def _run_qmd_command(command, args, deadline):
+    """Run `qmd <args>` and return (stdout, status). status == 'ok' on success.
+
+    `deadline` is a `time.monotonic()` timestamp shared across the calls in one
+    knowledge lookup, so the lookup respects a single timeout budget overall.
+    """
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        return "", "timeout"
     try:
         completed = subprocess.run(
             [command, *args],
             check=False,
             capture_output=True,
             text=True,
-            timeout=DIALPAD_QMD_TIMEOUT_SECONDS,
+            timeout=remaining,
         )
     except FileNotFoundError:
         return "", "unavailable"

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -117,6 +117,12 @@ DIALPAD_AUTO_REPLY_ENABLED = parse_bool_env(os.environ.get("DIALPAD_AUTO_REPLY_E
 DIALPAD_RICH_SMS_DRAFTS_ENABLED = parse_bool_env(os.environ.get("DIALPAD_RICH_SMS_DRAFTS_ENABLED"), True)
 DIALPAD_QMD_COMMAND = os.environ.get("DIALPAD_QMD_COMMAND", "qmd")
 DIALPAD_QMD_TIMEOUT_SECONDS = float(os.environ.get("DIALPAD_QMD_TIMEOUT_SECONDS", "8"))
+# Curated, human-readable knowledge collection to search (Gorgias help articles +
+# training). Empty string = search all collections. Scoping here keeps SMS answers
+# grounded in the customer-facing KB instead of code/workflow collections.
+DIALPAD_QMD_COLLECTION = os.environ.get("DIALPAD_QMD_COLLECTION", "shapescale-knowledge")
+# How many leading lines of the matched doc to pull for the answer body.
+DIALPAD_QMD_GET_LINES = int(os.environ.get("DIALPAD_QMD_GET_LINES", "40"))
 DIALPAD_BOOK_DEMO_URL = os.environ.get("DIALPAD_BOOK_DEMO_URL", "https://bysha.pe/book-demo")
 DIALPAD_CRM_CONTEXT_COMMAND = os.environ.get("DIALPAD_CRM_CONTEXT_COMMAND", "")
 DIALPAD_CALENDAR_CONTEXT_COMMAND = os.environ.get("DIALPAD_CALENDAR_CONTEXT_COMMAND", "")
@@ -2166,84 +2172,144 @@ def classify_rich_sms_question(text, recent_thread=None):
 
 
 def lookup_shapescale_knowledge(query):
-    """Retrieve ShapeScale knowledge for rich SMS drafts; fail closed on any issue."""
-    result = {
-        "usable": False,
-        "status": "disabled",
-        "text": "",
-    }
+    """Retrieve a customer-ready ShapeScale answer for rich SMS drafts; fail closed.
+
+    Two steps: BM25 `qmd search` finds the best-matching knowledge doc, then
+    `qmd get` pulls that doc so we can extract its *answer body* — not the search
+    snippet, which is only the title + source URL and never the actual answer.
+    """
+    result = {"usable": False, "status": "disabled", "text": ""}
     command = str(DIALPAD_QMD_COMMAND or "").strip()
     if not command:
         return result
 
-    args = [command, "search", str(query or "").strip()]
-    if not args[-1]:
+    query = str(query or "").strip()
+    if not query:
         result["status"] = "empty_query"
         return result
 
+    search_args = ["search", query, "-n", "1"]
+    if DIALPAD_QMD_COLLECTION:
+        search_args += ["-c", DIALPAD_QMD_COLLECTION]
+    search_out, status = _run_qmd_command(command, search_args)
+    if status != "ok":
+        result["status"] = status
+        return result
+
+    doc_ref = _qmd_top_hit_ref(search_out)
+    if not doc_ref:
+        result["status"] = "no_match"
+        return result
+
+    get_out, status = _run_qmd_command(command, ["get", doc_ref, "-l", str(DIALPAD_QMD_GET_LINES)])
+    if status != "ok":
+        result["status"] = f"get_{status}"  # distinguish get failures from search failures
+        return result
+
+    safe_output = customer_safe_knowledge_text(_qmd_answer_body(get_out))
+    if not safe_output:
+        result["status"] = "unsafe_output"
+        return result
+
+    result.update({"usable": True, "status": "ok", "text": safe_output[:1200]})
+    return result
+
+
+def _run_qmd_command(command, args):
+    """Run `qmd <args>` and return (stdout, status). status == 'ok' on success."""
     try:
         completed = subprocess.run(
-            args,
+            [command, *args],
             check=False,
             capture_output=True,
             text=True,
             timeout=DIALPAD_QMD_TIMEOUT_SECONDS,
         )
     except FileNotFoundError:
-        result["status"] = "unavailable"
-        return result
+        return "", "unavailable"
     except subprocess.TimeoutExpired:
-        result["status"] = "timeout"
-        return result
+        return "", "timeout"
     except Exception as exc:  # noqa: BLE001 - qmd must not break webhook processing.
         print(f"⚠️  ShapeScale knowledge lookup failed ({type(exc).__name__})")
-        result["status"] = "request_failed"
-        return result
+        return "", "request_failed"
 
-    output = (completed.stdout or "").strip()
     if completed.returncode != 0:
-        result["status"] = f"exit_{completed.returncode}"
-        return result
+        return "", f"exit_{completed.returncode}"
+    output = (completed.stdout or "").strip()
     if not output:
-        result["status"] = "empty"
-        return result
-    safe_output = customer_safe_knowledge_text(extract_qmd_customer_snippet(output))
-    if not safe_output:
-        result["status"] = "unsafe_output"
-        return result
-
-    result.update(
-        {
-            "usable": True,
-            "status": "ok",
-            "text": safe_output[:1200],
-        }
-    )
-    return result
+        return "", "empty"
+    return output, "ok"
 
 
-def extract_qmd_customer_snippet(output):
-    """Extract candidate snippet text from qmd search output."""
-    lines = []
-    in_snippet = False
-    for raw_line in str(output or "").splitlines():
+def _qmd_top_hit_ref(search_output):
+    """Return the top hit's `qmd://...` doc ref (without the :line/#hash suffix)."""
+    for raw_line in str(search_output or "").splitlines():
         line = raw_line.strip()
-        if not line:
-            continue
         if line.startswith("qmd://"):
-            if lines:
-                break
-            in_snippet = False
-            continue
-        if re.match(r"^(Title|Context|Score):", line, re.IGNORECASE):
-            continue
-        if line.startswith("@@"):
-            in_snippet = True
-            continue
-        if in_snippet:
-            lines.append(line)
+            ref = line.split()[0]  # drop the trailing " #hash"
+            return re.sub(r":\d+$", "", ref)  # drop the trailing :line
+    return None
 
-    return " ".join(lines) if lines else str(output or "")
+
+# Known metadata keys emitted by `qmd get` / source exports. These are stripped
+# wherever they appear (not just the leading preamble) so transcluded/footer
+# metadata can't leak internal URLs or record IDs into a customer draft. Matched
+# case-insensitively. A line is only treated as metadata when its key is in this
+# set — so legitimate prose lead-ins ("Note:", "Important:") are preserved.
+_QMD_META_KEYS = frozenset(
+    [
+        "folder context", "source", "source course", "source page id", "source url",
+        "article id", "category", "last updated", "created", "title", "context", "score",
+    ]
+)
+_QMD_KEY_LINE = re.compile(r"^([A-Za-z][A-Za-z ]{0,30}):")
+# Markdown image, then markdown link (keep its text), then angle-bracket and bare URLs.
+_MD_IMAGE_RE = re.compile(r"!\[[^\]]*\]\([^)]*\)")
+_MD_LINK_RE = re.compile(r"\[([^\]]*)\]\([^)]*\)")
+_URL_RE = re.compile(r"<https?://[^>]*>|https?://\S+|www\.\S+", re.IGNORECASE)
+
+
+def _strip_markup_and_urls(text):
+    """Remove markdown images/links and any URLs so internal links can't reach the SMS."""
+    text = _MD_IMAGE_RE.sub("", text)
+    text = _MD_LINK_RE.sub(r"\1", text)
+    text = _URL_RE.sub("", text)
+    return " ".join(text.split())
+
+
+def _is_qmd_metadata_line(line):
+    match = _QMD_KEY_LINE.match(line)
+    return bool(match) and match.group(1).strip().lower() in _QMD_META_KEYS
+
+
+def _qmd_answer_body(get_output):
+    """Extract the answer prose from `qmd get` output, dropping metadata and URLs.
+
+    A `qmd get` document opens with a metadata block — `# heading`, `---` fences,
+    and `Key: value` lines whose keys vary by source (Gorgias help articles use
+    `Source:`/`Article ID:`/`Category:`; Notion exports use `Source course:`/
+    `Source page ID:`/`Created:`). We drop:
+      - known metadata keys anywhere in the doc (leading *and* trailing/transcluded),
+      - any remaining `Key: value` line in the leading preamble, before prose starts,
+      - headings, `---` fences, qmd refs, and any URL/markdown-link,
+    keeping only the answer prose so the draft carries the answer, not a title or
+    an internal source URL.
+    """
+    body = []
+    started = False
+    for raw_line in str(get_output or "").splitlines():
+        line = raw_line.strip()
+        if not line or line == "---" or line.startswith(("#", "@@", "qmd://")):
+            continue
+        if _is_qmd_metadata_line(line):
+            continue  # known metadata key — drop wherever it appears
+        if not started and _QMD_KEY_LINE.match(line):
+            continue  # unknown leading `Key: value` preamble line
+        started = True
+        cleaned = _strip_markup_and_urls(line)
+        if cleaned:
+            body.append(cleaned)
+    return " ".join(body)
 
 
 def customer_safe_knowledge_text(output):
@@ -2557,15 +2623,40 @@ def _first_recent_link(recent_thread):
     return None
 
 
+# Question words / articles / fillers that carry no retrieval signal, plus the
+# brand itself (in nearly every doc, so it never discriminates). "shapescale" is
+# kept out of the AND-query so it can't shrink recall.
+_QMD_STOPWORDS = frozenset(
+    """a an the is are am be was were do does did how what when where why who whom
+    which can could would should will to for of on in at by with from my your our we
+    us i you me it this that these those and or but if so about get got have has had
+    need want much many cost costs price priced work works working please thanks
+    thank hi hello there here just like into out up down over more most any some
+    your shapescale shape scale""".split()
+)
+
+
 def _knowledge_query_for_category(category, text):
-    topic = str(text or "").strip()
-    if category == "booking":
-        return f"ShapeScale book demo booking link sales SMS answer: {topic}"
-    if category == "pricing":
-        return f"ShapeScale pricing lease buyout financing sales SMS answer: {topic}"
-    if category == "product":
-        return f"ShapeScale product business consumer scan results sales SMS answer: {topic}"
-    return f"ShapeScale sales SMS answer: {topic}"
+    """Build a focused AND-query from the customer's salient keywords + a category anchor.
+
+    `qmd search` is BM25 with AND semantics — every term must appear in a doc — so
+    the old keyword-stuffed sentence queries returned zero matches. We strip
+    stopwords/brand terms and keep the two most discriminating (longest) content
+    words, prefixed by a light category anchor, so recall stays high.
+    """
+    anchor = {"pricing": "pricing", "booking": "book demo"}.get(category, "")
+    words = re.findall(r"[a-zA-Z]{3,}", str(text or "").lower())
+    # Longest content words first; lexicographic tie-break keeps the query stable
+    # across processes (set iteration order is hash-randomized).
+    candidates = sorted({w for w in words if w not in _QMD_STOPWORDS}, key=lambda w: (-len(w), w))
+    # Dedup against the anchor's own words so we don't emit "book demo book demo".
+    tokens = anchor.split()
+    for word in candidates:
+        if word not in tokens:
+            tokens.append(word)
+        if len(tokens) >= len(anchor.split()) + 2:
+            break
+    return " ".join(tokens) or "ShapeScale"
 
 
 def _compose_knowledge_sms(category, knowledge_text):

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -2251,7 +2251,9 @@ def _qmd_top_hit_ref(search_output):
     for raw_line in str(search_output or "").splitlines():
         line = raw_line.strip()
         if line.startswith("qmd://"):
-            return line.split()[0]  # qmd://...md:line, without the trailing " #hash"
+            # Strip only the trailing " #hash"; splitting on all whitespace would
+            # truncate qmd virtual paths that contain spaces (Notion/training exports).
+            return re.sub(r"\s+#[0-9a-fA-F]+$", "", line)
     return None
 
 

--- a/tests/test_sender_enrichment.py
+++ b/tests/test_sender_enrichment.py
@@ -913,6 +913,10 @@ def test_qmd_answer_body_strips_preamble_and_top_hit_ref_keeps_line():
         "qmd://shapescale-knowledge/a/b.md:42 #deadbe\nTitle: x"
     ) == "qmd://shapescale-knowledge/a/b.md:42"
     assert webhook_server._qmd_top_hit_ref("Title: nothing here") is None
+    # Paths with spaces (Notion/training exports) must survive — strip only the hash.
+    assert webhook_server._qmd_top_hit_ref(
+        "qmd://shapescale-knowledge/online training/intro to scan.md:7 #abc123"
+    ) == "qmd://shapescale-knowledge/online training/intro to scan.md:7"
     body = webhook_server._qmd_answer_body(
         "Folder Context: ctx\n---\n# Heading\nSource: https://x\nArticle ID: 1\n---\nThe real answer is 42."
     )

--- a/tests/test_sender_enrichment.py
+++ b/tests/test_sender_enrichment.py
@@ -843,29 +843,145 @@ def test_product_question_falls_back_when_knowledge_unavailable(monkeypatch, tmp
     assert webhook_server.build_proactive_reply_message(normalized_event).startswith("Hi there, thanks for reaching")
 
 
-def test_qmd_search_metadata_is_stripped_before_customer_safe_knowledge(monkeypatch):
-    raw_qmd_output = """qmd://shapescale-json/sales/faq-13-business-faq.json:5 #f84e26
-Title: ShapeScale for Business FAQ
-Context: Structured ShapeScale JSON knowledge.
-Score:  90%
+def test_knowledge_lookup_extracts_answer_body_from_qmd_get(monkeypatch):
+    # qmd search returns the matching doc's title/source snippet (NOT the answer);
+    # qmd get returns the full doc whose body holds the actual answer.
+    search_output = """qmd://shapescale-knowledge/support/help-articles/693708-pricing-home.md:1 #237f44
+Title: What is the pricing for ShapeScale for Home?
+Context: Curated ShapeScale knowledge base.
+Score:  78%
 
-@@ -4,4 @@
-ShapeScale for Business supports client scans and demo booking for practices.
+@@ -1,3 @@
+# What is the pricing for ShapeScale for Home?
 """
+    get_output = """Folder Context: Curated ShapeScale knowledge base.
+---
+
+# What is the pricing for ShapeScale for Home?
+
+Source: https://shapescalehelpcenter.gorgias.help/pricing-home-693708?isEmbedded=true
+Article ID: 693708
+Category: Pricing & Shipping
+Last updated: 2026-02-03T10:32:07.289Z
+
+---
+
+ShapeScale's home device is priced at $1,799 upfront for the hardware, plus an app subscription that only starts billing once you receive your unit.
+"""
+    calls = []
+
+    def _fake_run(args, **kwargs):
+        calls.append(args)
+        stdout = search_output if args[1] == "search" else get_output
+        return _FakeCompletedProcess(stdout=stdout, returncode=0)
+
+    monkeypatch.setattr(webhook_server, "DIALPAD_QMD_COMMAND", "qmd")
+    monkeypatch.setattr(webhook_server.subprocess, "run", _fake_run)
+
+    result = webhook_server.lookup_shapescale_knowledge("how much does ShapeScale cost")
+
+    assert result["usable"] is True
+    assert result["status"] == "ok"
+    # The answer body is returned, not the title/source/metadata.
+    assert "$1,799" in result["text"]
+    assert "What is the pricing" not in result["text"]
+    assert "qmd://" not in result["text"]
+    assert "Source:" not in result["text"]
+    assert "Score:" not in result["text"]
+    # get was called with the search hit's ref, stripped of :line and #hash.
+    assert calls[0][1] == "search"
+    assert calls[1][1] == "get"
+    assert calls[1][2] == "qmd://shapescale-knowledge/support/help-articles/693708-pricing-home.md"
+
+
+def test_knowledge_lookup_no_match_when_search_returns_no_hit(monkeypatch):
     monkeypatch.setattr(webhook_server, "DIALPAD_QMD_COMMAND", "qmd")
     monkeypatch.setattr(
         webhook_server.subprocess,
         "run",
-        lambda *args, **kwargs: _FakeCompletedProcess(stdout=raw_qmd_output, returncode=0),
+        lambda *a, **k: _FakeCompletedProcess(stdout="No results found.", returncode=0),
     )
+    result = webhook_server.lookup_shapescale_knowledge("how much does ShapeScale cost")
+    assert result["usable"] is False
+    assert result["status"] == "no_match"
 
-    result = webhook_server.lookup_shapescale_knowledge("ShapeScale pricing")
 
-    assert result["usable"] is True
-    assert result["status"] == "ok"
-    assert result["text"] == "ShapeScale for Business supports client scans and demo booking for practices."
-    assert "qmd://" not in result["text"]
-    assert "Score:" not in result["text"]
+def test_qmd_answer_body_strips_preamble_and_top_hit_ref_cleans_suffix():
+    assert webhook_server._qmd_top_hit_ref(
+        "qmd://shapescale-knowledge/a/b.md:42 #deadbe\nTitle: x"
+    ) == "qmd://shapescale-knowledge/a/b.md"
+    assert webhook_server._qmd_top_hit_ref("Title: nothing here") is None
+    body = webhook_server._qmd_answer_body(
+        "Folder Context: ctx\n---\n# Heading\nSource: https://x\nArticle ID: 1\n---\nThe real answer is 42."
+    )
+    assert body == "The real answer is 42."
+
+
+def test_qmd_answer_body_strips_notion_metadata_block():
+    # Notion exports use different metadata keys than Gorgias help articles; the
+    # generic leading-block strip must drop them all, not just a fixed denylist.
+    notion = (
+        "Source course: Online Training\n"
+        "Source page ID: 312746d6-e6c2\n"
+        "Source URL: https://www.notion.so/Online-Training-312746d6\n"
+        "Created: 2026-02-25T00:28:00.000Z\n"
+        "\n"
+        "ShapeScale is accurate down to 1/20th of an inch."
+    )
+    assert webhook_server._qmd_answer_body(notion) == "ShapeScale is accurate down to 1/20th of an inch."
+
+
+def test_qmd_answer_body_strips_trailing_and_lowercase_metadata():
+    # Metadata that re-appears AFTER the first prose line (transcluded/footer) or
+    # uses lowercase keys must not leak internal URLs / record IDs into the draft.
+    doc = (
+        "---\n# Title\nSource: https://help.example/foo\n---\n"
+        "The first prose line is fine.\n"
+        "source: https://internal.shapescale.io/admin/leads\n"
+        "Article ID: 8675309\n"
+        "Last updated: 2026-06-19\n"
+    )
+    body = webhook_server._qmd_answer_body(doc)
+    assert body == "The first prose line is fine."
+    assert "internal.shapescale.io" not in body
+    assert "8675309" not in body
+
+
+def test_qmd_answer_body_strips_image_embeds_and_urls():
+    # Verified production-shape leak: Gorgias bodies carry ![](attachment.png) image
+    # embeds, <https://...> angle URLs, and bare URLs that must not reach the SMS.
+    doc = (
+        "---\n# Title\n---\n"
+        "See the difference ![](https://attachments.gorgias.help/abc/photo.png) here.\n"
+        "More at <https://business.shapescale.com/demo> or https://shapescale.com/x.\n"
+    )
+    body = webhook_server._qmd_answer_body(doc)
+    assert "http" not in body
+    assert "gorgias.help" not in body
+    assert "See the difference" in body and "here." in body
+
+
+def test_knowledge_query_is_deterministic_and_dedupes_anchor():
+    # Equal-length ties must resolve the same way every call (no hash-seed drift),
+    # and the anchor's own words must not be duplicated into the query.
+    q1 = webhook_server._knowledge_query_for_category("product", "refund cancel policy return delays")
+    q2 = webhook_server._knowledge_query_for_category("product", "refund cancel policy return delays")
+    assert q1 == q2
+    booking = webhook_server._knowledge_query_for_category("booking", "how do I book a demo")
+    assert booking.split().count("book") == 1
+    assert booking.split().count("demo") == 1
+
+
+def test_knowledge_query_extracts_salient_keywords_for_and_search():
+    # qmd search is AND-based, so the query must be a few high-signal content words,
+    # not the full sentence (which matches nothing). Stopwords + brand are dropped.
+    assert webhook_server._knowledge_query_for_category(
+        "pricing", "how much does ShapeScale for home cost"
+    ) == "pricing home"
+    q = webhook_server._knowledge_query_for_category("product", "how does the business scanner work")
+    assert set(q.split()) == {"business", "scanner"}
+    # Empty/stopword-only text still yields a non-empty query.
+    assert webhook_server._knowledge_query_for_category("product", "how do you do") == "ShapeScale"
 
 
 def test_failed_rich_lookup_is_cached_for_generic_fallback(monkeypatch):

--- a/tests/test_sender_enrichment.py
+++ b/tests/test_sender_enrichment.py
@@ -895,6 +895,14 @@ ShapeScale's home device is priced at $1,799 upfront for the hardware, plus an a
     assert calls[1][2] == "qmd://shapescale-knowledge/support/help-articles/693708-pricing-home.md:1"
 
 
+def test_qmd_command_returns_timeout_when_deadline_already_passed():
+    # The shared deadline means a second call after the budget is spent fails fast
+    # instead of starting a fresh full-timeout subprocess (no 2x worst-case hold).
+    import time as _time
+    out, status = webhook_server._run_qmd_command("qmd", ["search", "x"], _time.monotonic() - 1)
+    assert (out, status) == ("", "timeout")
+
+
 def test_knowledge_lookup_no_match_when_search_returns_no_hit(monkeypatch):
     monkeypatch.setattr(webhook_server, "DIALPAD_QMD_COMMAND", "qmd")
     monkeypatch.setattr(

--- a/tests/test_sender_enrichment.py
+++ b/tests/test_sender_enrichment.py
@@ -888,10 +888,11 @@ ShapeScale's home device is priced at $1,799 upfront for the hardware, plus an a
     assert "qmd://" not in result["text"]
     assert "Source:" not in result["text"]
     assert "Score:" not in result["text"]
-    # get was called with the search hit's ref, stripped of :line and #hash.
+    # get was called with the search hit's ref, keeping :line (to fetch the matched
+    # section of long docs) and dropping the #hash.
     assert calls[0][1] == "search"
     assert calls[1][1] == "get"
-    assert calls[1][2] == "qmd://shapescale-knowledge/support/help-articles/693708-pricing-home.md"
+    assert calls[1][2] == "qmd://shapescale-knowledge/support/help-articles/693708-pricing-home.md:1"
 
 
 def test_knowledge_lookup_no_match_when_search_returns_no_hit(monkeypatch):
@@ -906,15 +907,25 @@ def test_knowledge_lookup_no_match_when_search_returns_no_hit(monkeypatch):
     assert result["status"] == "no_match"
 
 
-def test_qmd_answer_body_strips_preamble_and_top_hit_ref_cleans_suffix():
+def test_qmd_answer_body_strips_preamble_and_top_hit_ref_keeps_line():
+    # The matched :line is kept (so qmd get fetches the right section); only #hash drops.
     assert webhook_server._qmd_top_hit_ref(
         "qmd://shapescale-knowledge/a/b.md:42 #deadbe\nTitle: x"
-    ) == "qmd://shapescale-knowledge/a/b.md"
+    ) == "qmd://shapescale-knowledge/a/b.md:42"
     assert webhook_server._qmd_top_hit_ref("Title: nothing here") is None
     body = webhook_server._qmd_answer_body(
         "Folder Context: ctx\n---\n# Heading\nSource: https://x\nArticle ID: 1\n---\nThe real answer is 42."
     )
     assert body == "The real answer is 42."
+
+
+def test_qmd_answer_body_keeps_labeled_answer_lines():
+    # A labeled answer line (label is NOT a known metadata key) must survive; only
+    # recognized metadata keys are dropped.
+    doc = "Source: https://x\n---\nPricing: $1,799 upfront for the hardware.\nNote: billing starts after delivery."
+    body = webhook_server._qmd_answer_body(doc)
+    assert "Pricing: $1,799 upfront for the hardware." in body
+    assert "Note: billing starts after delivery." in body
 
 
 def test_qmd_answer_body_strips_notion_metadata_block():
@@ -980,8 +991,11 @@ def test_knowledge_query_extracts_salient_keywords_for_and_search():
     ) == "pricing home"
     q = webhook_server._knowledge_query_for_category("product", "how does the business scanner work")
     assert set(q.split()) == {"business", "scanner"}
-    # Empty/stopword-only text still yields a non-empty query.
-    assert webhook_server._knowledge_query_for_category("product", "how do you do") == "ShapeScale"
+    # No anchor + no salient keywords -> empty query so the lookup fails closed
+    # (rather than searching the brand alone and matching an arbitrary doc).
+    assert webhook_server._knowledge_query_for_category("product", "how does it work") == ""
+    # An anchored category still yields a query even with all-stopword text.
+    assert webhook_server._knowledge_query_for_category("pricing", "how much does it cost") == "pricing"
 
 
 def test_failed_rich_lookup_is_cached_for_generic_fallback(monkeypatch):


### PR DESCRIPTION
## What

Reworks the ShapeScale-knowledge lookup that backs sales-line SMS draft replies
so it produces **grounded, usable answers** instead of the doc title + source URL.

- **Query** (`_knowledge_query_for_category`): build a focused AND-query from the
  customer's salient keywords (stopword + brand removal, deterministic top-2)
  instead of a keyword-stuffed sentence.
- **Lookup** (`lookup_shapescale_knowledge`): `qmd search` → parse the top
  `qmd://` ref → `qmd get` → `_qmd_answer_body` extracts the answer prose.
- **Answer extraction** (`_qmd_answer_body`): drop known metadata keys *anywhere*
  in the doc (case-insensitive), the leading `Key:` preamble, headings/fences,
  and all URLs / markdown images.
- Scope search to the curated `shapescale-knowledge` collection (configurable via
  `DIALPAD_QMD_COLLECTION`).

## Why

The path was effectively dead:
1. `qmd search` is **BM25 with AND-semantics** — every term must appear — so
   passing the full customer sentence (`"how much does ShapeScale for home cost"`)
   matched **zero** docs.
2. When it did match, it extracted only the search snippet, which is the doc's
   `# heading` + `Source:` URL — never the actual answer.

After the rework, against the live index:
| question | draft |
|---|---|
| home pricing | *"As of May 2024, ShapeScale for Home is not available for new orders…"* |
| business pricing | *"…$199 per month if paid annually (total $2,388)…"* |
| accuracy | *"…accurate down to 1/20th of an inch… trained on 1000+ DEXA scans…"* |

### Security hardening (from adversarial review)
Adversarial review found, **verified against a real Gorgias doc (693699)**, that
trailing/transcluded metadata, lowercase metadata keys, image embeds `![](url)`,
`<url>`, and bare URLs could leak internal attachment URLs / record IDs into a
customer draft. `_qmd_answer_body` now strips all of these (regression tests
added). Live re-check: all sampled answers are `URL/meta-leak=False`.

### Invariant preserved
Operator-approval draft path only — **no unattended auto-send**
(`send_proactive_reply` has zero callers; `NoUnattendedSendInvariantTests`
guards it). Every error/empty path fails closed to the generic fallback.

### Known limitation (follow-up, not in scope)
With `-n 1`, an ambiguous question can retrieve a confident-but-wrong doc (e.g.
the deprecated Home doc for a B2B pricing question). Operator-gated, so not a
customer risk, but a **doc-level provenance line on the approval card** would
help operator triage — tracked as follow-up (extends the PR3 provenance system).

## Tests

```bash
python3 -m pytest tests/test_sender_enrichment.py -q -k "qmd or knowledge_lookup or knowledge_query"
#  -> 8 passed
python3 -m pytest tests/ -q
#  -> 326 passed, 24 failed  (the 24 are PRE-EXISTING on main — identical failing
#     set with/without this change; verified via stash diff. None are QMD-related.)
```
New tests cover: search→get answer-body extraction, no-match, ref-suffix
cleaning, Notion + Gorgias + trailing + lowercase metadata stripping, image/URL
stripping, and deterministic/dedup query building.

## AI Assistance

Used (Claude Opus 4.8). Independent correctness + adversarial subagent reviews
run on the diff; all HIGH findings (metadata/URL leaks) fixed, cheap LOW findings
(determinism, dedup, failure-status observability) fixed, MEDIUM wrong-answer
provenance deferred with a note. Behavioral correctness validated against the
live qmd index. I understand this code.