### PR TITLE
feat(webhook): enrich missed-call approval drafts

### DIFF
--- a/docs/reference/enrichment-adapters.md
+++ b/docs/reference/enrichment-adapters.md
@@ -1,10 +1,11 @@
 # Enrichment context adapters (S1)
 
 Standalone context-command adapters that feed the CRM-aware, calendar-aware, and
-QMD-knowledge draft modes in `scripts/webhook_server.py`. Each is invoked as a
-subprocess: the webhook appends the query as a single final CLI arg and reads a
-JSON object from stdout (contract: `lookup_sales_crm_context` /
-`lookup_sales_calendar_context` / `lookup_shapescale_knowledge`).
+QMD-knowledge draft modes in `scripts/webhook_server.py` for Sales SMS and
+Sales missed-call approval drafts. Each is invoked as a subprocess: the webhook
+appends the query as a single final CLI arg and reads a JSON object from stdout
+(contract: `lookup_sales_crm_context` / `lookup_sales_calendar_context` /
+`lookup_shapescale_knowledge`).
 
 | Adapter | File | Query in | JSON out |
 |---|---|---|---|
@@ -15,6 +16,17 @@ JSON object from stdout (contract: `lookup_sales_crm_context` /
 All adapters fail closed (`{"usable": false, ...}`) and exit 0 on any miss, auth
 error, or timeout — the webhook treats a non-zero exit as failure.
 
+Silent missed calls can use Attio and calendar context from the caller/CRM
+query, but QMD is not applicable unless the normalized call event includes usable
+text or transcript-like content. Generic missed-call approval cards render source
+statuses so the operator can distinguish not configured, not found, unsafe,
+unavailable, and not applicable outcomes.
+
+The calendar adapter surfaces both upcoming demos and bounded recent demos. A
+recent missed call after a demo/no-show can therefore become meeting-aware instead
+of falling through to generic copy solely because the meeting is already in the
+past.
+
 ## Secrets (already present in `~/.config/systemd/user/secrets.conf`)
 
 - `ATTIO_API_KEY` — Attio REST bearer token (the adapter calls Attio directly, not the MCP).
@@ -22,12 +34,10 @@ error, or timeout — the webhook treats a non-zero exit as failure.
 
 ## Env wiring — apply at deploy time (U8), NOT yet
 
-> **Sequencing (plan KTD6):** do **not** enable `DIALPAD_CRM_CONTEXT_COMMAND` or
-> `DIALPAD_CALENDAR_CONTEXT_COMMAND` in the live `.env` until the async draft
-> refactor (U5) and SMS idempotency (U6) ship. The webhook runs draft generation
-> inline before the ACK on a single-threaded server; enabling these adds up to
-> 8s/call of inline work and would block the webhook. `.env` is gitignored, so
-> these lines are a deploy action, not a committed change.
+> **Sequencing:** `DIALPAD_CRM_CONTEXT_COMMAND` and
+> `DIALPAD_CALENDAR_CONTEXT_COMMAND` must only be enabled on builds where SMS and
+> missed-call draft generation run after the webhook ACK. `.env` is gitignored,
+> so these lines are a deploy action, not a committed change.
 
 ```sh
 # scripts/adapters invoked by absolute path (systemd PATH is nix-store only)

--- a/docs/solutions/ungate-enrichment-customer-pii.md
+++ b/docs/solutions/ungate-enrichment-customer-pii.md
@@ -7,8 +7,9 @@ related_pr: "#94"
 
 # Un-gating CRM enrichment into customer-facing drafts: the low-confidence PII trap
 
-Learnings from PR3/U7 (un-gate the CRM/QMD/calendar enrichment so it runs for every
-sales-line SMS draft, not just high-confidence known contacts).
+Learnings from PR3/U7 and the missed-call enrichment extension (un-gate the
+CRM/QMD/calendar enrichment so it runs for operator-approved sales-line drafts,
+not just high-confidence known SMS contacts).
 
 ## The trap: low-confidence Attio matches in customer-facing text
 
@@ -37,6 +38,9 @@ surfacing un-gated:
 - Greeting name in `draft_text`: suppressed at `identityConfidence == "low"` (matches
   the pre-existing generic fallback) via `_draft_greeting`.
 - Provenance line: any confidence, operator-only, never in `draft_text`.
+- Missed-call drafts follow the same rule. They may show low-confidence Attio,
+  calendar, or QMD context to the operator, but low-confidence customer text stays
+  generic and call-specific (`Hi there, sorry we missed your call...`).
 
 ## This was a CP4 (product) decision
 
@@ -59,3 +63,8 @@ Operators use the provenance line to validate sources, so a mislabel is worse th
 label. Whitelist exact bases (`shapescale_knowledge` → "QMD knowledge",
 `recent_thread_link` → "Prior-thread link") rather than blacklisting CRM/calendar —
 a blacklist mislabels everything else.
+
+For generic missed-call fallbacks, source status is part of the safety story:
+`not_applicable` QMD for silent calls is different from a failed knowledge lookup,
+and `unsafe` CRM/calendar output is different from no match. Keep those statuses
+operator-facing and out of customer SMS text.

--- a/scripts/adapters/calendar_context.py
+++ b/scripts/adapters/calendar_context.py
@@ -15,7 +15,8 @@ Emits the contract consumed by ``lookup_sales_calendar_context``:
     {"usable": true, "status": "ok", "basis": "attio",
      "summary": "...", "startsInMinutes": 42}
 
-Only future demos are surfaced; a stale/past date returns ``{"usable": false}``.
+Future demos and bounded recent demos are surfaced; stale/past dates outside the
+lookback window return ``{"usable": false}``.
 """
 import json
 import os
@@ -33,6 +34,20 @@ import attio_context as attio  # noqa: E402  (sibling adapter = shared Attio cli
 
 CALENDLY_BASE = os.environ.get("CALENDLY_API_BASE", "https://api.calendly.com").rstrip("/")
 CALENDLY_TIMEOUT = float(os.environ.get("CALENDLY_HTTP_TIMEOUT_SECONDS", "2.5"))
+DEFAULT_RECENT_DEMO_LOOKBACK_MINUTES = 7 * 24 * 60
+
+
+def parse_int_env(name, default):
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+RECENT_DEMO_LOOKBACK_MINUTES = parse_int_env(
+    "DIALPAD_RECENT_DEMO_LOOKBACK_MINUTES",
+    DEFAULT_RECENT_DEMO_LOOKBACK_MINUTES,
+)
 
 # Trailing timestamp the webhook appends (ISO 8601 or unix epoch).
 _TIMESTAMP_RE = re.compile(r"\s*(?:\d{4}-\d{2}-\d{2}[T ]\S+|\b\d{10}\b)\s*$")
@@ -81,26 +96,31 @@ def _demo_timestamp(deal):
 
 
 def resolve_attio_demo(remainder, now=None):
-    """Return (startsInMinutes, summary) from a single confident Attio deal match, else (None, None).
+    """Return (startsInMinutes, summary, demoState) from one confident Attio deal match.
 
     Conservative by design: 0 or multiple name matches → not usable, so the draft
     falls back to generic rather than guessing a meeting time.
     """
     token = _search_token(remainder)
     if not token:
-        return None, None
+        return None, None, None
     try:
         deals = attio._query_records("deals", {"name": {"$contains": token}}, limit=3)
     except attio.AttioError:
-        return None, None
+        return None, None, None
     if len(deals) != 1:
-        return None, None
+        return None, None, None
     deal = deals[0]
     sim = starts_in_minutes(parse_iso(_demo_timestamp(deal)), now=now)
-    if sim is None or sim < 0:
-        return None, None
+    if sim is None:
+        return None, None, None
     name = attio._text_value((deal.get("values") or {}), "name") or "your demo"
-    return sim, f"Upcoming demo: {attio._clean(name)}"
+    clean_name = attio._clean(name)
+    if sim < 0:
+        if abs(sim) > RECENT_DEMO_LOOKBACK_MINUTES:
+            return None, None, None
+        return abs(sim), f"Recent demo: {clean_name}", "recent"
+    return sim, f"Upcoming demo: {clean_name}", "upcoming"
 
 
 def calendly_next_event(email, now=None):
@@ -148,16 +168,24 @@ def build_calendar_context(query, now=None):
         return {"usable": False, "status": "empty_query"}
     remainder = _TIMESTAMP_RE.sub("", raw).strip()
 
-    sim, summary, basis = (*resolve_attio_demo(remainder, now=now), "attio")
+    sim, summary, demo_state, basis = (*resolve_attio_demo(remainder, now=now), "attio")
     if sim is None and os.environ.get("CALENDLY_API_KEY"):
         email_match = _EMAIL_RE.search(remainder)
         if email_match:
             sim, summary = calendly_next_event(email_match.group(0), now=now)
+            demo_state = "upcoming" if sim is not None else None
             basis = "calendly"
 
     if sim is None or not summary:
         return {"usable": False, "status": "not_found"}
-    return {"usable": True, "status": "ok", "basis": basis, "summary": summary, "startsInMinutes": sim}
+    return {
+        "usable": True,
+        "status": "ok",
+        "basis": basis,
+        "summary": summary,
+        "startsInMinutes": sim,
+        "demoState": demo_state or "upcoming",
+    }
 
 
 def main(argv=None):

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -652,6 +652,15 @@ def extract_message_text(data):
     return str(text or text_content or "")
 
 
+def extract_call_text(data):
+    """Extract transcript-like call text, skipping blank higher-priority fields."""
+    for key in ("text", "transcription", "transcript", "call_transcription"):
+        value = data.get(key)
+        if not is_blank_text(value):
+            return str(value)
+    return ""
+
+
 def is_blank_text(value):
     """True when text is empty or whitespace-only."""
     return not str(value or "").strip()
@@ -1381,7 +1390,12 @@ def build_missed_call_dedupe_key(data, resolved_context):
             )
         )
     bucket = event_ts_ms // MISSED_CALL_DEDUPE_FALLBACK_BUCKET_MS if event_ts_ms is not None else "unknown"
-    return f"missed-call:fingerprint:{sender_number or 'unknown'}:{recipient_number or 'unknown'}:{bucket}"
+    if sender_number and recipient_number:
+        return f"missed-call:fingerprint:{sender_number}:{recipient_number}:{bucket}"
+    payload_fingerprint = hashlib.sha256(
+        json.dumps(data, sort_keys=True, default=str, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:16]
+    return f"missed-call:fingerprint:{sender_number or 'unknown'}:{recipient_number or 'unknown'}:{bucket}:{payload_fingerprint}"
 
 
 def _apply_sqlite_concurrency_pragmas(conn):
@@ -2224,12 +2238,14 @@ def normalize_call_hook_payload(data, resolved_context, contact_info=None):
     call_id = data.get("call_id") or data.get("id")
     line_display = resolved_context.get("line_display") or get_line_name(recipient_number)
     sender = contact_info or sender_number or "Unknown"
+    text = extract_call_text(data)
 
     return {
         "event_type": "missed_call",
         "sender": sender,
         "sender_number": sender_number,
         "recipient_number": recipient_number,
+        "text": text,
         "timestamp": timestamp,
         "call_id": call_id,
         "line_display": line_display,
@@ -2308,15 +2324,15 @@ def build_proactive_reply_message(normalized_event, sender_enrichment=None):
     else:
         greeting_name = "there"
 
-    event_type = normalized_event.get("event_type") or "sms"
+    event_type = _event_type(normalized_event)
     if inbound_context.get("contextDraftAllowed"):
-        if event_type == "missed_call":
+        if _is_missed_call_event(normalized_event):
             body = "sorry we missed your call. I saw your recent ShapeScale conversation and can help from here. What would you like to cover?"
         elif event_type == "voicemail":
             body = "thanks for the voicemail. I saw your recent ShapeScale conversation and will follow up shortly."
         else:
             body = "thanks for reaching out. I saw your recent ShapeScale conversation and will follow up shortly."
-    elif event_type == "missed_call":
+    elif _is_missed_call_event(normalized_event):
         body = "you've reached ShapeScale for Business Sales. Sorry we missed your call. How can we help?"
     elif event_type == "voicemail":
         body = "thanks for the voicemail. We received it and will be in touch shortly."
@@ -2587,9 +2603,26 @@ def _context_greeting(sender_enrichment, normalized_event):
     return first_name or "there"
 
 
+SOURCE_STATUS_LABELS = {
+    "usable": "usable",
+    "not_applicable": "not applicable",
+    "not_configured": "not configured",
+    "disabled": "not configured",
+    "not_found": "not found",
+    "degraded": "degraded",
+    "unsafe": "unsafe",
+    "unsafe_output": "unsafe",
+    "unavailable": "unavailable",
+    "not_allowed": "not allowed",
+    "empty_query": "not found",
+    "empty": "not found",
+    "timeout": "unavailable",
+    "request_failed": "unavailable",
+}
+
+
 def _sales_context_draft_allowed(normalized_event):
-    """Allow CRM/calendar enrichment for the operator-approval DRAFT lane on any
-    sales-line SMS, regardless of identity confidence (plan U7 un-gate).
+    """Allow CRM/calendar enrichment for operator-approval DRAFT lanes on Sales events.
 
     Drafts are always operator-reviewed — there is no unattended auto-send (that is
     S4, not yet built) — so enriching at medium/unknown confidence is safe: a wrong
@@ -2597,7 +2630,15 @@ def _sales_context_draft_allowed(normalized_event):
     adapter does its own phone lookup, so a high-confidence Dialpad identity is not
     required. Sales-line/eligibility checks already ran upstream in
     should_send_proactive_reply before any draft is built."""
-    return (normalized_event.get("event_type") or "sms") == "sms"
+    return (normalized_event.get("event_type") or "sms") in {"sms", "missed_call"}
+
+
+def _event_type(normalized_event):
+    return normalized_event.get("event_type") or "sms"
+
+
+def _is_missed_call_event(normalized_event):
+    return _event_type(normalized_event) == "missed_call"
 
 
 def meeting_logistics_intent(text):
@@ -2815,12 +2856,33 @@ def write_attio_inbound_note(normalized_event, *, sender_enrichment=None, db_pat
         return {"written": False, "status": "error", "note_id": None}
 
 
+def _crm_has_demo_signal(crm_context):
+    if not isinstance(crm_context, dict) or not crm_context.get("usable"):
+        return False
+    if classify_deal_segment(crm_context.get("stage")) == "prospect_demo":
+        return True
+    text = " ".join(
+        str(crm_context.get(key) or "")
+        for key in ("summary", "deal", "stage")
+    ).lower()
+    return "demo" in text
+
+
+def _context_calendar_applicable(normalized_event, crm_context=None):
+    if meeting_logistics_intent(normalized_event.get("text")):
+        return True
+    if not _is_missed_call_event(normalized_event):
+        return False
+    inbound_context = normalized_event.get("inbound_context") or {}
+    return bool(inbound_context.get("contextDraftAllowed") or _crm_has_demo_signal(crm_context))
+
+
 def lookup_sales_calendar_context(normalized_event, crm_context=None, sender_enrichment=None):
     """Return compact calendar context for meeting-logistics Sales SMS drafts."""
     sender_enrichment = sender_enrichment or {}
     if not _sales_context_draft_allowed(normalized_event):
         return {"usable": False, "status": "not_allowed"}
-    if not meeting_logistics_intent(normalized_event.get("text")):
+    if not _context_calendar_applicable(normalized_event, crm_context=crm_context):
         return {"usable": False, "status": "not_applicable"}
 
     query_parts = [
@@ -2851,6 +2913,7 @@ def lookup_sales_calendar_context(normalized_event, crm_context=None, sender_enr
         "basis": result.get("basis") or "google_calendar",
         "summary": summary,
         "startsInMinutes": starts_in_minutes,
+        "demoState": result.get("demoState"),
     }
 
 
@@ -2909,17 +2972,25 @@ def classify_deal_segment(stage):
     return _DEAL_SEGMENT_BY_STAGE.get(normalized)
 
 
+def _crm_reply_opening(is_missed_call):
+    if is_missed_call:
+        return "sorry we missed your call"
+    return "thanks for the update"
+
+
 def _crm_reply_message(normalized_event, sender_enrichment, crm_context):
     greeting = _draft_greeting(normalized_event, sender_enrichment)
     confidence = (normalized_event.get("inbound_context") or {}).get("identityConfidence")
     company = str(crm_context.get("company") or "").strip()
+    is_missed_call = _is_missed_call_event(normalized_event)
     # Segment framing is CUSTOMER-facing, so it rides the same high-confidence gate
     # as naming the company (PR3/U7 PII rule). A low/medium-confidence Attio
     # phone-match may be wrong (reused/ported/shared number); at lower confidence we
     # return the existing generic line and let the operator personalize from the
     # provenance line + segment shown on the approval card before approving.
+    opening = _crm_reply_opening(is_missed_call)
     if confidence != "high":
-        return f"Hi {greeting}, thanks for the update. I have your ShapeScale conversation here and will follow up shortly."
+        return f"Hi {greeting}, {opening}. I have your ShapeScale conversation here and will follow up shortly."
 
     segment = classify_deal_segment(crm_context.get("stage"))
     inbound_context = normalized_event.get("inbound_context")
@@ -2933,17 +3004,23 @@ def _crm_reply_message(normalized_event, sender_enrichment, crm_context):
     # name is still only named when present (company-empty-at-high stays handled).
     with_company = f" with {company}" if company else ""
     if segment == "customer":
+        if is_missed_call:
+            return f"Hi {greeting}, {opening}. I have your ShapeScale account{with_company} here and will follow up shortly."
         return f"Hi {greeting}, great to hear from you again. I have your ShapeScale account{with_company} here and will follow up shortly."
     if segment == "prospect_demo":
-        return f"Hi {greeting}, thanks for the update. I have your ShapeScale demo conversation{with_company} here and will follow up shortly."
+        return f"Hi {greeting}, {opening}. I have your ShapeScale demo conversation{with_company} here and will follow up shortly."
     if segment == "prospect_cold":
+        if is_missed_call:
+            return f"Hi {greeting}, {opening}. I have your ShapeScale conversation{with_company} here and will follow up shortly with more details."
         return f"Hi {greeting}, thanks for reaching out about ShapeScale. I have your conversation{with_company} here and will follow up shortly with more details."
     # generic (None / Lost / Not a Fit / unmapped) — current copy, no special voice.
-    return f"Hi {greeting}, thanks for the update. I have your ShapeScale conversation{with_company} here and will follow up shortly."
+    return f"Hi {greeting}, {opening}. I have your ShapeScale conversation{with_company} here and will follow up shortly."
 
 
 def _meeting_reply_message(normalized_event, sender_enrichment, _crm_context, _calendar_context):
     greeting = _draft_greeting(normalized_event, sender_enrichment)
+    if _is_missed_call_event(normalized_event):
+        return f"Hi {greeting}, sorry we missed your call. I saw your ShapeScale demo context and will follow up shortly."
     body = str(normalized_event.get("text") or "").lower()
     if re.search(r"\blate\b|\bon my way\b", body):
         return f"Hi {greeting}, no worries, thanks for letting me know. See you shortly."
@@ -2952,6 +3029,23 @@ def _meeting_reply_message(normalized_event, sender_enrichment, _crm_context, _c
     if re.search(r"\b(?:zoom|meet|meeting|demo)\s+(?:link|url)\b", body):
         return f"Hi {greeting}, thanks for the heads up. I'll check the meeting link and send the right one shortly."
     return f"Hi {greeting}, thanks for the heads up. See you shortly."
+
+
+def _crm_reply_payload(normalized_event, sender_enrichment, crm_context):
+    return {
+        "usable": True,
+        "status": "ok",
+        "basis": "attio_crm",
+        "category": "crm_context",
+        "message": _crm_reply_message(normalized_event, sender_enrichment, crm_context),
+        "crmContext": {
+            "basis": crm_context.get("basis"),
+            "status": crm_context.get("status"),
+            "company": crm_context.get("company"),
+            "stage": crm_context.get("stage"),
+            "owner": crm_context.get("owner"),
+        },
+    }
 
 
 def build_contextual_sales_sms_reply(normalized_event, sender_enrichment=None):
@@ -2967,7 +3061,7 @@ def build_contextual_sales_sms_reply(normalized_event, sender_enrichment=None):
     if not crm_context.get("usable"):
         return {"usable": False, "status": f"crm_{crm_context.get('status') or 'unavailable'}"}
 
-    if meeting_logistics_intent(normalized_event.get("text")):
+    if _context_calendar_applicable(normalized_event, crm_context=crm_context):
         calendar_context = normalized_event.get("calendar_context")
         if calendar_context is None:
             calendar_context = lookup_sales_calendar_context(
@@ -2977,7 +3071,11 @@ def build_contextual_sales_sms_reply(normalized_event, sender_enrichment=None):
             )
             normalized_event["calendar_context"] = calendar_context
         if not calendar_context.get("usable"):
+            if _is_missed_call_event(normalized_event):
+                return _crm_reply_payload(normalized_event, sender_enrichment, crm_context)
             return {"usable": False, "status": f"calendar_{calendar_context.get('status') or 'unavailable'}"}
+        if not _is_missed_call_event(normalized_event) and calendar_context.get("demoState") == "recent":
+            return {"usable": False, "status": "calendar_recent"}
         return {
             "usable": True,
             "status": "ok",
@@ -2997,20 +3095,7 @@ def build_contextual_sales_sms_reply(normalized_event, sender_enrichment=None):
             },
         }
 
-    return {
-        "usable": True,
-        "status": "ok",
-        "basis": "attio_crm",
-        "category": "crm_context",
-        "message": _crm_reply_message(normalized_event, sender_enrichment, crm_context),
-        "crmContext": {
-            "basis": crm_context.get("basis"),
-            "status": crm_context.get("status"),
-            "company": crm_context.get("company"),
-            "stage": crm_context.get("stage"),
-            "owner": crm_context.get("owner"),
-        },
-    }
+    return _crm_reply_payload(normalized_event, sender_enrichment, crm_context)
 
 
 def _first_recent_link(recent_thread):
@@ -3024,6 +3109,18 @@ def _first_recent_link(recent_thread):
                 return link
             return f"https://{link}"
     return None
+
+
+def _missed_call_followup_message(message):
+    body = str(message or "").strip()
+    if not body:
+        return body
+    if "missed your call" in body.lower():
+        return body
+    prefix = "Hi there, "
+    if body.startswith(prefix):
+        body = body[len(prefix):]
+    return f"Hi there, sorry we missed your call. {body[0].lower()}{body[1:]}"
 
 
 # Question words / articles / fillers that carry no retrieval signal, plus the
@@ -3085,8 +3182,20 @@ def build_rich_sms_reply(normalized_event, sender_enrichment=None):
     """Build a short knowledge-backed approval draft when confidence is high enough."""
     if not DIALPAD_RICH_SMS_DRAFTS_ENABLED:
         return {"usable": False, "status": "disabled"}
-    if (normalized_event.get("event_type") or "sms") != "sms":
+    event_type = _event_type(normalized_event)
+    if event_type not in {"sms", "missed_call"}:
         return {"usable": False, "status": "unsupported_event"}
+
+    if _is_missed_call_event(normalized_event):
+        text = str(normalized_event.get("text") or "").strip()
+        if not text:
+            contextual_reply = build_contextual_sales_sms_reply(
+                normalized_event,
+                sender_enrichment=sender_enrichment,
+            )
+            if contextual_reply.get("usable"):
+                return contextual_reply
+            return {"usable": False, "status": contextual_reply.get("status") or "not_answerable"}
 
     if meeting_logistics_intent(normalized_event.get("text")):
         contextual_reply = build_contextual_sales_sms_reply(
@@ -3122,12 +3231,15 @@ def build_rich_sms_reply(normalized_event, sender_enrichment=None):
 
     if category == "link_issue":
         link = _first_recent_link(recent_thread) or DIALPAD_BOOK_DEMO_URL
+        message = f"Hi there, sorry about that. Try this link instead: {link}. If it still doesn't work, reply with a few times that work and we'll help schedule it."
+        if _is_missed_call_event(normalized_event):
+            message = _missed_call_followup_message(message)
         return {
             "usable": True,
             "status": "ok",
             "basis": "recent_thread_link",
             "category": category,
-            "message": f"Hi there, sorry about that. Try this link instead: {link}. If it still doesn't work, reply with a few times that work and we'll help schedule it.",
+            "message": message,
         }
 
     knowledge = lookup_shapescale_knowledge(_knowledge_query_for_category(category, normalized_event.get("text")))
@@ -3141,6 +3253,8 @@ def build_rich_sms_reply(normalized_event, sender_enrichment=None):
     message = _compose_knowledge_sms(category, knowledge.get("text"))
     if not message:
         return {"usable": False, "status": "empty_draft", "category": category}
+    if _is_missed_call_event(normalized_event):
+        message = _missed_call_followup_message(message)
 
     return {
         "usable": True,
@@ -3354,6 +3468,19 @@ def build_inbound_context_brief(inbound_context, auto_reply_status=None, auto_re
             "prospect_cold": "Prospect (cold)",
         }.get(segment, segment)
         lines.append(f"*Segment:* {escape_telegram_markdown(segment_label)}")
+    source_statuses = inbound_context.get("sourceStatuses") or {}
+    if isinstance(source_statuses, dict) and source_statuses:
+        rendered = []
+        source_labels = {"crm": "CRM", "calendar": "Calendar", "qmd": "QMD"}
+        for source in ("crm", "calendar", "qmd"):
+            status = source_statuses.get(source)
+            if not isinstance(status, dict):
+                continue
+            raw_status = str(status.get("status") or "")
+            label = SOURCE_STATUS_LABELS.get(raw_status, raw_status or "unknown")
+            rendered.append(f"{source_labels[source]}: {label}")
+        if rendered:
+            lines.append(f"*Sources:* {escape_telegram_markdown('; '.join(rendered))}")
     return "\n".join(lines)
 
 
@@ -3451,6 +3578,47 @@ def _build_draft_provenance(normalized_event):
         elif rich_basis == "recent_thread_link":
             parts.append("Prior-thread link")
     return " | ".join(parts) if parts else None
+
+
+def _source_status(status):
+    text = str(status or "unavailable")
+    if text.startswith(("crm_", "calendar_", "knowledge_")):
+        text = text.split("_", 1)[1] or text
+    return text
+
+
+def collect_enrichment_source_statuses(normalized_event):
+    statuses = {}
+    crm = normalized_event.get("crm_context")
+    if isinstance(crm, dict):
+        statuses["crm"] = {
+            "status": "usable" if crm.get("usable") else _source_status(crm.get("status")),
+            "basis": crm.get("basis"),
+        }
+    else:
+        statuses["crm"] = {"status": "not_configured" if not DIALPAD_CRM_CONTEXT_COMMAND else "not_found"}
+
+    cal = normalized_event.get("calendar_context")
+    if isinstance(cal, dict):
+        statuses["calendar"] = {
+            "status": "usable" if cal.get("usable") else _source_status(cal.get("status")),
+            "basis": cal.get("basis"),
+        }
+    else:
+        statuses["calendar"] = {"status": "not_applicable"}
+
+    rich = normalized_event.get("rich_reply")
+    if isinstance(rich, dict) and rich.get("basis") == "shapescale_knowledge" and rich.get("usable"):
+        statuses["qmd"] = {"status": "usable", "basis": "shapescale_knowledge"}
+    elif not str(normalized_event.get("text") or "").strip():
+        statuses["qmd"] = {"status": "not_applicable"}
+    elif isinstance(rich, dict) and str(rich.get("status") or "").startswith("knowledge_"):
+        statuses["qmd"] = {"status": _source_status(rich.get("status")), "basis": rich.get("basis")}
+    elif isinstance(rich, dict):
+        statuses["qmd"] = {"status": "not_applicable"}
+    else:
+        statuses["qmd"] = {"status": "not_found"}
+    return statuses
 
 
 def evaluate_auto_send_shadow(normalized_event, reply_policy=None):
@@ -3580,6 +3748,10 @@ def create_proactive_reply_draft(normalized_event, sender_enrichment=None, line_
                 inbound_context["draftMode"] = "knowledge_backed"
 
     message = build_proactive_reply_message(normalized_event, sender_enrichment=sender_enrichment)
+    inbound_context = normalized_event.get("inbound_context")
+    source_statuses = collect_enrichment_source_statuses(normalized_event)
+    if isinstance(inbound_context, dict):
+        inbound_context["sourceStatuses"] = source_statuses
     if sms_approval is None:
         return False, "approval_unavailable", message, None, reply_policy
     if not sender_number or not recipient_number:
@@ -3602,6 +3774,7 @@ def create_proactive_reply_draft(normalized_event, sender_enrichment=None, line_
             "rich_reply": normalized_event.get("rich_reply"),
             "crm_context": normalized_event.get("crm_context"),
             "calendar_context": normalized_event.get("calendar_context"),
+            "source_statuses": source_statuses,
         }
     )
     try:
@@ -3637,6 +3810,7 @@ def create_proactive_reply_draft(normalized_event, sender_enrichment=None, line_
                     "rich_reply": normalized_event.get("rich_reply"),
                     "crm_context": normalized_event.get("crm_context"),
                     "calendar_context": normalized_event.get("calendar_context"),
+                    "source_statuses": source_statuses,
                     "provenance": _build_draft_provenance(normalized_event),
                     # S4 SHADOW MODE decision (booleans/enums only, no PII) for S6.
                     "autoSendShadow": auto_send_shadow,
@@ -3656,8 +3830,7 @@ def create_proactive_reply_draft(normalized_event, sender_enrichment=None, line_
 
 def build_hook_session_key(normalized_event):
     """Build stable OpenClaw hook session key with fallbacks."""
-    event_type = normalized_event.get("event_type") or "sms"
-    if event_type == "missed_call":
+    if _is_missed_call_event(normalized_event):
         call_id = normalized_event.get("call_id")
         if call_id:
             return f"hook:dialpad:call:{call_id}"
@@ -3688,10 +3861,9 @@ def format_hook_message(normalized_event, line_display=None):
     sender_number = normalized_event.get("sender_number") or "Unknown"
     recipient_number = normalized_event.get("recipient_number")
     timestamp = normalized_event.get("timestamp")
-    event_type = normalized_event.get("event_type") or "sms"
     resolved_line = line_display or normalized_event.get("line_display")
 
-    if event_type == "missed_call":
+    if _is_missed_call_event(normalized_event):
         lines = ["📞 Dialpad Missed Call", f"From: {sender} ({sender_number})"]
         if resolved_line:
             lines.append(f"Line: {resolved_line}")
@@ -3724,9 +3896,8 @@ def get_openclaw_hooks_url():
 
 def build_openclaw_hook_payload(normalized_event, line_display=None):
     """Build /hooks/agent payload for a normalized hook event."""
-    event_type = normalized_event.get("event_type") or "sms"
     hook_name = OPENCLAW_HOOKS_NAME
-    if event_type == "missed_call":
+    if _is_missed_call_event(normalized_event):
         hook_name = OPENCLAW_HOOKS_CALL_NAME
 
     payload = {
@@ -3778,10 +3949,9 @@ def send_to_openclaw_hooks(normalized_event, line_display=None):
     Forward a normalized event payload to OpenClaw hooks.
     Returns (success: bool, status: str).
     """
-    event_type = normalized_event.get("event_type") or "sms"
     hooks_enabled = OPENCLAW_HOOKS_SMS_ENABLED
     event_label = "SMS"
-    if event_type == "missed_call":
+    if _is_missed_call_event(normalized_event):
         hooks_enabled = OPENCLAW_HOOKS_CALL_ENABLED
         event_label = "missed call"
 
@@ -4390,7 +4560,7 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
         missed_call_dedupe_key = None
         missed_call_dedupe_status = None
         if should_notify:
-            resolved = resolve_missed_call_context(data)
+            resolved = resolve_missed_call_context(data, history_fetcher=lambda _ts: [])
             from_num = resolved["from_number"]
             to_num = resolved["to_number"]
             call_ts = resolved["event_ts_ms"] or (
@@ -4420,20 +4590,21 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                 self.end_headers()
                 response = {
                     "status": "ok",
-                    "missed_call": True,
-                    "duplicate": True,
-                    "dedupe_key": missed_call_dedupe_key,
-                    "dedupe_status": missed_call_dedupe_status,
-                    "hook_forwarded": False,
-                    "hook_status": "duplicate_suppressed",
-                    "auto_reply_sent": False,
-                    "auto_reply_status": "duplicate_suppressed",
-                    "auto_reply_draft_id": None,
-                    "telegram_sent": False,
+                    "stored": True,
+                    "processing": "duplicate",
                 }
                 self.wfile.write(json.dumps(response).encode())
                 return
 
+            try:
+                self._ack_webhook_200(stored=True, duplicate=False)
+            except Exception:  # noqa: BLE001 - process once even if the client disconnected mid-ACK.
+                print("⚠️  Missed-call ACK write failed (client disconnect); processing anyway")
+
+            resolved = resolve_missed_call_context(data)
+            from_num = resolved["from_number"]
+            to_num = resolved["to_number"]
+            call_ts = resolved["event_ts_ms"] or call_ts
             sender_enrichment = (
                 lookup_contact_enrichment(from_num) if from_num != "Unknown" else {
                     "contact_name": None,
@@ -4506,6 +4677,7 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                 "draftId": auto_reply_draft_id,
                 "status": auto_reply_status,
                 "message": auto_reply_message,
+                "richReply": normalized_event.get("rich_reply"),
                 "replyPolicy": reply_policy,
                 # S4 shadow decision is metadata/log-only — NOT in auto_reply, which
                 # build_openclaw_hook_payload forwards to the hook. (Lives in the log line.)
@@ -4520,6 +4692,9 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
                 auto_reply_status=auto_reply_status,
                 auto_reply_draft_created=auto_reply_draft_created,
             )
+            provenance = _build_draft_provenance(normalized_event)
+            if provenance:
+                tg_text += f"\n↳ {escape_telegram_markdown(provenance)}"
             tg_text += build_approval_review_suffix(
                 auto_reply_draft_id,
                 auto_reply_message,
@@ -4558,6 +4733,7 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
             print(f"   🪝 OpenClaw Hook: {'✓' if hook_sent else '✗'} ({hook_status})")
             print(f"   📨 Telegram: {'✓' if telegram_sent else '✗'}")
             print()
+            return
         else:
             print(f"[{datetime.now().isoformat()}]")
             print(f"   📞 CALL EVENT ignored (not inbound missed call)")

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -3590,11 +3590,19 @@ def _source_status(status):
 def collect_enrichment_source_statuses(normalized_event):
     statuses = {}
     crm = normalized_event.get("crm_context")
+    rich = normalized_event.get("rich_reply")
+    qmd_answered = (
+        isinstance(rich, dict) and
+        rich.get("basis") == "shapescale_knowledge" and
+        rich.get("usable")
+    )
     if isinstance(crm, dict):
         statuses["crm"] = {
             "status": "usable" if crm.get("usable") else _source_status(crm.get("status")),
             "basis": crm.get("basis"),
         }
+    elif qmd_answered:
+        statuses["crm"] = {"status": "not_applicable"}
     else:
         statuses["crm"] = {"status": "not_configured" if not DIALPAD_CRM_CONTEXT_COMMAND else "not_found"}
 
@@ -3607,8 +3615,7 @@ def collect_enrichment_source_statuses(normalized_event):
     else:
         statuses["calendar"] = {"status": "not_applicable"}
 
-    rich = normalized_event.get("rich_reply")
-    if isinstance(rich, dict) and rich.get("basis") == "shapescale_knowledge" and rich.get("usable"):
+    if qmd_answered:
         statuses["qmd"] = {"status": "usable", "basis": "shapescale_knowledge"}
     elif not str(normalized_event.get("text") or "").strip():
         statuses["qmd"] = {"status": "not_applicable"}
@@ -4605,6 +4612,25 @@ class DialpadWebhookHandler(BaseHTTPRequestHandler):
             from_num = resolved["from_number"]
             to_num = resolved["to_number"]
             call_ts = resolved["event_ts_ms"] or call_ts
+            canonical_dedupe_key = build_missed_call_dedupe_key(data, resolved)
+            if canonical_dedupe_key != missed_call_dedupe_key:
+                canonical_claim = claim_missed_call_notification(canonical_dedupe_key)
+                duplicate = bool(canonical_claim.get("duplicate"))
+                missed_call_dedupe_key = canonical_dedupe_key
+                missed_call_dedupe_status = canonical_claim.get("status")
+                if duplicate:
+                    print(f"[{datetime.now().isoformat()}]")
+                    print(f"   📞 MISSED CALL duplicate suppressed after backfill: {from_num} -> {resolved['line_display'] or get_line_name(to_num) or 'Unknown'}")
+                    print(f"   🧷 Dedupe: {missed_call_dedupe_key} ({missed_call_dedupe_status})")
+                    call_id = data.get("call_id") or data.get("id")
+                    entry_point_call_id = data.get("entry_point_call_id")
+                    if call_id:
+                        print(f"   📞 Call ID: {call_id}")
+                    if entry_point_call_id:
+                        print(f"   📞 Entry point call ID: {entry_point_call_id}")
+                    print()
+                    return
+
             sender_enrichment = (
                 lookup_contact_enrichment(from_num) if from_num != "Unknown" else {
                     "contact_name": None,

--- a/tests/test_calendar_context.py
+++ b/tests/test_calendar_context.py
@@ -26,7 +26,7 @@ PAST_DEAL = {
     "id": {"record_id": "deal-2"},
     "values": {
         "name": [{"value": "Old Deal", "attribute_type": "text"}],
-        "demo_scheduled_at": [{"value": "2026-06-19T10:00:00.000000000Z", "attribute_type": "timestamp"}],
+        "demo_scheduled_at": [{"value": "2026-06-20T17:30:00.000000000Z", "attribute_type": "timestamp"}],
     },
 }
 
@@ -54,25 +54,40 @@ class TimeHelpersTests(unittest.TestCase):
 class ResolveAttioDemoTests(unittest.TestCase):
     def test_single_future_match(self):
         with patch.object(attio, "_query_records", return_value=[DEAL]):
-            sim, summary = cal.resolve_attio_demo("Synergy Wellness", now=NOW)
+            sim, summary, state = cal.resolve_attio_demo("Synergy Wellness", now=NOW)
         self.assertEqual(sim, 30)
         self.assertIn("Synergy Wellness", summary)
+        self.assertEqual(state, "upcoming")
 
     def test_ambiguous_match_not_usable(self):
         with patch.object(attio, "_query_records", return_value=[DEAL, PAST_DEAL]):
-            self.assertEqual(cal.resolve_attio_demo("Demo", now=NOW), (None, None))
+            self.assertEqual(cal.resolve_attio_demo("Demo", now=NOW), (None, None, None))
 
     def test_no_match(self):
         with patch.object(attio, "_query_records", return_value=[]):
-            self.assertEqual(cal.resolve_attio_demo("Synergy", now=NOW), (None, None))
+            self.assertEqual(cal.resolve_attio_demo("Synergy", now=NOW), (None, None, None))
 
-    def test_past_demo_not_surfaced(self):
+    def test_recent_past_demo_is_surfaced(self):
         with patch.object(attio, "_query_records", return_value=[PAST_DEAL]):
-            self.assertEqual(cal.resolve_attio_demo("Old", now=NOW), (None, None))
+            sim, summary, state = cal.resolve_attio_demo("Old Deal", now=NOW)
+        self.assertGreater(sim, 0)
+        self.assertIn("Recent demo", summary)
+        self.assertEqual(state, "recent")
+
+    def test_stale_past_demo_not_surfaced(self):
+        stale = {
+            "id": {"record_id": "deal-3"},
+            "values": {
+                "name": [{"value": "Stale Deal", "attribute_type": "text"}],
+                "demo_scheduled_at": [{"value": "2026-06-01T10:00:00.000000000Z", "attribute_type": "timestamp"}],
+            },
+        }
+        with patch.object(attio, "_query_records", return_value=[stale]):
+            self.assertEqual(cal.resolve_attio_demo("Stale", now=NOW), (None, None, None))
 
     def test_api_error_fails_closed(self):
         with patch.object(attio, "_query_records", side_effect=attio.AttioError("network")):
-            self.assertEqual(cal.resolve_attio_demo("Synergy", now=NOW), (None, None))
+            self.assertEqual(cal.resolve_attio_demo("Synergy", now=NOW), (None, None, None))
 
 
 class BuildCalendarContextTests(unittest.TestCase):
@@ -145,9 +160,14 @@ class CalendlyBestEffortTests(unittest.TestCase):
         self.assertTrue(ctx["usable"])
         self.assertEqual(ctx["basis"], "calendly")
         self.assertEqual(ctx["startsInMinutes"], 20)
+        self.assertEqual(ctx["demoState"], "upcoming")
 
 
 class HardeningTests(unittest.TestCase):
+    def test_parse_int_env_falls_back_on_invalid_value(self):
+        with patch.dict("os.environ", {"BAD_INT": "not-an-int"}):
+            self.assertEqual(cal.parse_int_env("BAD_INT", 42), 42)
+
     def test_main_exits_zero_on_internal_exception(self):
         import io
         from contextlib import redirect_stdout
@@ -166,7 +186,7 @@ class HardeningTests(unittest.TestCase):
             },
         }
         with patch.object(attio, "_query_records", return_value=[deal]):
-            sim, summary = cal.resolve_attio_demo("Evil", now=NOW)
+            sim, summary, _state = cal.resolve_attio_demo("Evil", now=NOW)
         self.assertEqual(summary, "Upcoming demo: Evil Demo")
 
     def test_calendly_rejects_unexpected_org(self):

--- a/tests/test_ungate_provenance.py
+++ b/tests/test_ungate_provenance.py
@@ -156,6 +156,17 @@ class ProvenanceTests(unittest.TestCase):
         self.assertEqual(statuses["crm"]["status"], "usable")
         self.assertEqual(statuses["qmd"]["status"], "not_applicable")
 
+    def test_source_statuses_show_crm_not_applicable_when_qmd_skipped_crm(self):
+        ev = {
+            "event_type": "sms",
+            "rich_reply": {"usable": True, "status": "ok", "basis": "shapescale_knowledge"},
+            "text": "how do I reset the app?",
+        }
+        with patch.object(ws, "DIALPAD_CRM_CONTEXT_COMMAND", "crm-lookup"):
+            statuses = ws.collect_enrichment_source_statuses(ev)
+        self.assertEqual(statuses["crm"]["status"], "not_applicable")
+        self.assertEqual(statuses["qmd"]["status"], "usable")
+
 
 class CustomerTextSafetyTests(unittest.TestCase):
     CRM = {"usable": True, "company": "Acme Corp", "stage": "Demo Booked"}

--- a/tests/test_ungate_provenance.py
+++ b/tests/test_ungate_provenance.py
@@ -25,8 +25,9 @@ class GateRelaxationTests(unittest.TestCase):
         self.assertTrue(ws._sales_context_draft_allowed({"event_type": "sms"}))
         self.assertTrue(ws._sales_context_draft_allowed({}))  # defaults to sms
 
-    def test_rejects_non_sms(self):
-        self.assertFalse(ws._sales_context_draft_allowed({"event_type": "missed_call"}))
+    def test_allows_missed_call(self):
+        self.assertTrue(ws._sales_context_draft_allowed({"event_type": "missed_call"}))
+        self.assertFalse(ws._sales_context_draft_allowed({"event_type": "voicemail"}))
 
 
 class UngatedLookupTests(unittest.TestCase):
@@ -43,6 +44,55 @@ class UngatedLookupTests(unittest.TestCase):
             ctx = ws.lookup_sales_crm_context(event, sender_enrichment={"contact_name": "Jane", "company": "Acme"})
         self.assertTrue(ctx["usable"])
         self.assertEqual(ctx["company"], "Acme Corp")
+
+    def test_missed_call_crm_context_builds_call_specific_rich_reply(self):
+        event = {
+            "event_type": "missed_call",
+            "sender_number": "+14155550123",
+            "text": "",
+            "inbound_context": {"identityConfidence": "high"},
+        }
+        crm_payload = {
+            "usable": True,
+            "basis": "attio",
+            "summary": "Acme Corp Manual Review",
+            "company": "Acme Corp",
+            "stage": "Manual Review",
+            "deal": "Acme",
+            "owner": None,
+        }
+        with patch.object(ws, "_run_context_command", side_effect=[crm_payload]):
+            rich = ws.build_rich_sms_reply(event, sender_enrichment={"first_name": "Jane"})
+        self.assertTrue(rich["usable"])
+        self.assertEqual(rich["basis"], "attio_crm")
+        self.assertIn("sorry we missed your call", rich["message"])
+        self.assertNotIn("texted", rich["message"])
+
+    def test_missed_call_calendar_miss_preserves_crm_draft(self):
+        event = {
+            "event_type": "missed_call",
+            "sender_number": "+14155550123",
+            "text": "",
+            "inbound_context": {
+                "identityConfidence": "high",
+                "contextDraftAllowed": True,
+            },
+        }
+        crm_payload = {
+            "usable": True,
+            "basis": "attio",
+            "summary": "Acme Corp Demo Booked",
+            "company": "Acme Corp",
+            "stage": "Demo Booked",
+            "deal": "Acme",
+            "owner": None,
+        }
+        calendar_payload = {"usable": False, "status": "not_found"}
+        with patch.object(ws, "_run_context_command", side_effect=[crm_payload, calendar_payload]):
+            rich = ws.build_rich_sms_reply(event, sender_enrichment={"first_name": "Jane"})
+        self.assertTrue(rich["usable"])
+        self.assertEqual(rich["basis"], "attio_crm")
+        self.assertEqual(event["calendar_context"]["status"], "not_found")
 
 
 class ProvenanceTests(unittest.TestCase):
@@ -81,6 +131,30 @@ class ProvenanceTests(unittest.TestCase):
         # context; it must not also show as "QMD knowledge".
         ev = {"rich_reply": {"usable": True, "basis": "attio_crm"}}
         self.assertIsNone(ws._build_draft_provenance(ev))
+
+    def test_source_statuses_show_qmd_not_applicable_for_silent_call(self):
+        ev = {
+            "event_type": "missed_call",
+            "crm_context": {"usable": False, "status": "not_found"},
+            "calendar_context": {"usable": False, "status": "not_applicable"},
+            "rich_reply": {"usable": False, "status": "not_answerable"},
+            "text": "",
+        }
+        statuses = ws.collect_enrichment_source_statuses(ev)
+        self.assertEqual(statuses["crm"]["status"], "not_found")
+        self.assertEqual(statuses["calendar"]["status"], "not_applicable")
+        self.assertEqual(statuses["qmd"]["status"], "not_applicable")
+
+    def test_source_statuses_do_not_copy_crm_reply_status_into_qmd(self):
+        ev = {
+            "event_type": "missed_call",
+            "crm_context": {"usable": True, "status": "ok", "basis": "attio"},
+            "rich_reply": {"usable": True, "status": "ok", "basis": "attio_crm"},
+            "text": "pricing question from transcript",
+        }
+        statuses = ws.collect_enrichment_source_statuses(ev)
+        self.assertEqual(statuses["crm"]["status"], "usable")
+        self.assertEqual(statuses["qmd"]["status"], "not_applicable")
 
 
 class CustomerTextSafetyTests(unittest.TestCase):
@@ -124,6 +198,14 @@ class CustomerTextSafetyTests(unittest.TestCase):
         self.assertIn("Hi there,", msg)
         self.assertNotIn("Wrong", msg)
 
+    def test_low_confidence_missed_call_crm_copy_is_call_specific_and_pii_safe(self):
+        ev = {"event_type": "missed_call", "inbound_context": {"identityConfidence": "low"}}
+        msg = ws._crm_reply_message(ev, {"first_name": "Wrong"}, {"usable": True, "company": "Acme"})
+        self.assertIn("sorry we missed your call", msg)
+        self.assertIn("Hi there,", msg)
+        self.assertNotIn("Wrong", msg)
+        self.assertNotIn("Acme", msg)
+
 
 class CalendarUngateTests(unittest.TestCase):
     def test_calendar_lookup_runs_at_low_confidence(self):
@@ -134,6 +216,110 @@ class CalendarUngateTests(unittest.TestCase):
             ctx = ws.lookup_sales_calendar_context(
                 event, crm_context={"company": "Acme"}, sender_enrichment={"contact_name": "Jane"})
         self.assertTrue(ctx["usable"])
+
+    def test_missed_call_calendar_lookup_does_not_require_sms_text_intent(self):
+        event = {
+            "event_type": "missed_call",
+            "sender_number": "+14155550123",
+            "timestamp": 1760000000000,
+            "inbound_context": {"identityConfidence": "low", "contextDraftAllowed": True},
+        }
+        cal_payload = {
+            "usable": True,
+            "basis": "attio",
+            "summary": "Recent demo: Acme",
+            "startsInMinutes": 30,
+            "demoState": "recent",
+        }
+        with patch.object(ws, "_run_context_command", return_value=cal_payload):
+            ctx = ws.lookup_sales_calendar_context(
+                event,
+                crm_context={"usable": True, "company": "Acme", "deal": "Acme"},
+                sender_enrichment={"contact_name": "Jane"},
+            )
+        self.assertTrue(ctx["usable"])
+        self.assertIn("Recent demo", ctx["summary"])
+
+    def test_missed_call_calendar_lookup_uses_crm_demo_context(self):
+        event = {
+            "event_type": "missed_call",
+            "sender_number": "+14155550123",
+            "timestamp": 1760000000000,
+            "inbound_context": {"identityConfidence": "medium", "contextDraftAllowed": False},
+        }
+        cal_payload = {
+            "usable": True,
+            "basis": "attio",
+            "summary": "Upcoming demo: Acme",
+            "startsInMinutes": 30,
+            "demoState": "upcoming",
+        }
+        crm_context = {"usable": True, "company": "Acme", "deal": "Acme demo", "stage": "Demo Booked"}
+        with patch.object(ws, "_run_context_command", return_value=cal_payload) as run:
+            ctx = ws.lookup_sales_calendar_context(event, crm_context=crm_context)
+        self.assertTrue(ctx["usable"])
+        self.assertTrue(run.called)
+
+    def test_missed_call_knowledge_reply_is_call_specific(self):
+        event = {
+            "event_type": "missed_call",
+            "sender_number": "+14155550123",
+            "recipient_number": "+14155201316",
+            "text": "What does it cost?",
+        }
+        with patch.object(ws, "lookup_recent_sms_thread", return_value=[]), \
+                patch.object(ws, "lookup_shapescale_knowledge", return_value={
+                    "usable": True,
+                    "status": "ok",
+                    "text": "ShapeScale costs $1,799 upfront.",
+                }):
+            rich = ws.build_rich_sms_reply(event)
+        self.assertTrue(rich["usable"])
+        self.assertEqual(rich["basis"], "shapescale_knowledge")
+        self.assertIn("sorry we missed your call", rich["message"])
+
+    def test_missed_call_transcript_question_uses_qmd_before_crm_fallback(self):
+        event = {
+            "event_type": "missed_call",
+            "sender_number": "+14155550123",
+            "recipient_number": "+14155201316",
+            "text": "What does it cost?",
+        }
+        with patch.object(ws, "lookup_recent_sms_thread", return_value=[]), \
+                patch.object(ws, "lookup_sales_crm_context", return_value={
+                    "usable": True,
+                    "status": "ok",
+                    "basis": "attio",
+                    "company": "Acme",
+                    "stage": "Manual Review",
+                }), \
+                patch.object(ws, "lookup_shapescale_knowledge", return_value={
+                    "usable": True,
+                    "status": "ok",
+                    "text": "ShapeScale costs $1,799 upfront.",
+                }):
+            rich = ws.build_rich_sms_reply(event)
+        self.assertTrue(rich["usable"])
+        self.assertEqual(rich["basis"], "shapescale_knowledge")
+
+    def test_sms_meeting_logistics_rejects_recent_demo_context(self):
+        event = {
+            "event_type": "sms",
+            "sender_number": "+14155550123",
+            "recipient_number": "+14155201316",
+            "text": "I'm running late",
+        }
+        event["crm_context"] = {"usable": True, "status": "ok", "basis": "attio", "company": "Acme"}
+        event["calendar_context"] = {
+            "usable": True,
+            "status": "ok",
+            "basis": "attio",
+            "summary": "Recent demo: Acme",
+            "demoState": "recent",
+        }
+        rich = ws.build_contextual_sales_sms_reply(event)
+        self.assertFalse(rich["usable"])
+        self.assertEqual(rich["status"], "calendar_recent")
 
 
 class ProvenanceRobustnessTests(unittest.TestCase):

--- a/tests/test_webhook_async.py
+++ b/tests/test_webhook_async.py
@@ -249,6 +249,54 @@ class MissedCallAckFirstTests(unittest.TestCase):
         self.assertIn('"processing": "duplicate"', second.wfile.getvalue().decode())
         self.assertEqual(lookup.call_count, 1)
 
+    def test_backfilled_missed_call_duplicate_stops_before_side_effects(self):
+        first_payload = {
+            "direction": "inbound",
+            "call_direction": "inbound",
+            "call_missed": True,
+            "contact": {"phone": "+14155550123"},
+            "date_started": 1760000000000,
+            "webhook_event_id": "parent",
+        }
+        second_payload = {
+            **first_payload,
+            "webhook_event_id": "child",
+            "event": {"delivery": "retry"},
+        }
+        history_row = {
+            "direction": "inbound",
+            "state": "missed",
+            "duration": 0,
+            "date_started": 1760000000500,
+            "external_number": "+14155550123",
+            "entry_point_target": {"phone": "+14155201316", "name": "Sales"},
+        }
+        lookup = MagicMock(return_value={
+            "contact_name": None,
+            "status": "not_found",
+            "degraded": False,
+            "degraded_reason": None,
+        })
+        hooks = MagicMock(return_value=(False, "disabled_by_config"))
+        telegram = MagicMock(return_value=True)
+
+        with patch.object(ws, "_fetch_recent_calls_around", return_value=[history_row]), \
+                patch.object(ws, "lookup_contact_enrichment", lookup), \
+                patch.object(ws, "send_to_openclaw_hooks", hooks), \
+                patch.object(ws, "send_to_telegram", telegram):
+            first, first_status = _build_handler(first_payload)
+            first.handle_call_webhook()
+            second, second_status = _build_handler(second_payload)
+            second.handle_call_webhook()
+
+        self.assertEqual(first_status["code"], 200)
+        self.assertEqual(second_status["code"], 200)
+        self.assertIn('"processing": "async"', first.wfile.getvalue().decode())
+        self.assertIn('"processing": "async"', second.wfile.getvalue().decode())
+        self.assertEqual(lookup.call_count, 1)
+        self.assertEqual(hooks.call_count, 1)
+        self.assertEqual(telegram.call_count, 1)
+
 
 class ServerConfigTests(unittest.TestCase):
     def test_main_uses_threading_http_server(self):

--- a/tests/test_webhook_async.py
+++ b/tests/test_webhook_async.py
@@ -167,6 +167,89 @@ class AckFirstIdempotencyTests(unittest.TestCase):
         self.assertEqual(self.assess.call_count, 1)
 
 
+class MissedCallAckFirstTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
+        self.db = self.tmp.name
+        self.patchers = [
+            patch.object(ws, "verify_webhook_auth", lambda *a, **k: (True, "test")),
+            patch.object(ws, "_missed_call_dedupe_db_path", lambda: Path(self.db)),
+            patch.object(ws, "DIALPAD_AUTO_REPLY_ENABLED", False),
+            patch.object(ws, "_fetch_recent_calls_around", return_value=[]),
+            patch.object(ws, "send_to_openclaw_hooks", return_value=(False, "disabled_by_config")),
+            patch.object(ws, "send_to_telegram", return_value=True),
+        ]
+        for p in self.patchers:
+            p.start()
+
+    def tearDown(self):
+        for p in self.patchers:
+            p.stop()
+        Path(self.db).unlink(missing_ok=True)
+
+    def _missed_call(self, call_id):
+        return {
+            "direction": "inbound",
+            "call_direction": "inbound",
+            "call_missed": True,
+            "call_id": call_id,
+            "from_number": "+14155550123",
+            "to_number": "+14155201316",
+            "date_started": 1760000000000,
+        }
+
+    def test_missed_call_ack_written_before_enrichment_lookup(self):
+        handler, status = _build_handler(self._missed_call("call-ack-1"))
+        seen = {}
+
+        def _probe(_number):
+            seen["ack_len"] = len(handler.wfile.getvalue())
+            return {"contact_name": None, "status": "not_found", "degraded": False, "degraded_reason": None}
+
+        with patch.object(ws, "lookup_contact_enrichment", side_effect=_probe):
+            handler.handle_call_webhook()
+
+        self.assertEqual(status["code"], 200)
+        self.assertIn('"processing": "async"', handler.wfile.getvalue().decode())
+        self.assertGreater(seen.get("ack_len", 0), 0)
+
+    def test_missed_call_ack_written_before_history_backfill(self):
+        payload = self._missed_call("call-ack-history-1")
+        payload.pop("from_number")
+        payload["contact"] = {"phone": "+14155550123"}
+        handler, status = _build_handler(payload)
+        seen = {}
+
+        def _history(_event_ts_ms):
+            seen["ack_len"] = len(handler.wfile.getvalue())
+            return []
+
+        with patch.object(ws, "_fetch_recent_calls_around", side_effect=_history):
+            handler.handle_call_webhook()
+
+        self.assertEqual(status["code"], 200)
+        self.assertIn('"processing": "async"', handler.wfile.getvalue().decode())
+        self.assertGreater(seen.get("ack_len", 0), 0)
+
+    def test_duplicate_missed_call_acks_without_side_effects(self):
+        lookup = MagicMock(return_value={
+            "contact_name": None,
+            "status": "not_found",
+            "degraded": False,
+            "degraded_reason": None,
+        })
+        with patch.object(ws, "lookup_contact_enrichment", lookup):
+            first, _ = _build_handler(self._missed_call("call-dup-1"))
+            first.handle_call_webhook()
+            second, status = _build_handler(self._missed_call("call-dup-1"))
+            second.handle_call_webhook()
+
+        self.assertEqual(status["code"], 200)
+        self.assertIn('"processing": "duplicate"', second.wfile.getvalue().decode())
+        self.assertEqual(lookup.call_count, 1)
+
+
 class ServerConfigTests(unittest.TestCase):
     def test_main_uses_threading_http_server(self):
         # ACK-first relies on per-request threads -> main() must instantiate

--- a/tests/test_webhook_hooks.py
+++ b/tests/test_webhook_hooks.py
@@ -258,6 +258,15 @@ def test_build_missed_call_dedupe_key_uses_stable_fingerprint_without_ids():
     assert build_missed_call_dedupe_key({}, resolved) != build_missed_call_dedupe_key({}, later)
 
 
+def test_build_missed_call_dedupe_key_separates_unresolved_payloads_without_ids():
+    first_payload = {"date_started": 1760000000999, "contact": {"phone": "+14155550123"}}
+    second_payload = {"date_started": 1760000000999, "contact": {"phone": "+14155550999"}}
+    unresolved = {"from_number": "Unknown", "to_number": None, "event_ts_ms": 1760000000999}
+
+    assert build_missed_call_dedupe_key(first_payload, unresolved) == build_missed_call_dedupe_key(first_payload, unresolved)
+    assert build_missed_call_dedupe_key(first_payload, unresolved) != build_missed_call_dedupe_key(second_payload, unresolved)
+
+
 def test_claim_missed_call_notification_marks_duplicate(tmp_path):
     db_path = tmp_path / "approvals.db"
 

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -19,6 +19,7 @@ from webhook_server import (
     detect_reliable_missed_call_hint,
     extract_message_text,
     is_sensitive_message,
+    normalize_call_hook_payload,
     resolve_missed_call_context,
 )
 
@@ -489,6 +490,21 @@ class LineTopicRoutingTests(unittest.TestCase):
 
 
 class MissedCallResolutionTests(unittest.TestCase):
+    def test_call_payload_text_falls_back_to_transcript_when_text_is_blank(self):
+        normalized = normalize_call_hook_payload(
+            {
+                "text": "   ",
+                "transcription": "STOP texting me.",
+                "call_id": "call-123",
+            },
+            {
+                "from_number": "+14155550123",
+                "to_number": "+14155201316",
+                "event_ts_ms": 1760000000000,
+            },
+        )
+        self.assertEqual(normalized["text"], "STOP texting me.")
+
     def test_sparse_payload_nested_key_resolution(self):
         payload = {
             "event": {
@@ -1016,11 +1032,23 @@ class CallWebhookHandlerTests(unittest.TestCase):
         hook_calls = []
         telegram_messages = []
         sms_calls = []
+        crm_payload = {
+            "usable": True,
+            "basis": "attio",
+            "summary": "Acme Corp Demo Booked",
+            "company": "Acme Corp",
+            "stage": "Demo Booked",
+            "deal": "Acme",
+            "owner": None,
+        }
+        calendar_payload = {"usable": False, "status": "not_found"}
 
         with tempfile.TemporaryDirectory() as temp_dir, \
                 patch.object(webhook_server.sms_approval, "DB_PATH", Path(temp_dir) / "approvals.db"), \
                 patch.object(webhook_server, "DIALPAD_AUTO_REPLY_ENABLED", True), \
                 patch.object(webhook_server, "DIALPAD_AUTO_REPLY_SALES_LINE", "4155201316"), \
+                patch.object(webhook_server, "DIALPAD_CRM_CONTEXT_COMMAND", "crm"), \
+                patch.object(webhook_server, "_run_context_command", side_effect=[crm_payload, calendar_payload]), \
                 patch.object(webhook_server, "OPENCLAW_HOOKS_CALL_ENABLED", True), \
                 patch.object(webhook_server, "OPENCLAW_HOOKS_TOKEN", "token-123"), \
                 patch.object(
@@ -1087,14 +1115,10 @@ class CallWebhookHandlerTests(unittest.TestCase):
         self.assertFalse(hook_calls[0]["normalized_event"]["auto_reply"]["sent"])
         self.assertTrue(hook_calls[0]["normalized_event"]["auto_reply"]["draftCreated"])
         self.assertTrue(hook_calls[0]["normalized_event"]["auto_reply"]["draftId"])
+        self.assertIsInstance(hook_calls[0]["normalized_event"]["auto_reply"].get("richReply"), dict)
+        self.assertEqual(hook_calls[0]["normalized_event"]["auto_reply"]["richReply"]["basis"], "attio_crm")
         self.assertEqual(len(telegram_messages), 1)
-        self.assertTrue(response["missed_call"])
-        self.assertTrue(response["hook_forwarded"])
-        self.assertEqual(response["hook_status"], "http_200")
-        self.assertTrue(response["telegram_sent"])
-        self.assertFalse(response["auto_reply_sent"])
-        self.assertEqual(response["auto_reply_status"], "draft_created")
-        self.assertTrue(response["auto_reply_draft_id"])
+        self.assertEqual(response["processing"], "async")
 
     def test_missed_call_child_duplicate_skips_side_effects(self):
         hook_calls = []
@@ -1157,12 +1181,10 @@ class CallWebhookHandlerTests(unittest.TestCase):
         second_response = json.loads(second_handler.wfile.getvalue().decode("utf-8"))
         self.assertEqual(first_status["code"], 200)
         self.assertEqual(second_status["code"], 200)
-        self.assertFalse(first_response["duplicate"])
-        self.assertTrue(second_response["duplicate"])
+        self.assertEqual(first_response["processing"], "async")
+        self.assertEqual(second_response["processing"], "duplicate")
         self.assertEqual(len(hook_calls), 1)
         self.assertEqual(len(telegram_messages), 1)
-        self.assertFalse(second_response["telegram_sent"])
-        self.assertIsNone(second_response["auto_reply_draft_id"])
 
     def test_missed_call_two_child_events_share_entry_point_dedupe(self):
         hook_calls = []
@@ -1218,8 +1240,8 @@ class CallWebhookHandlerTests(unittest.TestCase):
         second_response = json.loads(second_handler.wfile.getvalue().decode("utf-8"))
         self.assertEqual(first_status["code"], 200)
         self.assertEqual(second_status["code"], 200)
-        self.assertFalse(first_response["duplicate"])
-        self.assertTrue(second_response["duplicate"])
+        self.assertEqual(first_response["processing"], "async")
+        self.assertEqual(second_response["processing"], "duplicate")
         self.assertEqual(len(hook_calls), 1)
         self.assertEqual(len(telegram_messages), 1)
 
@@ -1261,8 +1283,7 @@ class CallWebhookHandlerTests(unittest.TestCase):
 
         response = json.loads(handler.wfile.getvalue().decode("utf-8"))
         self.assertEqual(status["code"], 200)
-        self.assertFalse(response["duplicate"])
-        self.assertTrue(response["telegram_sent"])
+        self.assertEqual(response["processing"], "async")
         self.assertEqual(len(telegram_messages), 1)
 
     def test_inbound_missed_call_respects_disabled_hook_config(self):
@@ -1297,13 +1318,8 @@ class CallWebhookHandlerTests(unittest.TestCase):
             handler, status = _build_handler(payload)
             webhook_server.DialpadWebhookHandler.handle_call_webhook(handler)
 
-        response = json.loads(handler.wfile.getvalue().decode("utf-8"))
         self.assertEqual(status["code"], 200)
         self.assertEqual(len(telegram_messages), 1)
-        self.assertTrue(response["missed_call"])
-        self.assertFalse(response["hook_forwarded"])
-        self.assertEqual(response["hook_status"], "disabled_by_config")
-        self.assertTrue(response["telegram_sent"])
 
     def test_inbound_missed_call_hook_failure_keeps_webhook_200(self):
         telegram_messages = []
@@ -1342,12 +1358,8 @@ class CallWebhookHandlerTests(unittest.TestCase):
             handler, status = _build_handler(payload)
             webhook_server.DialpadWebhookHandler.handle_call_webhook(handler)
 
-        response = json.loads(handler.wfile.getvalue().decode("utf-8"))
         self.assertEqual(status["code"], 200)
-        self.assertTrue(response["missed_call"])
-        self.assertFalse(response["hook_forwarded"])
-        self.assertEqual(response["hook_status"], "request_failed")
-        self.assertTrue(response["telegram_sent"])
+        self.assertEqual(len(telegram_messages), 1)
 
     def test_inbound_missed_call_token_missing_keeps_webhook_200(self):
         telegram_messages = []
@@ -1381,12 +1393,8 @@ class CallWebhookHandlerTests(unittest.TestCase):
             handler, status = _build_handler(payload)
             webhook_server.DialpadWebhookHandler.handle_call_webhook(handler)
 
-        response = json.loads(handler.wfile.getvalue().decode("utf-8"))
         self.assertEqual(status["code"], 200)
-        self.assertTrue(response["missed_call"])
-        self.assertFalse(response["hook_forwarded"])
-        self.assertEqual(response["hook_status"], "token_missing")
-        self.assertTrue(response["telegram_sent"])
+        self.assertEqual(len(telegram_messages), 1)
 
     def test_outbound_call_does_not_forward_hook_or_telegram(self):
         hook_calls = []
@@ -1472,6 +1480,16 @@ class CallWebhookHandlerTests(unittest.TestCase):
         telegram_messages = []
         sms_calls = []
         event_ts = 1760000000000
+        crm_payload = {
+            "usable": True,
+            "basis": "attio",
+            "summary": "Acme Corp Demo Booked",
+            "company": "Acme Corp",
+            "stage": "Demo Booked",
+            "deal": "Acme",
+            "owner": None,
+        }
+        calendar_payload = {"usable": False, "status": "not_found"}
         recent_call = {
             "external_number": "+14322083277",
             "entry_point_target": {"phone": "+14155201316", "name": "Sales"},
@@ -1485,6 +1503,8 @@ class CallWebhookHandlerTests(unittest.TestCase):
                 patch.object(webhook_server.sms_approval, "DB_PATH", Path(temp_dir) / "approvals.db"), \
                 patch.object(webhook_server, "DIALPAD_AUTO_REPLY_ENABLED", True), \
                 patch.object(webhook_server, "DIALPAD_AUTO_REPLY_SALES_LINE", "4155201316"), \
+                patch.object(webhook_server, "DIALPAD_CRM_CONTEXT_COMMAND", "crm"), \
+                patch.object(webhook_server, "_run_context_command", side_effect=[crm_payload, calendar_payload]), \
                 patch.object(webhook_server, "OPENCLAW_HOOKS_CALL_ENABLED", True), \
                 patch.object(webhook_server, "OPENCLAW_HOOKS_TOKEN", "token-123"), \
                 patch.object(
@@ -1532,7 +1552,6 @@ class CallWebhookHandlerTests(unittest.TestCase):
             handler, status = _build_handler(payload)
             webhook_server.DialpadWebhookHandler.handle_call_webhook(handler)
 
-        response = json.loads(handler.wfile.getvalue().decode("utf-8"))
         inbound_context = hook_calls[0]["normalized_event"]["inbound_context"]
         self.assertEqual(status["code"], 200)
         self.assertEqual(sms_calls, [])
@@ -1541,8 +1560,9 @@ class CallWebhookHandlerTests(unittest.TestCase):
         self.assertEqual(inbound_context["recency"]["state"], "fresh")
         self.assertTrue(inbound_context["contextDraftAllowed"])
         self.assertTrue(hook_calls[0]["normalized_event"]["auto_reply"]["draftCreated"])
-        self.assertEqual(response["auto_reply_status"], "draft_created")
-        self.assertTrue(response["auto_reply_draft_id"])
+        self.assertEqual(hook_calls[0]["normalized_event"]["auto_reply"]["status"], "draft_created")
+        self.assertTrue(hook_calls[0]["normalized_event"]["auto_reply"]["draftId"])
+        self.assertEqual(hook_calls[0]["normalized_event"]["auto_reply"]["richReply"]["basis"], "attio_crm")
         self.assertIn("Inbound context", telegram_messages[0])
         self.assertIn("Ann Harper", telegram_messages[0])
         self.assertIn("SMS approval draft", telegram_messages[0])
@@ -1606,14 +1626,13 @@ class CallWebhookHandlerTests(unittest.TestCase):
             handler, status = _build_handler(payload)
             webhook_server.DialpadWebhookHandler.handle_call_webhook(handler)
 
-        response = json.loads(handler.wfile.getvalue().decode("utf-8"))
         inbound_context = hook_calls[0]["normalized_event"]["inbound_context"]
         self.assertEqual(status["code"], 200)
         self.assertEqual(inbound_context["recency"]["state"], "stale")
         self.assertFalse(inbound_context["contextDraftAllowed"])
         self.assertFalse(hook_calls[0]["normalized_event"]["auto_reply"]["draftCreated"])
-        self.assertEqual(response["auto_reply_status"], "not_eligible")
-        self.assertIsNone(response["auto_reply_draft_id"])
+        self.assertEqual(hook_calls[0]["normalized_event"]["auto_reply"]["status"], "not_eligible")
+        self.assertIsNone(hook_calls[0]["normalized_event"]["auto_reply"]["draftId"])
         self.assertIn("Inbound context", telegram_messages[0])
         self.assertNotIn("SMS approval draft", telegram_messages[0])
 
@@ -1677,7 +1696,6 @@ class CallWebhookHandlerTests(unittest.TestCase):
             handler, status = _build_handler(payload)
             webhook_server.DialpadWebhookHandler.handle_call_webhook(handler)
 
-        response = json.loads(handler.wfile.getvalue().decode("utf-8"))
         first_contact = hook_calls[0]["normalized_event"]["first_contact"]
         inbound_context = hook_calls[0]["normalized_event"]["inbound_context"]
         self.assertEqual(status["code"], 200)
@@ -1689,13 +1707,14 @@ class CallWebhookHandlerTests(unittest.TestCase):
         self.assertTrue(inbound_context["genericDraftAllowed"])
         self.assertEqual(inbound_context["draftMode"], "deterministic_fallback")
         self.assertNotIn("exact_phone_match", inbound_context["evidence"])
-        self.assertEqual(response["auto_reply_status"], "draft_created")
-        self.assertTrue(response["auto_reply_draft_id"])
+        self.assertEqual(hook_calls[0]["normalized_event"]["auto_reply"]["status"], "draft_created")
+        self.assertTrue(hook_calls[0]["normalized_event"]["auto_reply"]["draftId"])
         self.assertTrue(hook_calls[0]["normalized_event"]["auto_reply"]["draftCreated"])
         self.assertTrue(hook_calls[0]["normalized_event"]["auto_reply"]["message"].startswith("Hi there,"))
         self.assertNotIn("Payload Person", hook_calls[0]["normalized_event"]["auto_reply"]["message"])
         self.assertIn("Inbound context", telegram_messages[0])
         self.assertIn("approval draft created (generic fallback)", telegram_messages[0])
+        self.assertIn("CRM: not configured; Calendar: not applicable; QMD: not applicable", telegram_messages[0])
         self.assertIn("SMS approval draft", telegram_messages[0])
 
 


### PR DESCRIPTION
## Summary

Missed-call webhooks now ACK before enrichment work and can create operator-approved CRM/calendar-aware reply drafts without exposing low-confidence PII to customers. Silent missed calls also show operator-facing source statuses, so a reviewer can tell whether CRM, calendar, or QMD was usable, unavailable, unsafe, not configured, or not applicable.

## What

- Moves missed-call webhook processing onto the ACK-first path and keeps duplicate responses minimal.
- Extends Sales enrichment drafts to missed calls, including call-specific CRM copy, recent-demo calendar context, and transcript-like text passthrough when Dialpad provides it.
- Preserves CRM-aware missed-call drafts when calendar lookup misses, while narrowing calendar lookup to calls with eligible inbound context.
- Adds source-status metadata to approval fingerprints, draft metadata, and Telegram approval cards.
- Documents the missed-call enrichment adapter contract and low-confidence PII rule.

## Why

The previous missed-call path could block Dialpad while enrichment/draft/hook/Telegram work ran inline, and missed calls could only fall back to generic approval copy even when safe CRM context existed. This makes missed-call drafts useful for Sales follow-up while keeping all customer-visible personalization behind the existing confidence gates.

## Tests

- `timeout -k5s 60s python -m unittest tests.test_calendar_context tests.test_ungate_provenance tests.test_webhook_server.CallWebhookHandlerTests`
- `timeout -k5s 120s python -m unittest discover -s tests`

Browser testing: not applicable. The changed surface is backend webhook/adapters/tests/docs, with no browser route to exercise.

## AI Assistance

Implemented with Codex. Local review findings were applied for calendar fallback behavior, `richReply` hook metadata, invalid env parsing, recent-demo state, and source-status coverage.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
