### PR TITLE
feat(adapters): phone-first identity resolver (S2)

### DIFF
--- a/scripts/adapters/attio_context.py
+++ b/scripts/adapters/attio_context.py
@@ -139,6 +139,62 @@ def _reference_id(values, key):
     return None
 
 
+# --- people-field extraction (confirmed shapes; side-effect-free, reused by S2) ---
+#
+# Verified live 2026-06-18 against the people object:
+#   values.name            -> [{"first_name", "last_name", "full_name", ...}]
+#   values.email_addresses -> [{"email_address", "original_email_address", ...}]
+#   values.company         -> [{"target_record_id", ...}] (direct ref; preferred)
+# Every values.* is a list of objects with an active_from/active_until envelope;
+# read the first active entry defensively and never assume a non-empty list.
+
+def person_name_parts(person):
+    """Return (first_name, last_name, full_name) from a person record, each cleaned or None.
+
+    Tolerates ``name`` not being a list, ``[None]``, or missing sub-keys.
+    """
+    item = _first(((person or {}).get("values") or {}), "name")
+    if not isinstance(item, dict):
+        return (None, None, None)
+    first = _clean(item.get("first_name")) if isinstance(item.get("first_name"), str) else None
+    last = _clean(item.get("last_name")) if isinstance(item.get("last_name"), str) else None
+    full = _clean(item.get("full_name")) if isinstance(item.get("full_name"), str) else None
+    if not full and (first or last):
+        full = " ".join(part for part in (first, last) if part) or None
+    return (first, last, full)
+
+
+def person_primary_email(person):
+    """Return the person's primary email address (cleaned, lower-cased), or None.
+
+    Tolerates ``email_addresses`` not being a list or holding non-dict entries.
+    """
+    item = _first(((person or {}).get("values") or {}), "email_addresses")
+    if not isinstance(item, dict):
+        return None
+    email = item.get("email_address") or item.get("original_email_address")
+    if isinstance(email, str) and "@" in email:
+        cleaned = _clean(email)
+        return cleaned.lower() if cleaned else None
+    return None
+
+
+def person_company_name(person):
+    """Resolve a person's company name from the direct ``company`` ref.
+
+    Prefers the direct ``company`` record-reference. Returns a cleaned name or
+    None; never raises (``get_record`` swallows AttioError and returns None).
+    """
+    values = (person or {}).get("values") or {}
+    company_id = _reference_id(values, "company")
+    if company_id:
+        company = get_record("companies", company_id)
+        name = _text_value((company or {}).get("values"), "name")
+        if name:
+            return name
+    return None
+
+
 # --- resolution helpers (reusable by S2) ---
 
 def find_person_by_phone(phone):

--- a/scripts/adapters/attio_context.py
+++ b/scripts/adapters/attio_context.py
@@ -111,8 +111,27 @@ def get_record(object_slug, record_id):
 # --- value extraction (Attio wraps each attribute as a list of typed objects) ---
 
 def _first(values, key):
+    """Return the first *active* dict entry for ``key`` (Attio value envelope).
+
+    Attio wraps each attribute as a list of typed objects carrying an
+    active_from/active_until envelope. Historical/inactive entries (those with a
+    non-null ``active_until``) can be listed BEFORE the active one, so blindly
+    taking ``arr[0]`` can return a stale name/email. Prefer the first entry whose
+    ``active_until`` is None; fall back to the first usable dict entry only when no
+    explicitly-active one exists. Non-dict entries are skipped defensively.
+    """
     arr = (values or {}).get(key)
-    return arr[0] if isinstance(arr, list) and arr else None
+    if not isinstance(arr, list) or not arr:
+        return None
+    fallback = None
+    for entry in arr:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("active_until") is None:
+            return entry
+        if fallback is None:
+            fallback = entry
+    return fallback
 
 
 def _text_value(values, key):

--- a/scripts/adapters/identity_resolver.py
+++ b/scripts/adapters/identity_resolver.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Phone-first identity resolver for the Dialpad SMS enrichment program (S2/U?).
+
+A standalone, importable library that resolves an inbound sender to a compact
+identity using a cheap -> expensive cascade, short-circuiting on a confident hit
+and recording each step in ``sources[]``.
+
+Single entrypoint::
+
+    resolve_identity(phone, dialpad_contact=None, email=None) -> {
+        "identity": {"name", "first_name", "last_name", "email", "company"},
+        "confidence": "high" | "medium" | "low",
+        "sources": [...],
+    }
+
+Cascade (ordered; a future unit can append later stages such as Apollo / Gmail /
+reverse-phone — none of those clients exist in this repo, so they are NOT built
+here):
+
+    1. ``dialpad_contact`` dict passed by the caller. This library NEVER calls
+       Dialpad over HTTP itself; the caller owns that lookup. Keeping the import
+       network-free except for Attio is a hard requirement.
+    2. Attio phone match via ``attio_context.find_person_by_phone``.
+    3. Attio email match via ``attio_context.find_person_by_email`` — only once
+       an email is known from the caller-supplied ``email`` arg or step 1/2.
+
+Confidence vocabulary mirrors the webhook's existing high/medium/low identity
+confidence:
+
+    high   = exact Attio phone match that resolves a usable name.
+    medium = Dialpad-contact name only (no Attio corroboration), OR an Attio
+             person matched but yielded no usable name.
+    low    = nothing resolved, or Attio degraded / errored.
+
+Fail-closed discipline (mirrors ``attio_context``'s ``AttioError`` handling):
+Attio failures are recorded as an ``attio_error`` source, never elevate
+confidence, and never propagate an exception to the caller. With ``ATTIO_API_KEY``
+unset, ``resolve_identity`` makes zero network calls and returns confidence
+``low`` without raising.
+
+WRONG-MATCH WARNING (for S3 and any customer-facing consumer):
+A ``high`` result here is a single ``limit=1`` Attio phone match with NO collision
+/ wrong-match check. That is acceptable in S2 because this unit produces no
+customer-facing text. S3 MUST NOT auto-promote a ``high`` resolver result into a
+customer-facing name or company (greeting, draft body, etc.) without re-applying
+the wrong-match guard described in
+``docs/solutions/ungate-enrichment-customer-pii.md`` (a reused / ported / shared
+number or a stale Attio record can match the wrong person at any confidence).
+"""
+import os
+import sys
+
+# Make the sibling adapter importable whether this file is imported as a module
+# or run from an arbitrary cwd. attio_context is the only Attio client we touch.
+_ADAPTER_DIR = os.path.dirname(os.path.abspath(__file__))
+if _ADAPTER_DIR not in sys.path:
+    sys.path.insert(0, _ADAPTER_DIR)
+
+import attio_context  # noqa: E402
+
+CONFIDENCE_HIGH = "high"
+CONFIDENCE_MEDIUM = "medium"
+CONFIDENCE_LOW = "low"
+
+
+def _empty_identity():
+    return {
+        "name": None,
+        "first_name": None,
+        "last_name": None,
+        "email": None,
+        "company": None,
+    }
+
+
+def _clean_str(value):
+    """Sanitize a caller-supplied value, returning a clean string or None.
+
+    ``attio_context._clean`` passes non-strings through unchanged, so guard the
+    type here: malformed Dialpad payloads (ints, lists, dicts) must never leak a
+    non-string into the identity contract or reach a ``str.join``.
+    """
+    if not isinstance(value, str):
+        return None
+    return attio_context._clean(value)
+
+
+def _identity_from_dialpad(contact):
+    """Extract a partial identity from a caller-supplied Dialpad contact dict.
+
+    Returns (identity, has_name). Tolerates a non-dict ``contact`` and missing
+    keys without raising. Accepts a handful of common name spellings so the
+    caller is not forced into one exact shape.
+    """
+    identity = _empty_identity()
+    if not isinstance(contact, dict):
+        return identity, False
+
+    first = _clean_str(contact.get("first_name"))
+    last = _clean_str(contact.get("last_name"))
+    name = (
+        _clean_str(contact.get("name"))
+        or _clean_str(contact.get("display_name"))
+        or _clean_str(contact.get("full_name"))
+    )
+    if not name and (first or last):
+        name = " ".join(part for part in (first, last) if part) or None
+
+    email = contact.get("email")
+    if isinstance(email, str) and "@" in email:
+        cleaned_email = _clean_str(email)
+        identity["email"] = cleaned_email.lower() if cleaned_email else None
+
+    company = _clean_str(contact.get("company"))
+
+    identity["first_name"] = first
+    identity["last_name"] = last
+    identity["name"] = name
+    identity["company"] = company
+    return identity, bool(name)
+
+
+def _merge_attio_person(identity, person):
+    """Overlay an Attio person's name/email/company onto ``identity`` in place.
+
+    Attio is the more authoritative source for the matched record, so its fields
+    win where present; caller-supplied fields fill any gaps. Returns
+    ``has_name``: whether a usable name was resolved (from either source).
+    Never raises — ``person_company_name`` swallows AttioError internally.
+    """
+    first, last, full = attio_context.person_name_parts(person)
+    if full:
+        identity["name"] = full
+    if first:
+        identity["first_name"] = first
+    if last:
+        identity["last_name"] = last
+
+    email = attio_context.person_primary_email(person)
+    if email:
+        identity["email"] = email
+
+    try:
+        company = attio_context.person_company_name(person)
+    except attio_context.AttioError:
+        company = None
+    if company:
+        identity["company"] = company
+
+    return bool(identity.get("name"))
+
+
+def resolve_identity(phone, dialpad_contact=None, email=None):
+    """Resolve an inbound sender to a compact identity via a cheap->expensive cascade.
+
+    Args:
+        phone: the inbound sender's phone number (the primary lookup key).
+        dialpad_contact: optional dict the caller already fetched from Dialpad.
+            This library does NOT call Dialpad itself.
+        email: optional email the caller already knows; seeds the Attio email
+            stage even before an Attio person is matched.
+
+    Returns a dict with ``identity``, ``confidence`` (high/medium/low), and an
+    ordered ``sources`` list recording each cascade step. Never raises.
+
+    See the module docstring for the wrong-match warning that S3 must honor
+    before putting any of this into customer-facing text.
+    """
+    identity = _empty_identity()
+    sources = []
+    confidence = CONFIDENCE_LOW
+
+    # Seed a known email from the caller so the Attio email stage can run even if
+    # the Dialpad contact carried no email and the phone match misses.
+    if isinstance(email, str) and "@" in email:
+        cleaned = _clean_str(email)
+        if cleaned:
+            identity["email"] = cleaned.lower()
+
+    # --- Stage 1: caller-supplied Dialpad contact (cheapest; no I/O) ----------
+    has_name = False
+    if dialpad_contact is not None:
+        dp_identity, dp_has_name = _identity_from_dialpad(dialpad_contact)
+        for key, value in dp_identity.items():
+            if value and not identity.get(key):
+                identity[key] = value
+        has_name = dp_has_name
+        if dp_has_name:
+            # A Dialpad name alone (no Attio corroboration yet) is medium.
+            confidence = CONFIDENCE_MEDIUM
+            sources.append("dialpad_contact")
+        else:
+            sources.append("dialpad_contact_empty")
+
+    # --- Stage 2: Attio phone match ------------------------------------------
+    # Fail closed on any Attio error: record it, do not elevate confidence, keep
+    # whatever the Dialpad stage produced. With ATTIO_API_KEY unset, the adapter
+    # raises AttioError("missing_api_key") BEFORE any network call, so this stays
+    # network-free and degrades to the caller-supplied data.
+    person = None
+    try:
+        normalized = attio_context._normalize_phone(phone) if phone else None
+        if normalized:
+            person = attio_context.find_person_by_phone(normalized)
+    except attio_context.AttioError:
+        sources.append("attio_error")
+        person = None
+
+    if person is not None:
+        attio_has_name = _merge_attio_person(identity, person)
+        sources.append("attio_phone")
+        if attio_has_name:
+            confidence = CONFIDENCE_HIGH
+            has_name = True
+        else:
+            # Person matched but no usable name -> medium (never downgrade a name
+            # we already had from Dialpad).
+            has_name = has_name or False
+            if confidence != CONFIDENCE_HIGH:
+                confidence = CONFIDENCE_MEDIUM
+
+    # --- Stage 3: Attio email match ------------------------------------------
+    # Only runs once an email is known (from the caller, Dialpad, or the phone
+    # match) AND we have not already resolved a high-confidence name from phone.
+    if confidence != CONFIDENCE_HIGH and identity.get("email"):
+        try:
+            email_person = attio_context.find_person_by_email(identity["email"])
+        except attio_context.AttioError:
+            sources.append("attio_error")
+            email_person = None
+        if email_person is not None:
+            email_has_name = _merge_attio_person(identity, email_person)
+            sources.append("attio_email")
+            if email_has_name:
+                confidence = CONFIDENCE_HIGH
+                has_name = True
+            elif confidence != CONFIDENCE_HIGH:
+                confidence = CONFIDENCE_MEDIUM
+
+    # Make a fully-empty cascade explicit (no contact, no phone, no email) so a
+    # caller can distinguish "nothing to resolve from" from a real miss.
+    if not sources:
+        sources.append("no_input")
+
+    return {"identity": identity, "confidence": confidence, "sources": sources}

--- a/scripts/adapters/identity_resolver.py
+++ b/scripts/adapters/identity_resolver.py
@@ -106,7 +106,14 @@ def _identity_from_dialpad(contact):
     if not name and (first or last):
         name = " ".join(part for part in (first, last) if part) or None
 
+    # Raw Dialpad contacts carry an ``emails`` array (first entry primary) as well
+    # as (sometimes) a singular ``email``. Prefer the singular field, then fall
+    # back to the first array entry, so either shape seeds the Attio email stage.
     email = contact.get("email")
+    if not (isinstance(email, str) and "@" in email):
+        emails = contact.get("emails")
+        if isinstance(emails, list) and emails:
+            email = emails[0]
     if isinstance(email, str) and "@" in email:
         cleaned_email = _clean_str(email)
         identity["email"] = cleaned_email.lower() if cleaned_email else None
@@ -125,7 +132,10 @@ def _merge_attio_person(identity, person):
 
     Attio is the more authoritative source for the matched record, so its fields
     win where present; caller-supplied fields fill any gaps. Returns
-    ``has_name``: whether a usable name was resolved (from either source).
+    ``attio_has_name``: whether *Attio* (not a pre-existing Dialpad name) yielded
+    a usable name. A high promotion must hinge on Attio corroboration, so an Attio
+    person matched with no usable name stays medium even if Dialpad already named
+    the identity — and the email follow-up still gets a chance to run.
     Never raises — ``person_company_name`` swallows AttioError internally.
     """
     first, last, full = attio_context.person_name_parts(person)
@@ -147,7 +157,7 @@ def _merge_attio_person(identity, person):
     if company:
         identity["company"] = company
 
-    return bool(identity.get("name"))
+    return bool(full)
 
 
 def resolve_identity(phone, dialpad_contact=None, email=None):
@@ -161,7 +171,16 @@ def resolve_identity(phone, dialpad_contact=None, email=None):
             stage even before an Attio person is matched.
 
     Returns a dict with ``identity``, ``confidence`` (high/medium/low), and an
-    ordered ``sources`` list recording each cascade step. Never raises.
+    ordered ``sources`` list recording each cascade step. Never raises — a
+    numeric/odd ``phone`` (or ``email``) degrades to a low-confidence result
+    rather than raising.
+
+    ``sources`` vocabulary: ``dialpad_contact`` / ``dialpad_contact_empty`` (a
+    contact was supplied), ``attio_phone`` / ``attio_email`` (a person matched),
+    ``attio_phone_not_found`` / ``attio_email_not_found`` (the lookup ran but
+    matched nothing — provenance for a real miss), ``attio_error`` (fail-closed),
+    and ``no_input`` ONLY when there was genuinely no phone, no email, and no
+    usable dialpad_contact to resolve from.
 
     See the module docstring for the wrong-match warning that S3 must honor
     before putting any of this into customer-facing text.
@@ -197,14 +216,22 @@ def resolve_identity(phone, dialpad_contact=None, email=None):
     # whatever the Dialpad stage produced. With ATTIO_API_KEY unset, the adapter
     # raises AttioError("missing_api_key") BEFORE any network call, so this stays
     # network-free and degrades to the caller-supplied data.
+    # Coerce a non-string phone (e.g. a numeric Dialpad payload) to a safe string
+    # so _normalize_phone's re.sub never sees a non-str and raises. A blank/odd
+    # value degrades to "no phone lookup" rather than crashing this entrypoint.
+    phone_str = phone if isinstance(phone, str) else (str(phone) if phone is not None else None)
+    attempted_phone = bool(phone_str and phone_str.strip())
     person = None
-    try:
-        normalized = attio_context._normalize_phone(phone) if phone else None
-        if normalized:
-            person = attio_context.find_person_by_phone(normalized)
-    except attio_context.AttioError:
-        sources.append("attio_error")
-        person = None
+    if attempted_phone:
+        try:
+            normalized = attio_context._normalize_phone(phone_str)
+            if normalized:
+                person = attio_context.find_person_by_phone(normalized)
+                if person is None:
+                    sources.append("attio_phone_not_found")
+        except attio_context.AttioError:
+            sources.append("attio_error")
+            person = None
 
     if person is not None:
         attio_has_name = _merge_attio_person(identity, person)
@@ -222,12 +249,16 @@ def resolve_identity(phone, dialpad_contact=None, email=None):
     # --- Stage 3: Attio email match ------------------------------------------
     # Only runs once an email is known (from the caller, Dialpad, or the phone
     # match) AND we have not already resolved a high-confidence name from phone.
-    if confidence != CONFIDENCE_HIGH and identity.get("email"):
+    attempted_email = bool(confidence != CONFIDENCE_HIGH and identity.get("email"))
+    if attempted_email:
         try:
             email_person = attio_context.find_person_by_email(identity["email"])
         except attio_context.AttioError:
             sources.append("attio_error")
             email_person = None
+        else:
+            if email_person is None:
+                sources.append("attio_email_not_found")
         if email_person is not None:
             email_has_name = _merge_attio_person(identity, email_person)
             sources.append("attio_email")
@@ -237,8 +268,10 @@ def resolve_identity(phone, dialpad_contact=None, email=None):
             elif confidence != CONFIDENCE_HIGH:
                 confidence = CONFIDENCE_MEDIUM
 
-    # Make a fully-empty cascade explicit (no contact, no phone, no email) so a
-    # caller can distinguish "nothing to resolve from" from a real miss.
+    # ``no_input`` means there was genuinely nothing to resolve from: no phone, no
+    # email, and no usable dialpad_contact. A real miss (a lookup ran but found
+    # nothing) is already recorded by its own *_not_found source above, so it must
+    # not collapse to ``no_input`` and lose that provenance.
     if not sources:
         sources.append("no_input")
 

--- a/tests/test_attio_context.py
+++ b/tests/test_attio_context.py
@@ -65,6 +65,42 @@ class ValueExtractionTests(unittest.TestCase):
     def test_reference_id(self):
         self.assertEqual(attio._reference_id(DEAL["values"], "associated_company"), "co-1")
 
+    def test_first_prefers_active_over_inactive_leading_entry(self):
+        # Attio can list a historical entry (active_until set) BEFORE the active
+        # one. _first must skip the stale entry and return the active record.
+        values = {"name": [
+            {"full_name": "Old Name", "active_until": "2025-01-01T00:00:00Z"},
+            {"full_name": "Current Name", "active_until": None},
+        ]}
+        self.assertEqual(attio._first(values, "name").get("full_name"), "Current Name")
+
+    def test_first_falls_back_to_first_dict_when_none_active(self):
+        # No entry is explicitly active -> fall back to the first usable dict.
+        values = {"name": [
+            {"full_name": "Only Historical", "active_until": "2025-01-01T00:00:00Z"},
+        ]}
+        self.assertEqual(attio._first(values, "name").get("full_name"), "Only Historical")
+
+    def test_first_skips_non_dict_entries(self):
+        values = {"name": [None, "nope", {"full_name": "Real", "active_until": None}]}
+        self.assertEqual(attio._first(values, "name").get("full_name"), "Real")
+
+    def test_person_name_parts_returns_active_not_stale(self):
+        person = {"values": {"name": [
+            {"first_name": "Stale", "last_name": "Doe", "full_name": "Stale Doe",
+             "active_until": "2025-01-01T00:00:00Z"},
+            {"first_name": "Active", "last_name": "Doe", "full_name": "Active Doe",
+             "active_until": None},
+        ]}}
+        self.assertEqual(attio.person_name_parts(person), ("Active", "Doe", "Active Doe"))
+
+    def test_person_primary_email_returns_active_not_stale(self):
+        person = {"values": {"email_addresses": [
+            {"email_address": "old@acme.com", "active_until": "2025-01-01T00:00:00Z"},
+            {"email_address": "new@acme.com", "active_until": None},
+        ]}}
+        self.assertEqual(attio.person_primary_email(person), "new@acme.com")
+
 
 class CrmContextFromRecordsTests(unittest.TestCase):
     def test_usable_with_deal(self):

--- a/tests/test_identity_resolver.py
+++ b/tests/test_identity_resolver.py
@@ -1,0 +1,327 @@
+"""Unit tests for the phone-first identity resolver (S2). Attio HTTP fully mocked.
+
+Mirrors tests/test_attio_context.py: the Attio transport is mocked at
+``attio_context._request`` so the suite never touches live Attio.
+"""
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+sys.path.insert(0, str(ROOT / "scripts" / "adapters"))
+
+import attio_context as attio  # noqa: E402
+import identity_resolver as resolver  # noqa: E402
+
+
+# --- confirmed people field shapes (verified live 2026-06-18) -----------------
+PERSON_FULL = {
+    "id": {"record_id": "person-1", "workspace_id": "ws-1", "object_id": "people"},
+    "values": {
+        "name": [{
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "full_name": "Jane Doe",
+            "active_from": "2026-01-01T00:00:00Z",
+            "active_until": None,
+        }],
+        "email_addresses": [{
+            "email_address": "jane@acme.com",
+            "original_email_address": "Jane@Acme.com",
+            "email_domain": "acme.com",
+            "active_from": "2026-01-01T00:00:00Z",
+        }],
+        "company": [{"target_record_id": "co-1", "target_object": "companies"}],
+        "phone_numbers": [{"phone_number": "+14155201316"}],
+    },
+}
+
+# A person Attio matches by phone but whose name fields are unusable.
+PERSON_NO_NAME = {
+    "id": {"record_id": "person-2"},
+    "values": {
+        "name": [None],
+        "email_addresses": [],
+        "phone_numbers": [{"phone_number": "+14155551234"}],
+    },
+}
+
+COMPANY = {
+    "id": {"record_id": "co-1"},
+    "values": {"name": [{"value": "Acme Corp", "attribute_type": "text"}]},
+}
+
+
+def make_fake_request(person_for_phone=None, person_for_email=None, company=COMPANY):
+    """Build a fake _request honoring the people-query filter and company GET."""
+    def fake_request(method, path, body=None):
+        if method == "POST" and path == "/objects/people/records/query":
+            filt = (body or {}).get("filter") or {}
+            if "phone_numbers" in filt and person_for_phone is not None:
+                return {"data": [person_for_phone]}
+            if "email_addresses" in filt and person_for_email is not None:
+                return {"data": [person_for_email]}
+            return {"data": []}
+        if method == "GET" and path == "/objects/companies/records/co-1" and company is not None:
+            return {"data": company}
+        return {"data": []}
+    return fake_request
+
+
+def with_key(env=None):
+    """Patch context so ATTIO_API_KEY is present (so _request reaches the HTTP layer)."""
+    base = {"ATTIO_API_KEY": "test-key"}
+    if env:
+        base.update(env)
+    return patch.dict("os.environ", base)
+
+
+class AttioPhoneHighTests(unittest.TestCase):
+    def test_attio_phone_high(self):
+        fake = make_fake_request(person_for_phone=PERSON_FULL)
+        with with_key(), patch.object(attio, "_request", side_effect=fake):
+            out = resolver.resolve_identity("+1 (415) 520-1316")
+        self.assertEqual(out["confidence"], "high")
+        self.assertEqual(out["identity"]["name"], "Jane Doe")
+        self.assertEqual(out["identity"]["first_name"], "Jane")
+        self.assertEqual(out["identity"]["last_name"], "Doe")
+        self.assertEqual(out["identity"]["email"], "jane@acme.com")
+        self.assertEqual(out["identity"]["company"], "Acme Corp")
+        self.assertIn("attio_phone", out["sources"])
+        # Every identity field is a str or None (no type pollution from Attio).
+        for value in out["identity"].values():
+            self.assertTrue(value is None or isinstance(value, str))
+
+    def test_attio_wins_over_dialpad_but_fills_gaps(self):
+        # Attio name/email/company win; a Dialpad-only field with no Attio value stays.
+        fake = make_fake_request(person_for_phone=PERSON_FULL)
+        contact = {"name": "J. Doe (stale)", "company": None, "title": "VP"}
+        with with_key(), patch.object(attio, "_request", side_effect=fake):
+            out = resolver.resolve_identity("+14155201316", dialpad_contact=contact)
+        self.assertEqual(out["confidence"], "high")
+        self.assertEqual(out["identity"]["name"], "Jane Doe")  # Attio wins
+        self.assertEqual(out["identity"]["company"], "Acme Corp")
+
+
+class DialpadOnlyMediumTests(unittest.TestCase):
+    def test_dialpad_only_medium(self):
+        # Attio degraded/missing -> only the Dialpad name carries; medium.
+        contact = {"first_name": "Bob", "last_name": "Smith", "company": "Globex"}
+        with patch.dict("os.environ", {}, clear=True):  # no ATTIO_API_KEY
+            out = resolver.resolve_identity("+14155550000", dialpad_contact=contact)
+        self.assertEqual(out["confidence"], "medium")
+        self.assertEqual(out["identity"]["name"], "Bob Smith")
+        self.assertEqual(out["identity"]["company"], "Globex")
+        self.assertIn("dialpad_contact", out["sources"])
+
+    def test_attio_person_matched_no_name_is_medium(self):
+        fake = make_fake_request(person_for_phone=PERSON_NO_NAME)
+        with with_key(), patch.object(attio, "_request", side_effect=fake):
+            out = resolver.resolve_identity("+14155551234")
+        self.assertEqual(out["confidence"], "medium")
+        self.assertIsNone(out["identity"]["name"])
+        self.assertIn("attio_phone", out["sources"])
+
+
+class EmailFollowupHighTests(unittest.TestCase):
+    def test_email_followup_high(self):
+        # Phone misses; a caller-supplied email resolves an Attio person -> high.
+        fake = make_fake_request(person_for_phone=None, person_for_email=PERSON_FULL)
+        with with_key(), patch.object(attio, "_request", side_effect=fake):
+            out = resolver.resolve_identity("+14155559999", email="jane@acme.com")
+        self.assertEqual(out["confidence"], "high")
+        self.assertEqual(out["identity"]["name"], "Jane Doe")
+        self.assertIn("attio_email", out["sources"])
+
+    def test_email_from_dialpad_seeds_email_stage(self):
+        # No caller email arg, but the Dialpad contact carries one.
+        fake = make_fake_request(person_for_phone=None, person_for_email=PERSON_FULL)
+        contact = {"email": "jane@acme.com"}
+        with with_key(), patch.object(attio, "_request", side_effect=fake):
+            out = resolver.resolve_identity("+14155559999", dialpad_contact=contact)
+        self.assertEqual(out["confidence"], "high")
+        self.assertIn("attio_email", out["sources"])
+
+    def test_high_phone_match_short_circuits_email_stage(self):
+        # Phone already resolved high; the email stage must NOT run.
+        calls = []
+
+        def fake(method, path, body=None):
+            calls.append(((body or {}).get("filter") or {}))
+            if method == "POST" and path == "/objects/people/records/query":
+                filt = (body or {}).get("filter") or {}
+                if "phone_numbers" in filt:
+                    return {"data": [PERSON_FULL]}
+            if method == "GET" and path == "/objects/companies/records/co-1":
+                return {"data": COMPANY}
+            return {"data": []}
+
+        with with_key(), patch.object(attio, "_request", side_effect=fake):
+            out = resolver.resolve_identity("+14155201316", email="someone@else.com")
+        self.assertEqual(out["confidence"], "high")
+        self.assertNotIn("attio_email", out["sources"])
+        # No people query carried an email_addresses filter.
+        self.assertFalse(any("email_addresses" in c for c in calls))
+
+
+class NotFoundLowTests(unittest.TestCase):
+    def test_not_found_low(self):
+        fake = make_fake_request(person_for_phone=None, person_for_email=None)
+        with with_key(), patch.object(attio, "_request", side_effect=fake):
+            out = resolver.resolve_identity("+14155551111")
+        self.assertEqual(out["confidence"], "low")
+        self.assertIsNone(out["identity"]["name"])
+        self.assertIsNone(out["identity"]["company"])
+
+    def test_no_input_low(self):
+        # No phone, no contact, no email -> low, network-free, no_input source.
+        with patch.dict("os.environ", {}, clear=True):
+            out = resolver.resolve_identity(None)
+        self.assertEqual(out["confidence"], "low")
+        self.assertEqual(out["sources"], ["no_input"])
+
+
+class AttioDegradedLowTests(unittest.TestCase):
+    def test_attio_degraded_low_records_error_and_falls_back(self):
+        # Attio raises; no Dialpad name -> low, attio_error recorded, no raise.
+        with with_key(), patch.object(attio, "_request", side_effect=attio.AttioError("http_500")):
+            out = resolver.resolve_identity("+14155551234")
+        self.assertEqual(out["confidence"], "low")
+        self.assertIn("attio_error", out["sources"])
+
+    def test_attio_error_does_not_elevate_medium_dialpad(self):
+        # Dialpad gave a name (medium); Attio errors must not raise or change that.
+        contact = {"name": "Carol King"}
+        with with_key(), patch.object(attio, "_request", side_effect=attio.AttioError("network")):
+            out = resolver.resolve_identity("+14155551234", dialpad_contact=contact)
+        self.assertEqual(out["confidence"], "medium")
+        self.assertEqual(out["identity"]["name"], "Carol King")
+        self.assertIn("attio_error", out["sources"])
+
+    def test_email_stage_attio_error_fails_closed(self):
+        # Phone misses, email stage raises -> low, attio_error, no exception.
+        def fake(method, path, body=None):
+            filt = (body or {}).get("filter") or {}
+            if "phone_numbers" in filt:
+                return {"data": []}
+            if "email_addresses" in filt:
+                raise attio.AttioError("http_403")
+            return {"data": []}
+
+        with with_key(), patch.object(attio, "_request", side_effect=fake):
+            out = resolver.resolve_identity("+14155559999", email="x@y.com")
+        self.assertEqual(out["confidence"], "low")
+        self.assertIn("attio_error", out["sources"])
+
+
+class PersonFieldExtractionTests(unittest.TestCase):
+    """Confirmed people shapes through attio_context helpers."""
+
+    def test_person_name_parts(self):
+        self.assertEqual(attio.person_name_parts(PERSON_FULL), ("Jane", "Doe", "Jane Doe"))
+
+    def test_person_name_parts_builds_full_from_parts(self):
+        person = {"values": {"name": [{"first_name": "Ann", "last_name": "Lee"}]}}
+        self.assertEqual(attio.person_name_parts(person), ("Ann", "Lee", "Ann Lee"))
+
+    def test_person_primary_email_lowercased(self):
+        self.assertEqual(attio.person_primary_email(PERSON_FULL), "jane@acme.com")
+
+    def test_person_company_name_prefers_direct_company(self):
+        fake = make_fake_request(person_for_phone=PERSON_FULL)
+        with with_key(), patch.object(attio, "_request", side_effect=fake):
+            self.assertEqual(attio.person_company_name(PERSON_FULL), "Acme Corp")
+
+
+class MalformedRecordTests(unittest.TestCase):
+    def test_name_is_none_entry(self):
+        self.assertEqual(attio.person_name_parts({"values": {"name": [None]}}), (None, None, None))
+
+    def test_email_addresses_not_a_list(self):
+        person = {"values": {"email_addresses": "nope@nope.com"}}
+        self.assertIsNone(attio.person_primary_email(person))
+
+    def test_name_not_a_list(self):
+        person = {"values": {"name": {"first_name": "X"}}}
+        self.assertEqual(attio.person_name_parts(person), (None, None, None))
+
+    def test_non_dict_company_ref(self):
+        person = {"values": {"company": ["not-a-dict"]}}
+        self.assertIsNone(attio.person_company_name(person))
+
+    def test_dialpad_contact_not_a_dict(self):
+        with patch.dict("os.environ", {}, clear=True):
+            out = resolver.resolve_identity("+14155550000", dialpad_contact="oops")
+        self.assertEqual(out["confidence"], "low")
+
+    def test_dialpad_non_string_name_parts_do_not_raise(self):
+        # int first_name + no usable top-level name must not hit str.join.
+        contact = {"first_name": 123, "last_name": None}
+        with patch.dict("os.environ", {}, clear=True):
+            out = resolver.resolve_identity("+14155550000", dialpad_contact=contact)
+        self.assertEqual(out["confidence"], "low")
+        self.assertIsNone(out["identity"]["name"])
+        self.assertIsNone(out["identity"]["first_name"])
+
+    def test_dialpad_non_string_fields_never_pollute_identity(self):
+        # Non-string name/company must not leak into the contract as non-strings.
+        contact = {"name": 5, "company": 99, "email": ["x@y.com"]}
+        with patch.dict("os.environ", {}, clear=True):
+            out = resolver.resolve_identity("+14155550000", dialpad_contact=contact)
+        ident = out["identity"]
+        for key, value in ident.items():
+            self.assertTrue(value is None or isinstance(value, str), f"{key}={value!r}")
+
+    def test_malformed_person_does_not_crash_resolver(self):
+        bad_person = {"values": {"name": "wrong", "email_addresses": 5, "company": None}}
+        fake = make_fake_request(person_for_phone=bad_person)
+        with with_key(), patch.object(attio, "_request", side_effect=fake):
+            out = resolver.resolve_identity("+14155551234")
+        # Person matched but nothing usable -> medium, no crash.
+        self.assertEqual(out["confidence"], "medium")
+        self.assertIsNone(out["identity"]["name"])
+
+
+class SecretLeakTests(unittest.TestCase):
+    def test_secret_never_appears_in_output(self):
+        with patch.dict("os.environ", {"ATTIO_API_KEY": "SENTINEL"}), \
+             patch.object(attio, "_request", side_effect=attio.AttioError("http_403")):
+            out = resolver.resolve_identity("+14155201316", dialpad_contact={"name": "Z"})
+        self.assertNotIn("SENTINEL", json.dumps(out))
+
+
+class ImportSafeTests(unittest.TestCase):
+    def test_import_safe_no_network_when_key_unset(self):
+        # With ATTIO_API_KEY unset, _request raises before any urlopen. Assert we
+        # never even reach the HTTP layer (urlopen is not called).
+        with patch.dict("os.environ", {}, clear=True), \
+             patch("attio_context.urllib.request.urlopen") as urlopen:
+            out = resolver.resolve_identity("+14155201316")
+        urlopen.assert_not_called()
+        self.assertEqual(out["confidence"], "low")
+
+    def test_resolve_identity_returns_full_contract(self):
+        with patch.dict("os.environ", {}, clear=True):
+            out = resolver.resolve_identity(None)
+        self.assertEqual(set(out), {"identity", "confidence", "sources"})
+        self.assertEqual(
+            set(out["identity"]),
+            {"name", "first_name", "last_name", "email", "company"},
+        )
+
+
+class NoWebhookSideEffectTests(unittest.TestCase):
+    def test_resolver_source_does_not_reference_webhook_server(self):
+        # Auto-merge tier: the resolver must not import webhook_server (which
+        # would drag its side effects in). Inspect the source, not global
+        # sys.modules, which other tests in the suite may have populated.
+        src = Path(resolver.__file__).read_text(encoding="utf-8")
+        self.assertNotIn("webhook_server", src)
+        self.assertNotIn("import webhook", src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_identity_resolver.py
+++ b/tests/test_identity_resolver.py
@@ -49,6 +49,17 @@ PERSON_NO_NAME = {
     },
 }
 
+# Matched by phone, no usable name, but DOES carry an email so the follow-up
+# email stage has something to query.
+PERSON_NO_NAME_WITH_EMAIL = {
+    "id": {"record_id": "person-3"},
+    "values": {
+        "name": [None],
+        "email_addresses": [{"email_address": "jane@acme.com", "active_until": None}],
+        "phone_numbers": [{"phone_number": "+14155551234"}],
+    },
+}
+
 COMPANY = {
     "id": {"record_id": "co-1"},
     "values": {"name": [{"value": "Acme Corp", "attribute_type": "text"}]},
@@ -321,6 +332,106 @@ class NoWebhookSideEffectTests(unittest.TestCase):
         src = Path(resolver.__file__).read_text(encoding="utf-8")
         self.assertNotIn("webhook_server", src)
         self.assertNotIn("import webhook", src)
+
+
+class CodexP2RegressionTests(unittest.TestCase):
+    """Regression coverage for the five Codex P2 findings on PR #97."""
+
+    # P2-1: a non-string phone must degrade, never raise (TypeError in re.sub).
+    def test_numeric_phone_does_not_raise(self):
+        # No API key -> no network; the entrypoint must still return a contract.
+        with patch.dict("os.environ", {}, clear=True):
+            out = resolver.resolve_identity(14155201316)  # int, not str
+        self.assertEqual(set(out), {"identity", "confidence", "sources"})
+        self.assertEqual(out["confidence"], "low")
+
+    def test_numeric_phone_is_coerced_and_can_match(self):
+        # A coerced numeric phone still reaches Attio and can resolve high.
+        fake = make_fake_request(person_for_phone=PERSON_FULL)
+        with with_key(), patch.object(attio, "_request", side_effect=fake):
+            out = resolver.resolve_identity(14155201316)
+        self.assertEqual(out["confidence"], "high")
+        self.assertEqual(out["identity"]["name"], "Jane Doe")
+        self.assertIn("attio_phone", out["sources"])
+
+    def test_non_string_email_does_not_raise(self):
+        with patch.dict("os.environ", {}, clear=True):
+            out = resolver.resolve_identity("+14155550000", email=12345)
+        self.assertEqual(out["confidence"], "low")
+        self.assertIsNone(out["identity"]["email"])
+
+    # P2-2: an Attio phone match with no usable name is medium even when Dialpad
+    # already supplied a name, AND the email follow-up still runs.
+    def test_attio_no_name_stays_medium_despite_dialpad_name(self):
+        fake = make_fake_request(person_for_phone=PERSON_NO_NAME)
+        contact = {"name": "Dialpad Jane"}
+        with with_key(), patch.object(attio, "_request", side_effect=fake):
+            out = resolver.resolve_identity("+14155551234", dialpad_contact=contact)
+        # Dialpad name is retained, but confidence is NOT promoted to high.
+        self.assertEqual(out["confidence"], "medium")
+        self.assertEqual(out["identity"]["name"], "Dialpad Jane")
+        self.assertIn("attio_phone", out["sources"])
+
+    def test_attio_no_name_runs_email_followup_and_promotes(self):
+        # Phone match has no name but yields an email; the email stage then finds a
+        # named person and promotes to high. This only works if the no-name phone
+        # match did NOT short-circuit on the pre-existing Dialpad name.
+        fake = make_fake_request(
+            person_for_phone=PERSON_NO_NAME_WITH_EMAIL,
+            person_for_email=PERSON_FULL,
+        )
+        contact = {"name": "Dialpad Jane"}
+        with with_key(), patch.object(attio, "_request", side_effect=fake):
+            out = resolver.resolve_identity("+14155551234", dialpad_contact=contact)
+        self.assertEqual(out["confidence"], "high")
+        self.assertEqual(out["identity"]["name"], "Jane Doe")
+        self.assertIn("attio_phone", out["sources"])
+        self.assertIn("attio_email", out["sources"])
+
+    # P2-3: a Dialpad contact's emails[] array seeds the email stage.
+    def test_dialpad_emails_array_seeds_email_stage(self):
+        fake = make_fake_request(person_for_phone=None, person_for_email=PERSON_FULL)
+        contact = {"emails": ["jane@acme.com"]}
+        with with_key(), patch.object(attio, "_request", side_effect=fake):
+            out = resolver.resolve_identity("+14155559999", dialpad_contact=contact)
+        self.assertEqual(out["confidence"], "high")
+        self.assertEqual(out["identity"]["email"], "jane@acme.com")
+        self.assertIn("attio_email", out["sources"])
+
+    def test_dialpad_singular_email_preferred_over_emails_array(self):
+        contact = {"email": "primary@acme.com", "emails": ["secondary@acme.com"]}
+        with patch.dict("os.environ", {}, clear=True):
+            out = resolver.resolve_identity("+14155550000", dialpad_contact=contact)
+        self.assertEqual(out["identity"]["email"], "primary@acme.com")
+
+    def test_dialpad_emails_array_non_string_entry_ignored(self):
+        contact = {"emails": [12345]}
+        with patch.dict("os.environ", {}, clear=True):
+            out = resolver.resolve_identity("+14155550000", dialpad_contact=contact)
+        self.assertIsNone(out["identity"]["email"])
+
+    # P2-4: a real miss records its lookup source, not the misleading no_input.
+    def test_phone_not_found_records_source_not_no_input(self):
+        fake = make_fake_request(person_for_phone=None, person_for_email=None)
+        with with_key(), patch.object(attio, "_request", side_effect=fake):
+            out = resolver.resolve_identity("+14155551111")
+        self.assertEqual(out["confidence"], "low")
+        self.assertIn("attio_phone_not_found", out["sources"])
+        self.assertNotIn("no_input", out["sources"])
+
+    def test_email_not_found_records_source(self):
+        # Phone misses; a caller email is supplied but Attio matches nothing.
+        fake = make_fake_request(person_for_phone=None, person_for_email=None)
+        with with_key(), patch.object(attio, "_request", side_effect=fake):
+            out = resolver.resolve_identity("+14155551111", email="ghost@acme.com")
+        self.assertIn("attio_phone_not_found", out["sources"])
+        self.assertIn("attio_email_not_found", out["sources"])
+        self.assertNotIn("no_input", out["sources"])
+
+    def test_no_input_only_when_nothing_to_resolve_from(self):
+        with patch.dict("os.environ", {}, clear=True):
+            out = resolver.resolve_identity(None)
+        self.assertEqual(out["sources"], ["no_input"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Adds a standalone, importable library `scripts/adapters/identity_resolver.py` exposing one entrypoint:

```python
resolve_identity(phone, dialpad_contact=None, email=None)
  -> {"identity": {name, first_name, last_name, email, company},
      "confidence": "high"|"medium"|"low",
      "sources": [...]}
```

It runs a cheap→expensive cascade, short-circuiting on a confident hit and recording each step in `sources[]`:

1. Caller-supplied `dialpad_contact` dict (no Dialpad HTTP — the caller owns that lookup).
2. Attio phone match via `attio_context.find_person_by_phone`.
3. Attio email match via `attio_context.find_person_by_email` (only once an email is known).

Adds three side-effect-free people-field helpers to `scripts/adapters/attio_context.py` built to the confirmed live Attio people shapes: `person_name_parts` (name list → first/last/full), `person_primary_email` (email_addresses list, lower-cased), `person_company_name` (direct `company` ref).

Confidence mapping mirrors the webhook's vocabulary: **high** = exact Attio phone match resolving a usable name; **medium** = Dialpad-contact name only, or Attio person matched but no usable name; **low** = nothing resolved / Attio degraded or errored.

## Why

S2 of the Dialpad SMS enrichment program: resolve an inbound sender to a compact identity cheaply, reusing the existing Attio client instead of re-querying live for every consumer.

**Auto-merge tier guarantees honored:**
- Standalone and import-safe: does **not** import or modify `webhook_server.py`.
- Network-free except Attio; with `ATTIO_API_KEY` unset it makes zero network calls and returns `low`.
- Fails closed (mirrors `attio_context`'s `AttioError` discipline): Attio errors record `attio_error` in `sources`, never elevate confidence, fall back to any `dialpad_contact` name, and never raise to the caller.
- Malformed records (`email_addresses` not-a-list, `name: [None]`, non-dict refs, non-string Dialpad fields) are handled without crashing or polluting the contract.

**Adversarial-review flags honored:**
- Module docstring warns that S3 must **not** auto-promote a `high` resolver result into customer-facing name/company without re-applying the wrong-match guard in `docs/solutions/ungate-enrichment-customer-pii.md` (a `high` is a single `limit=1` phone match with no collision check).
- A correctness-review pass caught a fail-closed gap (non-string Dialpad `first_name`/`last_name` reaching `str.join` → `TypeError`); fixed with type-guarded `_clean_str` and covered by tests.

## Tests

pytest under `tests/`, Attio HTTP mocked at `attio_context._request` (mirrors `tests/test_attio_context.py`'s `fake_request` pattern) — never hits live Attio.

Exact command:

```
/run/current-system/sw/bin/python3 -m pytest tests/ -q
```

- New file `tests/test_identity_resolver.py`: 28 tests, all passing. Covers attio_phone_high, dialpad_only_medium, email_followup_high (incl. short-circuit on high phone match), not_found_low, attio_degraded_low (phone + email stages), person-field extraction on the confirmed shapes, malformed records, non-string Dialpad fields, secret-never-leaks, and import-safe/network-free.
- Full suite: **27 failed, 353 passed**. The 27 failures are the documented pre-existing baseline in `test_sender_enrichment.py` (27 on clean `main`); this branch introduces **no new failures** (failing set is byte-identical to baseline) and adds 28 passing tests.

## AI Assistance

Implemented by Claude (Opus 4.8). A `ce-correctness-reviewer` sub-agent reviewed the diff and surfaced a fail-closed `TypeError` on non-string Dialpad name fields plus a type-pollution path; both were fixed and regression-tested before shipping.

https://claude.ai/code/session_01FM3qqE97VHRBHVr4N2kFyw