### PR TITLE
fix(hooks): surface gateway 400 body + unbuffer logs

### DIFF
--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -3820,8 +3820,8 @@ def send_to_openclaw_hooks(normalized_event, line_display=None):
             body = e.read().decode("utf-8", "replace").strip()
         except Exception:
             body = ""
-        detail = f" {body[:500]}" if body else ""
-        print(f"❌ Error forwarding {event_label} to OpenClaw hooks: HTTP {e.code}:{detail}")
+        detail = f": {body[:500]}" if body else ""
+        print(f"❌ Error forwarding {event_label} to OpenClaw hooks: HTTP {e.code}{detail}")
         return False, f"http_{e.code}"
     except Exception as e:
         print(f"❌ Error forwarding {event_label} to OpenClaw hooks: {e}")

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -3812,6 +3812,17 @@ def send_to_openclaw_hooks(normalized_event, line_display=None):
             if 200 <= status_code < 300:
                 return True, f"http_{status_code}"
             return False, f"http_{status_code}"
+    except urllib.error.HTTPError as e:
+        # Surface the gateway's response body — it carries the actual rejection
+        # reason. A bare "HTTP Error 400" is undiagnosable; without this a hook
+        # outage looks identical regardless of cause. Truncate to keep logs sane.
+        try:
+            body = e.read().decode("utf-8", "replace").strip()
+        except Exception:
+            body = ""
+        detail = f" {body[:500]}" if body else ""
+        print(f"❌ Error forwarding {event_label} to OpenClaw hooks: HTTP {e.code}:{detail}")
+        return False, f"http_{e.code}"
     except Exception as e:
         print(f"❌ Error forwarding {event_label} to OpenClaw hooks: {e}")
         return False, "request_failed"
@@ -4741,6 +4752,16 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
 
 def main():
     """Start the webhook server"""
+    # Line-buffer stdout/stderr so per-request log lines reach the journal as they
+    # happen. Under systemd, stdout is a pipe (not a TTY) and Python block-buffers
+    # it by default, so on sparse traffic logs surface minutes late in bursts with
+    # misleading timestamps — which masked a real hook outage and broke log tailing.
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(line_buffering=True)
+        except (AttributeError, ValueError):
+            pass
+
     # ThreadingHTTPServer: each request runs on its own thread so the ACK-first
     # handlers' post-ACK work (draft generation, hooks, Telegram) never blocks or
     # delays other inbound webhooks.

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -3817,7 +3817,11 @@ def send_to_openclaw_hooks(normalized_event, line_display=None):
         # reason. A bare "HTTP Error 400" is undiagnosable; without this a hook
         # outage looks identical regardless of cause. Truncate to keep logs sane.
         try:
-            body = e.read().decode("utf-8", "replace").strip()
+            # Bounded read: the log keeps only 500 chars, but each post-ACK webhook
+            # runs this on its own thread, so reading a large error page in full would
+            # let a bad gateway response exhaust memory across concurrent requests.
+            # 2 KiB covers 500 chars even at 4 bytes/char.
+            body = e.read(2048).decode("utf-8", "replace").strip()
         except Exception:
             body = ""
         detail = f": {body[:500]}" if body else ""

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import sys
 import unittest
 from unittest.mock import patch
+import urllib.error
 import urllib.request
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -1980,6 +1981,50 @@ class VoicemailWebhookHandlerTests(unittest.TestCase):
         self.assertEqual(status["code"], 200)
         self.assertEqual(response["auto_reply_status"], "draft_created")
         self.assertEqual(draft["risk_state"], webhook_server.sms_approval.RISK_RISKY)
+
+
+class OpenClawHookErrorLoggingTests(unittest.TestCase):
+    """A failed hook forward must surface the gateway's response body, not just
+    'HTTP Error 400: Bad Request' (which is undiagnosable). Regression for the
+    silent-failure that made a real 400 outage opaque."""
+
+    def _raise_http_400(self, request, timeout=10):
+        raise urllib.error.HTTPError(
+            request.full_url, 400, "Bad Request", {},
+            io.BytesIO(b'{"error":"agent niemand-work not ready"}'),
+        )
+
+    def test_http_error_logs_response_body_and_returns_status_code(self):
+        with patch.object(webhook_server, "OPENCLAW_HOOKS_SMS_ENABLED", True), \
+                patch.object(webhook_server, "OPENCLAW_HOOKS_TOKEN", "tok"), \
+                patch.object(urllib.request, "urlopen", side_effect=self._raise_http_400), \
+                patch("builtins.print") as mock_print:
+            ok, status = webhook_server.send_to_openclaw_hooks(
+                {"event_type": "sms", "text": "hi", "sender_number": "+14155550000"}
+            )
+
+        self.assertFalse(ok)
+        # status now carries the HTTP code, not a generic "request_failed"
+        self.assertEqual(status, "http_400")
+        logged = " ".join(str(c.args[0]) for c in mock_print.call_args_list if c.args)
+        self.assertIn("400", logged)
+        # the gateway's actual reason must be in the log
+        self.assertIn("agent niemand-work not ready", logged)
+
+    def test_network_error_still_handled_generically(self):
+        def boom(request, timeout=10):
+            raise urllib.error.URLError("connection refused")
+
+        with patch.object(webhook_server, "OPENCLAW_HOOKS_SMS_ENABLED", True), \
+                patch.object(webhook_server, "OPENCLAW_HOOKS_TOKEN", "tok"), \
+                patch.object(urllib.request, "urlopen", side_effect=boom), \
+                patch("builtins.print"):
+            ok, status = webhook_server.send_to_openclaw_hooks(
+                {"event_type": "sms", "text": "hi", "sender_number": "+14155550000"}
+            )
+
+        self.assertFalse(ok)
+        self.assertEqual(status, "request_failed")
 
 
 if __name__ == "__main__":

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -2026,6 +2026,42 @@ class OpenClawHookErrorLoggingTests(unittest.TestCase):
         self.assertFalse(ok)
         self.assertEqual(status, "request_failed")
 
+    def test_http_error_body_read_is_bounded(self):
+        # The body read must be capped (each post-ACK webhook runs this concurrently;
+        # an unbounded read of a huge error page could exhaust memory). Assert read()
+        # is called with a positive byte limit, never unbounded (-1 / None).
+        reads = []
+
+        class RecordingFp:
+            def read(self, amt=-1):
+                reads.append(amt)
+                return b"x" * 100000  # pretend a large error page
+
+            def close(self):
+                pass
+
+        def raise_big(request, timeout=10):
+            raise urllib.error.HTTPError(
+                request.full_url, 502, "Bad Gateway", {}, RecordingFp()
+            )
+
+        with patch.object(webhook_server, "OPENCLAW_HOOKS_SMS_ENABLED", True), \
+                patch.object(webhook_server, "OPENCLAW_HOOKS_TOKEN", "tok"), \
+                patch.object(urllib.request, "urlopen", side_effect=raise_big), \
+                patch("builtins.print") as mock_print:
+            ok, status = webhook_server.send_to_openclaw_hooks(
+                {"event_type": "sms", "text": "hi", "sender_number": "+14155550000"}
+            )
+
+        self.assertFalse(ok)
+        self.assertEqual(status, "http_502")
+        self.assertTrue(reads, "response body was never read")
+        self.assertIsNotNone(reads[0])
+        self.assertGreater(reads[0], 0)  # bounded, not e.read() / e.read(-1)
+        # and the log stays capped regardless of body size
+        logged = " ".join(str(c.args[0]) for c in mock_print.call_args_list if c.args)
+        self.assertLessEqual(len(logged), 600)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What
Two observability fixes on the inbound-SMS → OpenClaw hook-forward path (`send_to_openclaw_hooks`):
1. Catch `urllib.error.HTTPError` separately, read + truncate the gateway's **response body**, log `HTTP <code>: <body>`, and return `http_<code>` instead of a generic `request_failed`.
2. Line-buffer `stdout`/`stderr` at startup so per-request log lines reach the journal live.

No behavior change to the 400 path itself.

## Why
A transient AlphaClaw gateway state (post-reboot, before its own restart) returned HTTP 400 for `/hooks/agent` on ~2.5h of inbound SMS (2026-06-22, 13:15–15:55 PDT). Diagnosis was slow because:
- The error handler logged only `str(HTTPError)` → `"HTTP Error 400: Bad Request"`, **discarding the body that carries the actual reason** (a silent failure on a customer-facing delivery path — violates the repo's no-silent-failure standard).
- `stdout` was block-buffered under systemd (pipe, not a TTY), so logs surfaced minutes late in bursts with misleading timestamps, masking the outage window.

The dialpad payload was verified **valid** during diagnosis — the exact code path and the fully-enriched payload both return HTTP 200 from the gateway now (after its restart). This PR does not change the 400 behavior; it makes any recurrence immediately diagnosable. Telegram SMS alerts were never affected (separate path); only the `niemand-work` co-pilot hook trigger was.

## Tests
`OpenClawHookErrorLoggingTests` in `tests/test_webhook_server.py`:
- `test_http_error_logs_response_body_and_returns_status_code` — asserts the gateway body is logged and status is `http_400`.
- `test_network_error_still_handled_generically` — non-HTTP errors still return `request_failed`.

Commands run:
- `python3 -m pytest tests/test_webhook_server.py::OpenClawHookErrorLoggingTests -q` → 2 passed
- `python3 -m pytest tests/ -q` → 492 passed (27 pre-existing `test_sender_enrichment.py` failures unchanged — unrelated baseline)

## AI Assistance
Diagnosed and implemented with Claude Code (ce-debug). Root cause traced to a gateway-side transient; this PR addresses the dialpad-side observability gaps that made it hard to see. Follow-up (not in this PR): investigate why the post-reboot AlphaClaw gateway rejected hooks until restart.