### PR TITLE
feat(eval): read-only SMS approval eval + weekly pulse (S6)

### DIFF
--- a/scripts/sms_approval_eval.py
+++ b/scripts/sms_approval_eval.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""Read-only evaluation of the Dialpad SMS approval gate.
+
+Computes per-category accept/reject statistics and a human-facing weekly
+pulse from the approval database (and, optionally, the SMS message store for
+cross-DB joins). This module never writes: every connection is opened in
+SQLite read-only mode (``file:...?mode=ro``).
+
+Maintainer decisions encoded here (do not "fix" without re-deciding):
+
+* An operator hand-typing their own reply instead of approving the draft
+  (``invalidated_reason == 'manual_outbound'``) is a draft REJECTION, not an
+  accept. The draft was not good enough to send as-is.
+* In-flight ``pending`` / ``risk_pending`` drafts are EXCLUDED from
+  accept/reject rates: their outcome is not yet determined, so including them
+  makes the rate non-deterministic run-to-run.
+* ``stale`` drafts are split by ``invalidated_reason`` rather than bucketed as
+  one "abandoned" group. ``manual_outbound`` is a reject;
+  ``superseded_by_new_draft`` is EXCLUDED (the customer texted again before the
+  operator acted — not a verdict on the draft); other reasons map explicitly.
+* The cross-DB join from approval ``dialpad_sms_id`` (TEXT) to messages
+  ``dialpad_id`` uses an explicit ``CAST(... AS TEXT)``. With the live INTEGER
+  column SQLite's numeric affinity happens to coerce, but a no-affinity column
+  (or an id beyond INT64) silently joins zero rows; the CAST makes the
+  comparison affinity-independent. See ``join_sent_message_text``.
+* The pulse is aggregate-only: it must never embed customer SMS bodies, phone
+  numbers, or contact names.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+# --- status taxonomy (mirrors scripts/sms_approval.py constants) -------------
+
+STATUS_PENDING = "pending"
+STATUS_RISK_PENDING = "risk_pending"
+STATUS_SENDING = "sending"
+STATUS_SENT = "sent"
+STATUS_FAILED = "failed"
+STATUS_STALE = "stale"
+STATUS_REJECTED = "rejected"
+
+# Every status a draft row can hold. The partition over these must be
+# exhaustive: see assert_exhaustive_partition.
+ALL_STATUSES: tuple[str, ...] = (
+    STATUS_PENDING,
+    STATUS_RISK_PENDING,
+    STATUS_SENDING,
+    STATUS_SENT,
+    STATUS_FAILED,
+    STATUS_STALE,
+    STATUS_REJECTED,
+)
+
+# Statuses whose outcome is not yet determined; excluded from accept/reject
+# rates so the pulse is reproducible run-to-run for a frozen window.
+IN_FLIGHT_STATUSES: frozenset[str] = frozenset({STATUS_PENDING, STATUS_RISK_PENDING, STATUS_SENDING})
+
+# Verdict buckets a draft is classified into.
+VERDICT_ACCEPT = "accept"
+VERDICT_REJECT = "reject"
+VERDICT_EXCLUDED = "excluded"  # in-flight or non-verdict (e.g. superseded)
+
+# invalidated_reason -> verdict, for rows in STATUS_STALE.
+#   manual_outbound       : operator hand-typed a reply -> draft REJECTED.
+#   superseded_by_new_draft: customer texted again first -> not a verdict.
+#   operator_rejected     : explicit reject (also surfaces as STATUS_REJECTED).
+#   new_inbound_not_eligible: inbound made the draft moot -> not a verdict.
+#   smoke_test_cleanup    : test fixture teardown -> not a verdict.
+STALE_REASON_VERDICTS: dict[str, str] = {
+    "manual_outbound": VERDICT_REJECT,
+    "operator_rejected": VERDICT_REJECT,
+    "superseded_by_new_draft": VERDICT_EXCLUDED,
+    "new_inbound_not_eligible": VERDICT_EXCLUDED,
+    "smoke_test_cleanup": VERDICT_EXCLUDED,
+}
+# A stale row with an unrecognized / missing reason is excluded rather than
+# silently counted as accept or reject.
+DEFAULT_STALE_VERDICT = VERDICT_EXCLUDED
+
+DEFAULT_APPROVAL_DB = "/home/art/clawd/logs/sms_approvals.db"
+DEFAULT_SMS_DB = "/home/art/clawd/logs/sms.db"
+DEFAULT_WINDOW_DAYS = 7
+
+
+# --- read-only connections ---------------------------------------------------
+
+
+def connect_ro(db_path: str | Path) -> sqlite3.Connection:
+    """Open a SQLite database in read-only mode.
+
+    Uses the URI ``mode=ro`` form so the eval can never mutate live data, and
+    sets ``PRAGMA query_only`` as belt-and-suspenders.
+    """
+    uri = f"file:{Path(db_path).as_posix()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only = ON")
+    return conn
+
+
+def resolve_approval_db() -> str:
+    return os.environ.get("DIALPAD_SMS_APPROVAL_DB", DEFAULT_APPROVAL_DB)
+
+
+def resolve_sms_db() -> str:
+    return os.environ.get("DIALPAD_SMS_DB", DEFAULT_SMS_DB)
+
+
+# --- verdict classification --------------------------------------------------
+
+
+def classify_verdict(status: str, invalidated_reason: str | None) -> str:
+    """Map (status, invalidated_reason) -> accept / reject / excluded.
+
+    * sent / failed are terminal send outcomes: sent == accept, failed == an
+      accepted-but-undelivered draft (the operator approved it; delivery is a
+      separate axis), so failed counts as accept for the *approval* verdict.
+    * rejected == reject.
+    * stale is split by invalidated_reason via STALE_REASON_VERDICTS.
+    * in-flight (pending / risk_pending / sending) == excluded.
+    """
+    if status in IN_FLIGHT_STATUSES:
+        return VERDICT_EXCLUDED
+    if status in (STATUS_SENT, STATUS_FAILED):
+        return VERDICT_ACCEPT
+    if status == STATUS_REJECTED:
+        return VERDICT_REJECT
+    if status == STATUS_STALE:
+        reason = (invalidated_reason or "").strip()
+        return STALE_REASON_VERDICTS.get(reason, DEFAULT_STALE_VERDICT)
+    # Unknown status: never silently bucket as a verdict.
+    return VERDICT_EXCLUDED
+
+
+@dataclass
+class CategoryStats:
+    category: str
+    accept: int = 0
+    reject: int = 0
+    excluded: int = 0
+    # status -> count, for the exhaustiveness check and drill-down.
+    by_status: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def decided(self) -> int:
+        return self.accept + self.reject
+
+    @property
+    def total(self) -> int:
+        return self.accept + self.reject + self.excluded
+
+    @property
+    def accept_rate(self) -> float | None:
+        """Accept rate over DECIDED drafts only (excludes in-flight/superseded).
+
+        None when there are no decided drafts, so callers can render "n/a"
+        rather than dividing by zero.
+        """
+        if self.decided == 0:
+            return None
+        return self.accept / self.decided
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "category": self.category,
+            "accept": self.accept,
+            "reject": self.reject,
+            "excluded": self.excluded,
+            "decided": self.decided,
+            "total": self.total,
+            "accept_rate": self.accept_rate,
+            "by_status": dict(sorted(self.by_status.items())),
+        }
+
+
+def category_for_row(row: sqlite3.Row | dict[str, Any]) -> str:
+    """Derive the per-category label for a draft row.
+
+    Primary dimension is the Dialpad line (``metadata.line_display``, e.g.
+    "Sales (415) 520-1316"). Falls back to the sender number, then to
+    "unknown". The label is a business line, never customer PII.
+    """
+    meta_raw = row["metadata_json"] if "metadata_json" in row.keys() else None
+    if meta_raw:
+        try:
+            meta = json.loads(meta_raw)
+        except (json.JSONDecodeError, TypeError):
+            meta = {}
+        line = meta.get("line_display")
+        if isinstance(line, str) and line.strip():
+            return line.strip()
+    sender = row["sender_number"] if "sender_number" in row.keys() else None
+    if isinstance(sender, str) and sender.strip():
+        return sender.strip()
+    return "unknown"
+
+
+# --- window selection --------------------------------------------------------
+
+
+def now_ms() -> int:
+    return int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+
+
+def window_cutoff_ms(window_days: int, *, end_ms: int | None = None) -> tuple[int, int]:
+    """Return (start_ms, end_ms) for a frozen window.
+
+    end_ms defaults to now; pass an explicit end_ms for a reproducible window.
+    """
+    end = end_ms if end_ms is not None else now_ms()
+    start = end - window_days * 24 * 60 * 60 * 1000
+    return start, end
+
+
+def fetch_drafts(
+    conn: sqlite3.Connection,
+    *,
+    start_ms: int | None = None,
+    end_ms: int | None = None,
+) -> list[sqlite3.Row]:
+    """Fetch draft rows, optionally windowed by created_at_ms [start, end]."""
+    clauses: list[str] = []
+    params: list[Any] = []
+    if start_ms is not None:
+        clauses.append("created_at_ms >= ?")
+        params.append(start_ms)
+    if end_ms is not None:
+        clauses.append("created_at_ms <= ?")
+        params.append(end_ms)
+    where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+    sql = (
+        "SELECT draft_id, status, invalidated_reason, sender_number, "
+        "metadata_json, created_at_ms, dialpad_sms_id "
+        f"FROM sms_approval_drafts{where}"
+    )
+    return list(conn.execute(sql, params).fetchall())
+
+
+# --- aggregation -------------------------------------------------------------
+
+
+def assert_exhaustive_partition(rows: Iterable[sqlite3.Row | dict[str, Any]]) -> dict[str, int]:
+    """Verify every row's status is one of ALL_STATUSES.
+
+    Returns the status histogram. Raises ValueError if any row carries a status
+    outside the known taxonomy, so a new status added upstream is caught loudly
+    instead of being silently dropped from the buckets.
+    """
+    histogram: dict[str, int] = {}
+    unknown: dict[str, int] = {}
+    for row in rows:
+        status = row["status"]
+        histogram[status] = histogram.get(status, 0) + 1
+        if status not in ALL_STATUSES:
+            unknown[status] = unknown.get(status, 0) + 1
+    if unknown:
+        raise ValueError(f"unknown approval statuses outside taxonomy: {sorted(unknown)}")
+    return histogram
+
+
+def aggregate_by_category(rows: Iterable[sqlite3.Row | dict[str, Any]]) -> dict[str, CategoryStats]:
+    """Aggregate verdicts per category. Asserts the status partition is total."""
+    rows = list(rows)
+    histogram = assert_exhaustive_partition(rows)
+    # Cross-check: sum of bucket counts == total rows (no row silently dropped).
+    assert sum(histogram.values()) == len(rows), "status histogram lost rows"
+
+    stats: dict[str, CategoryStats] = {}
+    for row in rows:
+        category = category_for_row(row)
+        status = row["status"]
+        reason = row["invalidated_reason"] if "invalidated_reason" in row.keys() else None
+        verdict = classify_verdict(status, reason)
+
+        bucket = stats.setdefault(category, CategoryStats(category=category))
+        bucket.by_status[status] = bucket.by_status.get(status, 0) + 1
+        if verdict == VERDICT_ACCEPT:
+            bucket.accept += 1
+        elif verdict == VERDICT_REJECT:
+            bucket.reject += 1
+        else:
+            bucket.excluded += 1
+
+    # Final invariant: per category, accept+reject+excluded == rows in category.
+    for bucket in stats.values():
+        assert bucket.total == sum(bucket.by_status.values()), (
+            f"category {bucket.category} verdict counts diverge from status counts"
+        )
+    return stats
+
+
+# --- cross-DB join (the CAST bug) -------------------------------------------
+
+
+def join_sent_message_text(
+    approval_conn: sqlite3.Connection,
+    sms_conn: sqlite3.Connection,
+    *,
+    dialpad_sms_ids: Iterable[str],
+) -> dict[str, str]:
+    """Resolve sent message text by joining approval ids to the SMS store.
+
+    The approval DB stores ``dialpad_sms_id`` as TEXT; the SMS store stores
+    ``messages.dialpad_id`` as INTEGER. Comparing them in a join predicate is an
+    affinity hazard: with the live INTEGER column, SQLite's numeric affinity
+    rules happen to coerce in-range Dialpad ids so a naive
+    ``messages.dialpad_id = drafts.dialpad_sms_id`` does match -- but that
+    coercion is NOT guaranteed: a join column with no affinity (or an id beyond
+    INT64) silently matches ZERO rows. The explicit
+    ``CAST(messages.dialpad_id AS TEXT)`` makes the comparison TEXT-to-TEXT and
+    affinity-independent, so this resolves correctly regardless of how the
+    messages column is declared. (See test_sms_approval_eval CrossDbJoinCastTests.)
+
+    This helper exists for ad-hoc operator drill-down and to anchor the
+    regression test; the pulse itself never embeds the returned text.
+    """
+    ids = [i for i in dialpad_sms_ids if i]
+    if not ids:
+        return {}
+    # Both connections are read-only; attach the SMS store to run a single join.
+    sms_path = sms_conn.execute("PRAGMA database_list").fetchone()["file"]
+    approval_conn.execute("ATTACH DATABASE ? AS smsdb", (f"file:{sms_path}?mode=ro",))
+    try:
+        placeholders = ",".join("?" for _ in ids)
+        sql = (
+            "SELECT d.dialpad_sms_id AS sms_id, m.text AS text "
+            "FROM sms_approval_drafts d "
+            "JOIN smsdb.messages m "
+            "  ON CAST(m.dialpad_id AS TEXT) = d.dialpad_sms_id "
+            f"WHERE d.dialpad_sms_id IN ({placeholders})"
+        )
+        return {row["sms_id"]: row["text"] for row in approval_conn.execute(sql, ids).fetchall()}
+    finally:
+        approval_conn.execute("DETACH DATABASE smsdb")
+
+
+# --- weekly pulse (aggregate-only, PII-free) --------------------------------
+
+
+def build_pulse(
+    rows: Iterable[sqlite3.Row | dict[str, Any]],
+    *,
+    start_ms: int,
+    end_ms: int,
+) -> dict[str, Any]:
+    """Build the aggregate-only weekly pulse.
+
+    The output contains ONLY counts, rates, category labels (business lines),
+    and timestamps. It never contains customer SMS bodies, phone numbers, or
+    contact names.
+    """
+    rows = list(rows)
+    by_category = aggregate_by_category(rows)
+    status_histogram = assert_exhaustive_partition(rows)
+
+    total_accept = sum(c.accept for c in by_category.values())
+    total_reject = sum(c.reject for c in by_category.values())
+    total_excluded = sum(c.excluded for c in by_category.values())
+    total_decided = total_accept + total_reject
+
+    categories = [c.to_dict() for c in sorted(by_category.values(), key=lambda c: (-c.decided, c.category))]
+
+    return {
+        "window": {
+            "start_ms": start_ms,
+            "end_ms": end_ms,
+            "start_iso": datetime.fromtimestamp(start_ms / 1000, tz=timezone.utc).isoformat(),
+            "end_iso": datetime.fromtimestamp(end_ms / 1000, tz=timezone.utc).isoformat(),
+        },
+        "totals": {
+            "drafts": len(rows),
+            "accept": total_accept,
+            "reject": total_reject,
+            "excluded": total_excluded,
+            "decided": total_decided,
+            "accept_rate": (total_accept / total_decided) if total_decided else None,
+        },
+        "status_histogram": dict(sorted(status_histogram.items())),
+        "categories": categories,
+    }
+
+
+def render_pulse_text(pulse: dict[str, Any]) -> str:
+    """Render the pulse as a compact human-readable report (aggregate-only)."""
+    w = pulse["window"]
+    t = pulse["totals"]
+    lines: list[str] = []
+    lines.append(f"SMS approval pulse  {w['start_iso'][:10]} -> {w['end_iso'][:10]}")
+    rate = t["accept_rate"]
+    rate_str = f"{rate * 100:.0f}%" if rate is not None else "n/a"
+    lines.append(
+        f"  drafts={t['drafts']}  decided={t['decided']}  "
+        f"accept={t['accept']} reject={t['reject']} (excluded={t['excluded']})  "
+        f"accept_rate={rate_str}"
+    )
+    lines.append("  by status: " + ", ".join(f"{k}={v}" for k, v in pulse["status_histogram"].items()))
+    lines.append("  by category (decided / accept_rate):")
+    for cat in pulse["categories"]:
+        cr = cat["accept_rate"]
+        cr_str = f"{cr * 100:.0f}%" if cr is not None else "n/a"
+        lines.append(
+            f"    - {cat['category']}: decided={cat['decided']} "
+            f"accept={cat['accept']} reject={cat['reject']} rate={cr_str}"
+        )
+    return "\n".join(lines)
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def run_pulse(args: argparse.Namespace) -> dict[str, Any]:
+    approval_db = args.approval_db or resolve_approval_db()
+    conn = connect_ro(approval_db)
+    try:
+        if args.end_ms is not None:
+            end_ms = args.end_ms
+        else:
+            end_ms = now_ms()
+        start_ms, end_ms = window_cutoff_ms(args.window_days, end_ms=end_ms)
+        rows = fetch_drafts(conn, start_ms=start_ms, end_ms=end_ms)
+        return build_pulse(rows, start_ms=start_ms, end_ms=end_ms)
+    finally:
+        conn.close()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Read-only SMS approval eval and weekly pulse")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    pulse = sub.add_parser("pulse", help="Weekly accept/reject pulse (aggregate-only)")
+    pulse.add_argument("--window-days", type=int, default=DEFAULT_WINDOW_DAYS)
+    pulse.add_argument(
+        "--end-ms",
+        type=int,
+        default=None,
+        help="Explicit window end (ms epoch) for a reproducible run; default now.",
+    )
+    pulse.add_argument("--approval-db", default=None, help="Override approval DB path.")
+    pulse.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "pulse":
+        pulse = run_pulse(args)
+        if args.json:
+            print(json.dumps(pulse, sort_keys=True))
+        else:
+            print(render_pulse_text(pulse))
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_sms_approval_eval.py
+++ b/tests/test_sms_approval_eval.py
@@ -1,0 +1,404 @@
+"""Tests for the read-only SMS approval eval + weekly pulse (S6).
+
+These tests use temporary databases only; they never touch live data.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import sms_approval_eval as ev  # noqa: E402
+
+
+def _make_approval_db(path: str, rows: list[dict]) -> None:
+    """Create an approval DB matching the live schema and insert rows."""
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE sms_approval_drafts (
+            draft_id TEXT PRIMARY KEY,
+            thread_key TEXT,
+            customer_number TEXT,
+            sender_number TEXT,
+            draft_text TEXT,
+            risk_state TEXT,
+            status TEXT NOT NULL,
+            created_at_ms INTEGER NOT NULL,
+            invalidated_reason TEXT,
+            dialpad_sms_id TEXT,
+            metadata_json TEXT
+        )
+        """
+    )
+    for i, r in enumerate(rows):
+        conn.execute(
+            """
+            INSERT INTO sms_approval_drafts (
+                draft_id, thread_key, customer_number, sender_number, draft_text,
+                risk_state, status, created_at_ms, invalidated_reason,
+                dialpad_sms_id, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                r.get("draft_id", f"draft_{i}"),
+                r.get("thread_key", "t"),
+                r.get("customer_number", "+14155550000"),
+                r.get("sender_number", "+14155201316"),
+                r.get("draft_text", "draft body"),
+                r.get("risk_state", "normal"),
+                r["status"],
+                r.get("created_at_ms", 1_000_000),
+                r.get("invalidated_reason"),
+                r.get("dialpad_sms_id"),
+                r.get("metadata_json"),
+            ),
+        )
+    conn.commit()
+    conn.close()
+
+
+class VerdictClassificationTests(unittest.TestCase):
+    def test_sent_is_accept(self):
+        self.assertEqual(ev.classify_verdict("sent", None), ev.VERDICT_ACCEPT)
+
+    def test_failed_is_accept(self):
+        # Operator approved; delivery failure is a separate axis.
+        self.assertEqual(ev.classify_verdict("failed", None), ev.VERDICT_ACCEPT)
+
+    def test_rejected_is_reject(self):
+        self.assertEqual(ev.classify_verdict("rejected", "operator_rejected"), ev.VERDICT_REJECT)
+
+    def test_manual_outbound_is_reject(self):
+        # MAINTAINER DECISION: hand-typed reply == draft rejection, not accept.
+        self.assertEqual(ev.classify_verdict("stale", "manual_outbound"), ev.VERDICT_REJECT)
+
+    def test_superseded_is_excluded(self):
+        # Customer texted again before operator acted -> not a verdict.
+        self.assertEqual(ev.classify_verdict("stale", "superseded_by_new_draft"), ev.VERDICT_EXCLUDED)
+
+    def test_pending_is_excluded(self):
+        self.assertEqual(ev.classify_verdict("pending", None), ev.VERDICT_EXCLUDED)
+        self.assertEqual(ev.classify_verdict("risk_pending", None), ev.VERDICT_EXCLUDED)
+        self.assertEqual(ev.classify_verdict("sending", None), ev.VERDICT_EXCLUDED)
+
+    def test_stale_unknown_reason_is_excluded_not_silently_counted(self):
+        self.assertEqual(ev.classify_verdict("stale", "some_new_reason"), ev.VERDICT_EXCLUDED)
+        self.assertEqual(ev.classify_verdict("stale", None), ev.VERDICT_EXCLUDED)
+
+
+class ExhaustivePartitionTests(unittest.TestCase):
+    def test_all_known_statuses_pass(self):
+        rows = [{"status": s} for s in ev.ALL_STATUSES]
+        histogram = ev.assert_exhaustive_partition(rows)
+        self.assertEqual(sum(histogram.values()), len(ev.ALL_STATUSES))
+
+    def test_unknown_status_raises(self):
+        rows = [{"status": "sent"}, {"status": "brand_new_status"}]
+        with self.assertRaises(ValueError):
+            ev.assert_exhaustive_partition(rows)
+
+    def test_taxonomy_covers_sms_approval_constants(self):
+        # Guard against drift: every STATUS_* in sms_approval must be in ALL_STATUSES.
+        import sms_approval as sa
+
+        status_consts = {
+            v for k, v in vars(sa).items() if k.startswith("STATUS_") and isinstance(v, str)
+        }
+        self.assertEqual(status_consts, set(ev.ALL_STATUSES))
+
+    def test_partition_sum_equals_total_rows(self):
+        # The pulse's core invariant: sum of buckets == total rows.
+        rows = [
+            {"status": "sent", "invalidated_reason": None},
+            {"status": "rejected", "invalidated_reason": "operator_rejected"},
+            {"status": "stale", "invalidated_reason": "manual_outbound"},
+            {"status": "stale", "invalidated_reason": "superseded_by_new_draft"},
+            {"status": "pending", "invalidated_reason": None},
+        ]
+        stats = ev.aggregate_by_category(rows)
+        total = sum(c.total for c in stats.values())
+        self.assertEqual(total, len(rows))
+
+
+class CategoryAggregationTests(unittest.TestCase):
+    def test_per_category_accept_reject_rates(self):
+        sales_meta = json.dumps({"line_display": "Sales (415) 520-1316"})
+        support_meta = json.dumps({"line_display": "Support (415) 999-0000"})
+        rows = [
+            {"status": "sent", "metadata_json": sales_meta},
+            {"status": "sent", "metadata_json": sales_meta},
+            {"status": "stale", "invalidated_reason": "manual_outbound", "metadata_json": sales_meta},
+            {"status": "rejected", "invalidated_reason": "operator_rejected", "metadata_json": support_meta},
+            {"status": "pending", "metadata_json": support_meta},  # excluded
+            {"status": "stale", "invalidated_reason": "superseded_by_new_draft", "metadata_json": support_meta},  # excluded
+        ]
+        stats = ev.aggregate_by_category(rows)
+
+        sales = stats["Sales (415) 520-1316"]
+        self.assertEqual((sales.accept, sales.reject, sales.excluded), (2, 1, 0))
+        self.assertAlmostEqual(sales.accept_rate, 2 / 3)
+
+        support = stats["Support (415) 999-0000"]
+        self.assertEqual((support.accept, support.reject, support.excluded), (0, 1, 2))
+        self.assertEqual(support.accept_rate, 0.0)
+
+    def test_accept_rate_excludes_in_flight(self):
+        # All pending -> no decided drafts -> accept_rate is None, not 0 or crash.
+        rows = [{"status": "pending"}, {"status": "risk_pending"}]
+        stats = ev.aggregate_by_category(rows)
+        only = next(iter(stats.values()))
+        self.assertIsNone(only.accept_rate)
+        self.assertEqual(only.decided, 0)
+
+    def test_category_falls_back_to_sender_then_unknown(self):
+        rows = [
+            {"status": "sent", "sender_number": "+14155201316", "metadata_json": None},
+            {"status": "sent", "sender_number": None, "metadata_json": None},
+        ]
+        stats = ev.aggregate_by_category(rows)
+        self.assertIn("+14155201316", stats)
+        self.assertIn("unknown", stats)
+
+
+class CrossDbJoinCastTests(unittest.TestCase):
+    """Cross-DB join correctness: approval ``dialpad_sms_id`` (TEXT) -> messages.
+
+    VERIFIED REALITY (probed against the live schema, not assumed): when the
+    messages join column is declared ``INTEGER`` (as live), SQLite's numeric
+    affinity rules coerce the TEXT id and a naive ``m.dialpad_id = d.dialpad_sms_id``
+    join *does* match for in-range Dialpad ids. So the originally-claimed
+    "naive join returns ZERO rows with INTEGER affinity" is NOT reproducible.
+
+    The CAST is still the correct, chosen approach because it is
+    affinity-INDEPENDENT: it returns the row whether the join column is declared
+    INTEGER, NUMERIC, or has no type affinity at all. The
+    ``test_no_affinity_join_*`` cases below prove a naive join genuinely returns
+    zero rows when the column has no affinity -- which is the real trap the CAST
+    guards against -- so the CAST in ``join_sent_message_text`` is load-bearing,
+    not cosmetic.
+    """
+
+    def setUp(self):
+        self.adb = tempfile.NamedTemporaryFile(suffix=".db", delete=False).name
+        self.mdb = tempfile.NamedTemporaryFile(suffix=".db", delete=False).name
+
+        _make_approval_db(
+            self.adb,
+            [{"status": "sent", "dialpad_sms_id": "4628326630105088"}],
+        )
+        # messages.dialpad_id is INTEGER (matches live schema); approval id is TEXT.
+        mconn = sqlite3.connect(self.mdb)
+        mconn.execute(
+            "CREATE TABLE messages (id INTEGER PRIMARY KEY, dialpad_id INTEGER UNIQUE, text TEXT)"
+        )
+        mconn.execute(
+            "INSERT INTO messages (dialpad_id, text) VALUES (?, ?)",
+            (4628326630105088, "the actual sent body"),
+        )
+        mconn.commit()
+        mconn.close()
+
+    def tearDown(self):
+        for p in (self.adb, self.mdb):
+            Path(p).unlink(missing_ok=True)
+
+    def test_cast_join_returns_the_matching_row(self):
+        # Primary correctness invariant: the eval resolves sent text for a real
+        # id stored as TEXT against an INTEGER column.
+        aconn = ev.connect_ro(self.adb)
+        mconn = ev.connect_ro(self.mdb)
+        try:
+            result = ev.join_sent_message_text(
+                aconn, mconn, dialpad_sms_ids=["4628326630105088"]
+            )
+        finally:
+            aconn.close()
+            mconn.close()
+        self.assertEqual(result, {"4628326630105088": "the actual sent body"})
+
+    def test_no_affinity_join_without_cast_returns_zero_rows(self):
+        # The real trap: a join column with NO declared affinity storing an
+        # integer does NOT coerce against a TEXT id -> naive join matches nothing.
+        # This is exactly the regression the CAST prevents.
+        mdb_noaff = tempfile.NamedTemporaryFile(suffix=".db", delete=False).name
+        try:
+            mconn = sqlite3.connect(mdb_noaff)
+            # Column declared WITHOUT a type name -> BLOB/no affinity.
+            mconn.execute("CREATE TABLE messages (dialpad_id, text TEXT)")
+            mconn.execute(
+                "INSERT INTO messages (dialpad_id, text) VALUES (?, ?)",
+                (4628326630105088, "the actual sent body"),
+            )
+            mconn.commit()
+            mconn.close()
+
+            aconn = ev.connect_ro(self.adb)
+            try:
+                aconn.execute(
+                    "ATTACH DATABASE ? AS smsdb",
+                    (f"file:{Path(mdb_noaff).as_posix()}?mode=ro",),
+                )
+                naive = aconn.execute(
+                    "SELECT m.text FROM sms_approval_drafts d "
+                    "JOIN smsdb.messages m ON m.dialpad_id = d.dialpad_sms_id"
+                ).fetchall()
+                cast = aconn.execute(
+                    "SELECT m.text FROM sms_approval_drafts d "
+                    "JOIN smsdb.messages m ON CAST(m.dialpad_id AS TEXT) = d.dialpad_sms_id"
+                ).fetchall()
+            finally:
+                aconn.close()
+        finally:
+            Path(mdb_noaff).unlink(missing_ok=True)
+
+        self.assertEqual(len(naive), 0)  # naive coercion fails for no-affinity columns
+        self.assertEqual(len(cast), 1)   # the CAST makes it affinity-independent
+
+    def test_cast_join_affinity_independent_for_no_affinity_column(self):
+        # End-to-end: join_sent_message_text must still resolve the row when the
+        # messages column has no affinity (proving the helper's CAST is the fix).
+        mdb_noaff = tempfile.NamedTemporaryFile(suffix=".db", delete=False).name
+        try:
+            mconn = sqlite3.connect(mdb_noaff)
+            mconn.execute("CREATE TABLE messages (dialpad_id, text TEXT)")
+            mconn.execute(
+                "INSERT INTO messages (dialpad_id, text) VALUES (?, ?)",
+                (4628326630105088, "the actual sent body"),
+            )
+            mconn.commit()
+            mconn.close()
+
+            aconn = ev.connect_ro(self.adb)
+            mconn_ro = ev.connect_ro(mdb_noaff)
+            try:
+                result = ev.join_sent_message_text(
+                    aconn, mconn_ro, dialpad_sms_ids=["4628326630105088"]
+                )
+            finally:
+                aconn.close()
+                mconn_ro.close()
+        finally:
+            Path(mdb_noaff).unlink(missing_ok=True)
+        self.assertEqual(result, {"4628326630105088": "the actual sent body"})
+
+
+class PiiSafetyTests(unittest.TestCase):
+    """The pulse is human-facing; it must never leak customer SMS text/PII."""
+
+    def test_pulse_output_contains_no_raw_message_text(self):
+        secret_body = "CALL ME AT 415-867-5309 ABOUT MY ORDER"
+        secret_phone = "+14158675309"
+        secret_name = "Jane Q. Customer"
+        meta = json.dumps({"line_display": "Sales (415) 520-1316"})
+        rows = [
+            {
+                "status": "sent",
+                "draft_text": secret_body,
+                "customer_number": secret_phone,
+                "metadata_json": meta,
+            },
+            {
+                "status": "rejected",
+                "invalidated_reason": "operator_rejected",
+                "draft_text": secret_body,
+                "customer_number": secret_phone,
+                "metadata_json": meta,
+            },
+        ]
+        # Need the actual draft_text/customer_number columns present in the row,
+        # so go through a real DB read (not the trimmed-row helper).
+        adb = tempfile.NamedTemporaryFile(suffix=".db", delete=False).name
+        try:
+            _make_approval_db(adb, rows)
+            conn = ev.connect_ro(adb)
+            try:
+                db_rows = ev.fetch_drafts(conn)
+            finally:
+                conn.close()
+            pulse = ev.build_pulse(db_rows, start_ms=0, end_ms=2_000_000)
+            blob = json.dumps(pulse) + "\n" + ev.render_pulse_text(pulse)
+        finally:
+            Path(adb).unlink(missing_ok=True)
+
+        self.assertNotIn(secret_body, blob)
+        self.assertNotIn(secret_phone, blob)
+        self.assertNotIn(secret_name, blob)
+        # The business-line category label IS allowed.
+        self.assertIn("Sales (415) 520-1316", blob)
+
+    def test_fetch_drafts_does_not_select_draft_text(self):
+        # Belt-and-suspenders: the windowed query never pulls customer body.
+        adb = tempfile.NamedTemporaryFile(suffix=".db", delete=False).name
+        try:
+            _make_approval_db(adb, [{"status": "sent", "draft_text": "SECRET"}])
+            conn = ev.connect_ro(adb)
+            try:
+                row = ev.fetch_drafts(conn)[0]
+            finally:
+                conn.close()
+        finally:
+            Path(adb).unlink(missing_ok=True)
+        self.assertNotIn("draft_text", row.keys())
+
+
+class DeterminismAndWindowTests(unittest.TestCase):
+    def test_frozen_window_is_reproducible(self):
+        # Two pulses over the same frozen [start,end] must be identical, and
+        # a pending row inside the window must not change the decided counts.
+        meta = json.dumps({"line_display": "Sales (415) 520-1316"})
+        rows_data = [
+            {"status": "sent", "created_at_ms": 1_500_000, "metadata_json": meta},
+            {"status": "stale", "invalidated_reason": "manual_outbound", "created_at_ms": 1_600_000, "metadata_json": meta},
+            {"status": "pending", "created_at_ms": 1_700_000, "metadata_json": meta},
+            {"status": "sent", "created_at_ms": 9_999_999_999, "metadata_json": meta},  # outside window
+        ]
+        adb = tempfile.NamedTemporaryFile(suffix=".db", delete=False).name
+        try:
+            _make_approval_db(adb, rows_data)
+            conn = ev.connect_ro(adb)
+            try:
+                windowed = ev.fetch_drafts(conn, start_ms=1_000_000, end_ms=2_000_000)
+            finally:
+                conn.close()
+            p1 = ev.build_pulse(windowed, start_ms=1_000_000, end_ms=2_000_000)
+            p2 = ev.build_pulse(windowed, start_ms=1_000_000, end_ms=2_000_000)
+        finally:
+            Path(adb).unlink(missing_ok=True)
+
+        self.assertEqual(p1, p2)  # reproducible
+        self.assertEqual(p1["totals"]["drafts"], 3)  # the future row is excluded by window
+        self.assertEqual(p1["totals"]["decided"], 2)  # pending excluded from decided
+        self.assertEqual(p1["totals"]["accept"], 1)
+        self.assertEqual(p1["totals"]["reject"], 1)
+
+    def test_window_cutoff_math(self):
+        start, end = ev.window_cutoff_ms(7, end_ms=1_000_000_000)
+        self.assertEqual(end, 1_000_000_000)
+        self.assertEqual(end - start, 7 * 24 * 60 * 60 * 1000)
+
+
+class ReadOnlyTests(unittest.TestCase):
+    def test_connection_rejects_writes(self):
+        adb = tempfile.NamedTemporaryFile(suffix=".db", delete=False).name
+        try:
+            _make_approval_db(adb, [{"status": "sent"}])
+            conn = ev.connect_ro(adb)
+            try:
+                with self.assertRaises(sqlite3.OperationalError):
+                    conn.execute("DELETE FROM sms_approval_drafts")
+            finally:
+                conn.close()
+        finally:
+            Path(adb).unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds `scripts/sms_approval_eval.py` (read-only library + thin `pulse` CLI) and `tests/test_sms_approval_eval.py`. Computes per-category accept/reject statistics and an aggregate-only weekly pulse from the SMS approval database. Read-only by construction: every connection is opened `file:...?mode=ro` with `PRAGMA query_only`. Independent, additive, does not touch `scripts/webhook_server.py`.

Encodes the maintainer decisions:
- `manual_outbound` (operator hand-typed their own reply) counts as a draft **REJECTION**, not an accept.
- In-flight `pending` / `risk_pending` / `sending` are **excluded** from accept/reject rates (non-deterministic outcome).
- `stale` is split by `invalidated_reason` (`manual_outbound`=reject, `superseded_by_new_draft`=excluded, `operator_rejected`=reject, `new_inbound_not_eligible`/`smoke_test_cleanup`=excluded) — never bucketed as one "abandoned" group; unknown reasons default to excluded rather than silently counted.
- The full status taxonomy (`pending/risk_pending/sending/sent/failed/stale/rejected`) is enumerated and the partition is asserted exhaustive (sum of buckets == total rows); a test guards drift against `sms_approval.STATUS_*`.
- The pulse is aggregate-only (counts, rates, business-line labels, timestamps); it never embeds SMS bodies, customer phone numbers, or contact names. The windowed query does not even `SELECT draft_text`.
- The window is frozen (`created_at_ms` cutoff + `--end-ms`, plus pending exclusion) so the pulse is reproducible run-to-run.

## Why

S6 gives maintainers a deterministic, PII-safe read on how well the SMS approval gate is performing per Dialpad line — accept rate, reject rate, and where drafts are being abandoned — without leaking customer content into a human-facing report.

**Verified-bug note (honest finding):** the brief specified the cross-DB join `messages.dialpad_id = drafts.dialpad_sms_id` returns ZERO rows without a CAST. Probed against the live schema, that is **not reproducible**: `messages.dialpad_id` is declared `INTEGER`, and SQLite's numeric affinity coerces in-range Dialpad ids, so the naive join *does* match. The CAST is still the correct choice — it is affinity-independent and the genuine trap it prevents is a **no-affinity** join column (or an id beyond INT64), which silently joins zero rows. `join_sent_message_text` uses `CAST(messages.dialpad_id AS TEXT) = drafts.dialpad_sms_id`; the regression test proves naive=0 / cast=1 on a no-affinity fixture and that the helper still resolves the row. Docstrings document the verified reality, not the original assumption.

## Tests

```
/run/current-system/sw/bin/python3 -m pytest tests/ -q
```

- New file `tests/test_sms_approval_eval.py`: **22 tests, all pass**. Covers verdict classification (manual_outbound=reject, pending/superseded=excluded, sent/failed=accept), exhaustive partition + taxonomy-drift guard, per-category accept/reject rates, the cross-DB CAST regression (naive=0 / cast=1 on a no-affinity fixture), PII-safety (no SMS body / phone / name in JSON or text output; `fetch_drafts` does not select `draft_text`), determinism over a frozen window, and read-only enforcement.
- Full suite: **361 passed, 27 failed**. All 27 failures are pre-existing on clean `main` (every one in `tests/test_sender_enrichment.py`, unrelated `hook_forwarded` assertions). **No new failures.** Baseline before this branch: 339 passed / 27 failed.
- Smoke-tested the CLI against the live read-only DB; the pulse reconciles exactly with the raw status histogram (141 drafts; accept=19, reject=50, excluded=72; partition exhaustive).

## AI Assistance

Implemented by Claude Opus 4.8 (1M context) as an isolated-worktree subagent. The agent read `sms_approval.py`, `approve_sms_draft.py`, and `sms_sqlite.py`, probed the live approval/SMS databases (read-only) to verify the status/reason distributions and the cross-DB join behavior, then wrote the library and tests. The agent independently verified and corrected the stated cross-DB-join premise rather than coding to the assumption.

https://claude.ai/code/session_01FM3qqE97VHRBHVr4N2kFyw