### PR TITLE
feat(webhook): branch CRM draft copy by Attio deal segment (S3)

### DIFF
--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -2621,18 +2621,82 @@ def _draft_greeting(normalized_event, sender_enrichment):
     return _context_greeting(sender_enrichment, normalized_event)
 
 
+# Exact live Attio "stage" titles → coarse deal segment, verified by a live Attio
+# pull (do not invent/guess titles). Keys are normalized (lowercase + collapsed
+# internal whitespace) so spacing variants like 'Not Qualified (MQL > SQL)' match.
+# Lost / Not a Fit / empty / any unmapped-or-new stage deliberately fall through
+# to None → generic copy, never a special voice. Keep robust to renamed stages.
+_DEAL_SEGMENT_STAGES = {
+    "customer": ("Won 🎉",),
+    "prospect_demo": (
+        "Sales Qualified", "DC Scheduling", "Call", "Call - Follow Up Sent",
+        "Call - No Show", "Demo Request", "Demo Booked", "Demo - No Show",
+        "Demo Canceled", "Demo Completed", "Demo Follow Up", "Negotiations",
+    ),
+    "prospect_cold": (
+        "MQL", "MQL Sequence", "Manual Review", "Qualifying Sequence",
+        "Not Qualified (MQL > SQL)", "Pause - Nurture (Timing)",
+    ),
+}
+
+
+def _normalize_stage_title(stage):
+    """Lowercase + collapse internal whitespace so spacing/case variants match."""
+    return " ".join(str(stage or "").split()).lower()
+
+
+_DEAL_SEGMENT_BY_STAGE = {
+    _normalize_stage_title(title): segment
+    for segment, titles in _DEAL_SEGMENT_STAGES.items()
+    for title in titles
+}
+
+
+def classify_deal_segment(stage):
+    """Map an Attio deal stage title to a coarse customer-facing segment.
+
+    Normalizes the title (lowercase + collapsed internal whitespace) and matches
+    the verified live-Attio segment map. Returns one of 'customer',
+    'prospect_demo', 'prospect_cold', or None for Lost / Not a Fit / empty / any
+    unmapped or newly-renamed stage. Never raises — an unknown stage is a safe
+    None (generic copy), so a new Attio stage can't crash the draft path."""
+    normalized = _normalize_stage_title(stage)
+    if not normalized:
+        return None
+    return _DEAL_SEGMENT_BY_STAGE.get(normalized)
+
+
 def _crm_reply_message(normalized_event, sender_enrichment, crm_context):
     greeting = _draft_greeting(normalized_event, sender_enrichment)
     confidence = (normalized_event.get("inbound_context") or {}).get("identityConfidence")
     company = str(crm_context.get("company") or "").strip()
-    # Name the matched company in the CUSTOMER-facing text ONLY at high confidence.
-    # A low/medium-confidence Attio phone-match may be wrong (reused/ported/shared
-    # number), and naming the wrong company to a customer is a PII leak. At lower
-    # confidence the operator still sees the Attio context via the draft's
-    # provenance line and can personalize manually before approving (U7 decision).
-    if company and confidence == "high":
-        return f"Hi {greeting}, thanks for the update. I have your ShapeScale conversation with {company} here and will follow up shortly."
-    return f"Hi {greeting}, thanks for the update. I have your ShapeScale conversation here and will follow up shortly."
+    # Segment framing is CUSTOMER-facing, so it rides the same high-confidence gate
+    # as naming the company (PR3/U7 PII rule). A low/medium-confidence Attio
+    # phone-match may be wrong (reused/ported/shared number); at lower confidence we
+    # return the existing generic line and let the operator personalize from the
+    # provenance line + segment shown on the approval card before approving.
+    if confidence != "high":
+        return f"Hi {greeting}, thanks for the update. I have your ShapeScale conversation here and will follow up shortly."
+
+    segment = classify_deal_segment(crm_context.get("stage"))
+    inbound_context = normalized_event.get("inbound_context")
+    if isinstance(inbound_context, dict) and segment:
+        # Surface the segment to the operator (brief + dedup fingerprint). Setting
+        # this alone is invisible — build_inbound_context_brief renders it.
+        inbound_context["dealSegment"] = segment
+
+    # Per-segment copy reads fine even if the phone-match is wrong: no "as a
+    # churned customer" framing, just a warm/relevant-but-safe opener. The company
+    # name is still only named when present (company-empty-at-high stays handled).
+    with_company = f" with {company}" if company else ""
+    if segment == "customer":
+        return f"Hi {greeting}, great to hear from you again. I have your ShapeScale account{with_company} here and will follow up shortly."
+    if segment == "prospect_demo":
+        return f"Hi {greeting}, thanks for the update. I have your ShapeScale demo conversation{with_company} here and will follow up shortly."
+    if segment == "prospect_cold":
+        return f"Hi {greeting}, thanks for reaching out about ShapeScale. I have your conversation{with_company} here and will follow up shortly with more details."
+    # generic (None / Lost / Not a Fit / unmapped) — current copy, no special voice.
+    return f"Hi {greeting}, thanks for the update. I have your ShapeScale conversation{with_company} here and will follow up shortly."
 
 
 def _meeting_reply_message(normalized_event, sender_enrichment, _crm_context, _calendar_context):
@@ -3036,6 +3100,17 @@ def build_inbound_context_brief(inbound_context, auto_reply_status=None, auto_re
         f"*Recency:* {escape_telegram_markdown(recency_text)}",
         f"*Draft basis:* {escape_telegram_markdown(draft_text)}",
     ]
+    # Segment is only set when the customer-facing copy was actually varied
+    # (high-confidence Attio match). Surface it so the operator knows which voice
+    # the draft used and can sanity-check the match before approving.
+    segment = inbound_context.get("dealSegment")
+    if segment:
+        segment_label = {
+            "customer": "Customer",
+            "prospect_demo": "Prospect (demo)",
+            "prospect_cold": "Prospect (cold)",
+        }.get(segment, segment)
+        lines.append(f"*Segment:* {escape_telegram_markdown(segment_label)}")
     return "\n".join(lines)
 
 

--- a/tests/test_deal_segment.py
+++ b/tests/test_deal_segment.py
@@ -1,0 +1,318 @@
+"""Tests for the S3 customer/prospect segment branching.
+
+When an inbound sales-line SMS resolves an Attio deal at HIGH identity confidence,
+the CRM-aware approval-draft copy varies by deal segment (derived from the Attio
+`stage` already in crm_context — no new lookups). The segment is also surfaced to
+the operator on the Telegram approval card. Segment framing is customer-facing, so
+it is applied ONLY at high confidence (same gate as the company name, PR3 PII rule).
+"""
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Import webhook_server without leaving scripts/ ahead of bin/ on sys.path, and
+# without leaving scripts/send_sms cached in sys.modules. webhook_server does
+# `from send_sms import send_sms`, and there are TWO send_sms modules
+# (scripts/send_sms.py with the function, bin/send_sms.py the CLI wrapper). The
+# send_sms-wrapper tests (test_json_contract, test_send_sms_group_intro) need the
+# bin/ version; if we leave scripts/send_sms in sys.modules they'd reuse the wrong
+# one. So we snapshot/restore send_sms and drop the scripts/ path entry after import.
+_scripts_dir = str(ROOT / "scripts")
+_prev_send_sms = sys.modules.get("send_sms")
+_added_scripts = _scripts_dir not in sys.path
+if _added_scripts:
+    sys.path.insert(0, _scripts_dir)
+
+import webhook_server as ws  # noqa: E402
+sms_approval = ws.sms_approval
+
+if _added_scripts:
+    try:
+        sys.path.remove(_scripts_dir)
+    except ValueError:
+        pass
+# Restore send_sms to its prior state so wrapper tests re-resolve their bin/ copy.
+if _prev_send_sms is not None:
+    sys.modules["send_sms"] = _prev_send_sms
+else:
+    sys.modules.pop("send_sms", None)
+
+
+class ClassifyDealSegmentTests(unittest.TestCase):
+    def test_customer_stage(self):
+        self.assertEqual(ws.classify_deal_segment("Won 🎉"), "customer")
+
+    def test_prospect_demo_stages(self):
+        for stage in (
+            "Sales Qualified", "DC Scheduling", "Call", "Call - Follow Up Sent",
+            "Call - No Show", "Demo Request", "Demo Booked", "Demo - No Show",
+            "Demo Canceled", "Demo Completed", "Demo Follow Up", "Negotiations",
+        ):
+            self.assertEqual(ws.classify_deal_segment(stage), "prospect_demo", stage)
+
+    def test_prospect_cold_stages(self):
+        for stage in (
+            "MQL", "MQL Sequence", "Manual Review", "Qualifying Sequence",
+            "Not Qualified (MQL > SQL)", "Pause - Nurture (Timing)",
+        ):
+            self.assertEqual(ws.classify_deal_segment(stage), "prospect_cold", stage)
+
+    def test_exact_title_edge_cases_with_spacing(self):
+        # Match is case-insensitive with collapsed internal whitespace, so spacing
+        # and case variants of the tricky punctuated titles still resolve.
+        self.assertEqual(ws.classify_deal_segment("Not Qualified (MQL > SQL)"), "prospect_cold")
+        self.assertEqual(ws.classify_deal_segment("not qualified  (mql > sql)"), "prospect_cold")
+        self.assertEqual(ws.classify_deal_segment("  Not Qualified (MQL > SQL)  "), "prospect_cold")
+        self.assertEqual(ws.classify_deal_segment("Pause - Nurture (Timing)"), "prospect_cold")
+        self.assertEqual(ws.classify_deal_segment("pause -  nurture   (timing)"), "prospect_cold")
+
+    def test_generic_stages_are_none(self):
+        for stage in ("Lost", "Not a Fit", "", "   "):
+            self.assertIsNone(ws.classify_deal_segment(stage), repr(stage))
+
+    def test_unmapped_or_new_stage_is_none(self):
+        self.assertIsNone(ws.classify_deal_segment("Brand New Stage 2027"))
+        self.assertIsNone(ws.classify_deal_segment("Renamed Demo Stage"))
+
+    def test_robust_to_non_string_and_none(self):
+        # Never crash on odd input — a new/renamed/None stage is a safe generic.
+        self.assertIsNone(ws.classify_deal_segment(None))
+        self.assertIsNone(ws.classify_deal_segment(12345))
+        self.assertIsNone(ws.classify_deal_segment(["Won 🎉"]))
+
+
+class SegmentFramingHighConfidenceTests(unittest.TestCase):
+    def _msg(self, stage, confidence="high", company="Acme Corp"):
+        crm = {"usable": True, "company": company, "stage": stage}
+        ev = {"inbound_context": {"identityConfidence": confidence}}
+        return ws._crm_reply_message(ev, {}, crm)
+
+    def test_customer_voice(self):
+        msg = self._msg("Won 🎉")
+        self.assertIn("great to hear from you again", msg)
+        self.assertIn("Acme Corp", msg)
+
+    def test_prospect_demo_voice(self):
+        msg = self._msg("Demo Booked")
+        self.assertIn("demo conversation", msg)
+        self.assertIn("Acme Corp", msg)
+
+    def test_prospect_cold_voice(self):
+        msg = self._msg("MQL")
+        self.assertIn("thanks for reaching out", msg)
+        self.assertIn("Acme Corp", msg)
+
+    def test_generic_voice_for_unmapped_stage(self):
+        # Lost / Not a Fit / unmapped → existing generic copy, no special voice.
+        for stage in ("Lost", "Not a Fit", "Some New Stage"):
+            msg = self._msg(stage)
+            self.assertIn("thanks for the update", msg)
+            self.assertIn("ShapeScale conversation with Acme Corp", msg)
+            self.assertNotIn("great to hear", msg)
+            self.assertNotIn("demo conversation", msg)
+
+    def test_copy_reads_safely_even_if_match_wrong(self):
+        # No "as a churned customer" framing — copy must be natural if the
+        # phone-match resolved the wrong deal.
+        for stage in ("Won 🎉", "Demo Booked", "MQL"):
+            msg = self._msg(stage)
+            for bad in ("churn", "as a customer", "as a prospect", "since you"):
+                self.assertNotIn(bad, msg.lower(), f"{bad} leaked for {stage}")
+
+    def test_customer_facing_text_has_no_provenance_tokens(self):
+        for stage in ("Won 🎉", "Demo Booked", "MQL", "Lost"):
+            msg = self._msg(stage)
+            for tok in ("Attio:", "stage:", "QMD", "Segment:", "dealSegment"):
+                self.assertNotIn(tok, msg, f"{tok} leaked for {stage}")
+
+
+class SegmentFramingGateTests(unittest.TestCase):
+    """Segment framing is customer-facing → only at high confidence."""
+
+    GENERIC_HIGH_NO_COMPANY = "Hi there, thanks for the update. I have your ShapeScale conversation here and will follow up shortly."
+
+    def _msg(self, confidence, stage="Won 🎉", company="Acme Corp"):
+        crm = {"usable": True, "company": company, "stage": stage}
+        ev = {"inbound_context": {"identityConfidence": confidence}}
+        return ws._crm_reply_message(ev, {}, crm)
+
+    def test_medium_low_none_return_generic_line_unchanged(self):
+        for confidence in ("medium", "low", None):
+            msg = self._msg(confidence)
+            self.assertEqual(msg, self.GENERIC_HIGH_NO_COMPANY, confidence)
+            # No segment voice and no company name leak at sub-high confidence.
+            self.assertNotIn("great to hear", msg)
+            self.assertNotIn("Acme Corp", msg)
+
+    def test_segment_not_set_on_inbound_context_below_high(self):
+        for confidence in ("medium", "low", None):
+            crm = {"usable": True, "company": "Acme Corp", "stage": "Won 🎉"}
+            ev = {"inbound_context": {"identityConfidence": confidence}}
+            ws._crm_reply_message(ev, {}, crm)
+            self.assertNotIn("dealSegment", ev["inbound_context"], confidence)
+
+    def test_segment_set_on_inbound_context_at_high(self):
+        crm = {"usable": True, "company": "Acme Corp", "stage": "Demo Booked"}
+        ev = {"inbound_context": {"identityConfidence": "high"}}
+        ws._crm_reply_message(ev, {}, crm)
+        self.assertEqual(ev["inbound_context"]["dealSegment"], "prospect_demo")
+
+    def test_generic_stage_at_high_does_not_set_segment(self):
+        crm = {"usable": True, "company": "Acme Corp", "stage": "Lost"}
+        ev = {"inbound_context": {"identityConfidence": "high"}}
+        ws._crm_reply_message(ev, {}, crm)
+        self.assertNotIn("dealSegment", ev["inbound_context"])
+
+
+class CompanyEmptyAtHighTests(unittest.TestCase):
+    """Company-empty handling must survive the segment additions."""
+
+    def test_empty_company_at_high_still_drops_company_clause(self):
+        for stage, marker in (
+            ("Won 🎉", "great to hear from you again"),
+            ("Demo Booked", "demo conversation"),
+            ("MQL", "thanks for reaching out"),
+            ("Lost", "thanks for the update"),
+        ):
+            crm = {"usable": True, "company": "", "stage": stage}
+            ev = {"inbound_context": {"identityConfidence": "high"}}
+            msg = ws._crm_reply_message(ev, {}, crm)
+            self.assertIn(marker, msg, stage)
+            # The company clause ("conversation with <company>") must be absent...
+            self.assertNotIn("conversation with", msg, stage)
+            self.assertNotIn("account with", msg, stage)
+            self.assertNotIn("None", msg, stage)
+
+    def test_missing_company_key_does_not_crash(self):
+        crm = {"usable": True, "stage": "Won 🎉"}  # no company key at all
+        ev = {"inbound_context": {"identityConfidence": "high"}}
+        msg = ws._crm_reply_message(ev, {}, crm)
+        self.assertIn("great to hear from you again", msg)
+        self.assertNotIn(" with ", msg)
+
+
+class InboundContextBriefSegmentTests(unittest.TestCase):
+    def test_brief_renders_segment_when_present(self):
+        # Parens are not Telegram MarkdownV1 control chars, so the readable label
+        # renders unescaped.
+        for segment, label in (
+            ("customer", "Customer"),
+            ("prospect_demo", "Prospect (demo)"),
+            ("prospect_cold", "Prospect (cold)"),
+        ):
+            brief = ws.build_inbound_context_brief(
+                {"identityConfidence": "high", "dealSegment": segment}
+            )
+            self.assertIn("*Segment:*", brief)
+            self.assertIn(label, brief)
+
+    def test_brief_omits_segment_when_absent(self):
+        brief = ws.build_inbound_context_brief({"identityConfidence": "high"})
+        self.assertNotIn("*Segment:*", brief)
+
+    def test_brief_empty_context_returns_empty(self):
+        self.assertEqual(ws.build_inbound_context_brief({}), "")
+
+    def test_brief_renders_set_segment_regardless_of_confidence(self):
+        # _crm_reply_message only sets dealSegment at high confidence, but the brief
+        # is a dumb renderer: if a segment is present it shows it. This pins the
+        # renderer behavior so the gate stays enforced where it belongs (in
+        # _crm_reply_message), not silently relocated into the brief.
+        brief = ws.build_inbound_context_brief(
+            {"identityConfidence": "medium", "dealSegment": "customer"}
+        )
+        self.assertIn("*Segment:*", brief)
+        self.assertIn("Customer", brief)
+
+
+class FingerprintStabilityTests(unittest.TestCase):
+    """create_proactive_reply_draft builds context_fingerprint from a dict that
+    includes inbound_context + crm_context (PR2 dedup). Adding dealSegment must not
+    make an UNCHANGED draft churn: the same inputs must yield the same fingerprint."""
+
+    def _fingerprint(self, *, segment, stage):
+        inbound_context = {"identityConfidence": "high"}
+        if segment:
+            inbound_context["dealSegment"] = segment
+        return sms_approval.build_context_fingerprint(
+            {
+                "thread_key": "hook:dialpad:sms:+1:+2",
+                "sender": "+1",
+                "recipient": "+2",
+                "message_id": "msg-1",
+                "line_display": "Sales",
+                "first_contact": None,
+                "inbound_context": inbound_context,
+                "rich_reply": {"usable": True, "basis": "attio_crm"},
+                "crm_context": {"usable": True, "company": "Acme", "stage": stage},
+                "calendar_context": None,
+            }
+        )
+
+    def test_unchanged_draft_has_stable_fingerprint(self):
+        a = self._fingerprint(segment="prospect_demo", stage="Demo Booked")
+        b = self._fingerprint(segment="prospect_demo", stage="Demo Booked")
+        self.assertEqual(a, b)
+
+    def test_segment_change_changes_fingerprint(self):
+        # A genuinely different segment is a different draft — dedup should not
+        # suppress it.
+        demo = self._fingerprint(segment="prospect_demo", stage="Demo Booked")
+        customer = self._fingerprint(segment="customer", stage="Won 🎉")
+        self.assertNotEqual(demo, customer)
+
+    def _draft_then_fingerprint(self, stage):
+        """Mirror create_proactive_reply_draft's ordering: build the message first
+        (which mutates inbound_context['dealSegment'] via _crm_reply_message), THEN
+        fingerprint the mutated inbound_context. A reorder that fingerprints before
+        the mutation would silently drop the segment and is what this pins."""
+        event = {"inbound_context": {"identityConfidence": "high"}}
+        crm = {"usable": True, "company": "Acme", "stage": stage}
+        ws._crm_reply_message(event, {}, crm)
+        return sms_approval.build_context_fingerprint(
+            {
+                "inbound_context": event["inbound_context"],
+                "crm_context": crm,
+            }
+        )
+
+    def test_mutated_segment_is_folded_into_fingerprint(self):
+        # The high-confidence Attio match sets dealSegment, and the fingerprint must
+        # reflect it (so a different segment is a different draft) while staying
+        # stable for an unchanged draft.
+        a = self._draft_then_fingerprint("Demo Booked")
+        b = self._draft_then_fingerprint("Demo Booked")
+        self.assertEqual(a, b)  # unchanged draft → stable fingerprint
+        customer = self._draft_then_fingerprint("Won 🎉")
+        self.assertNotEqual(a, customer)  # different segment → different fingerprint
+
+
+class NoNewSendCallerTests(unittest.TestCase):
+    def test_no_caller_of_send_proactive_reply(self):
+        # S3 is draft-copy only: it must not introduce an unattended send path.
+        import inspect
+        src = inspect.getsource(ws)
+        send_callers = [
+            line.strip() for line in src.splitlines()
+            if "send_proactive_reply(" in line
+            and "should_send_proactive_reply(" not in line
+            and not line.lstrip().startswith("def send_proactive_reply(")
+        ]
+        self.assertEqual(send_callers, [], f"new send_proactive_reply caller: {send_callers}")
+
+    def test_approve_draft_caller_count_unchanged(self):
+        # The only legitimate approve_draft caller is the operator-driven Telegram
+        # callback handler (a human pressing approve). S3 must not add another.
+        import inspect
+        src = inspect.getsource(ws)
+        approve_callers = [
+            line.strip() for line in src.splitlines()
+            if "sms_approval.approve_draft(" in line
+        ]
+        self.assertEqual(len(approve_callers), 1, f"unexpected approve_draft callers: {approve_callers}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

When an inbound sales-line SMS resolves an Attio deal at **high identity confidence**, vary the CRM-aware approval-draft copy by deal **segment** and surface that segment to the operator on the Telegram approval card.

- New `classify_deal_segment(stage)` normalizes the title (lowercase + collapsed internal whitespace) and maps the exact live Attio stage titles to one of `customer` / `prospect_demo` / `prospect_cold`. `Lost` / `Not a Fit` / empty / any unmapped-or-renamed stage falls through to `None` (generic copy) and never raises.
- `_crm_reply_message` branches the draft copy by segment **only at `identityConfidence == "high"`** (the same gate as naming the company). At medium/low/None it returns the existing generic line unchanged and does not set `dealSegment`.
- Sets `inbound_context['dealSegment']` (camelCase, like `identityConfidence`/`richDraftCategory`) only when a real segment is chosen, and renders it on the operator card via `build_inbound_context_brief` (`*Segment:* Customer / Prospect (demo) / Prospect (cold)`).

Per-segment copy (reads naturally even if the phone-match is wrong — no "as a churned customer" framing):
- **customer**: `Hi {greeting}, great to hear from you again. I have your ShapeScale account[ with {company}] here and will follow up shortly.`
- **prospect_demo**: `Hi {greeting}, thanks for the update. I have your ShapeScale demo conversation[ with {company}] here and will follow up shortly.`
- **prospect_cold**: `Hi {greeting}, thanks for reaching out about ShapeScale. I have your conversation[ with {company}] here and will follow up shortly with more details.`
- **generic** (None / Lost / Not a Fit / unmapped): unchanged — `Hi {greeting}, thanks for the update. I have your ShapeScale conversation[ with {company}] here and will follow up shortly.`

The company clause `[ with {company}]` is only added when a company is present, so the empty-company-at-high path is preserved.

## Why

The segment map uses the **exact live Attio stage titles from a verified live Attio pull** (not invented or guessed). Segment framing is **customer-facing**, so per the PR3/U7 PII rule it is applied **high-confidence-only** — a low/medium-confidence Attio phone-match (reused/ported/shared number) can resolve the wrong deal, and a wrong segment voice to a customer is a PII-style leak. At lower confidence the operator still sees the Attio context via the provenance line and can personalize manually before approving.

No new Attio lookup (segment derives from `stage` already in `crm_context`; the QMD/pricing hot path is untouched), and no new caller of `send_proactive_reply` / `approve_draft` — this is draft-copy only.

## Tests

`tests/test_deal_segment.py` (new, 28 tests) covers: each segment incl. the exact-title edge cases (`Not Qualified (MQL > SQL)`, `Pause - Nurture (Timing)`, whitespace/case variants); `Lost` / `Not a Fit` / unmapped → generic; framing applied **only** at high confidence (medium/low/None → generic line unchanged, `dealSegment` not set); company-empty-at-high still handled; the operator brief renders the segment; the mutate-then-fingerprint ordering folds `dealSegment` into the PR2 dedup fingerprint and stays **stable for an unchanged draft**; and no new `send_proactive_reply` caller.

Commands run:
- `/run/current-system/sw/bin/python3 -m pytest tests/test_deal_segment.py -q` -> 28 passed
- `/run/current-system/sw/bin/python3 -m pytest tests/ -q` -> 27 failed, 433 passed

The 27 failures are the **pre-existing** baseline in `test_sender_enrichment.py` (a shared-DB/idempotency isolation defect unrelated to this change); a with/without-file diff confirms **zero new failures** and zero non-`test_sender_enrichment.py` failures. (Note: importing `webhook_server` eagerly imports `scripts/send_sms`, which collided with the `bin/send_sms` the wrapper tests expect; the new test file restores `sys.modules['send_sms']` after import so it does not poison `test_json_contract` / `test_send_sms_group_intro`.)

## AI Assistance

Implemented with Claude (Opus 4.8). An independent correctness-review agent verified the change against all requirements (no high-confidence bugs); two of its defense-in-depth testing-gap suggestions were adopted (brief-renderer gate pin + end-to-end mutation-then-fingerprint test).

This PR is **customer-facing draft copy and is human-gated — do not merge without review.**

https://claude.ai/code/session_01FM3qqE97VHRBHVr4N2kFyw