### PR TITLE
fix(webhook): keep Dialpad hook replies in line topics

### DIFF
--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -412,6 +412,47 @@ def resolve_telegram_route(sender_number, recipient_line):
     return None, None
 
 
+def format_telegram_group_route(chat_id, message_thread_id=None):
+    """Format an OpenClaw Telegram group route from chat/topic components."""
+    if chat_id is None:
+        return None
+    resolved_chat_id = str(chat_id).strip()
+    if not resolved_chat_id:
+        return None
+    route = f"telegram:group:{resolved_chat_id}"
+    if message_thread_id is not None and str(message_thread_id).strip():
+        route += f":topic:{str(message_thread_id).strip()}"
+    return route
+
+
+def resolve_openclaw_hook_target(normalized_event):
+    """
+    Resolve the OpenClaw hook delivery target for a Dialpad event.
+
+    Precedence:
+      1. Explicit priority sender route, preserving the existing hook-only behavior.
+      2. Recipient-line Telegram topic route, matching the direct review card topic.
+      3. OPENCLAW_HOOKS_TO fallback.
+    """
+    sender_number_normalized = normalize_phone_number(normalized_event.get("sender_number"))
+    if (
+        DIALPAD_PRIORITY_ROUTE_TO
+        and sender_number_normalized
+        and sender_number_normalized in PRIORITY_ROUTE_PHONES
+    ):
+        return DIALPAD_PRIORITY_ROUTE_TO
+
+    route_chat_id, route_thread_id = resolve_telegram_route(
+        normalized_event.get("sender_number"),
+        normalized_event.get("recipient_number"),
+    )
+    line_target = format_telegram_group_route(route_chat_id, route_thread_id)
+    if line_target:
+        return line_target
+
+    return OPENCLAW_HOOKS_TO
+
+
 def get_line_name(to_number):
     """
     Resolve a Dialpad receiving line number to display text.
@@ -1100,6 +1141,7 @@ def update_telegram_review_after_callback(callback_query, result, draft_id):
     chat = message.get("chat") or {}
     chat_id = chat.get("id")
     message_id = message.get("message_id")
+    message_thread_id = message.get("message_thread_id")
     status = (result or {}).get("status")
 
     if status == "risky_confirmation_required":
@@ -1112,7 +1154,11 @@ def update_telegram_review_after_callback(callback_query, result, draft_id):
     elif (result or {}).get("sent") or status in TELEGRAM_TERMINAL_APPROVAL_STATUSES:
         edit_telegram_message_reply_markup(chat_id, message_id, reply_markup=None)
 
-    return send_to_telegram(build_telegram_callback_status_message(result, draft_id))
+    return send_to_telegram(
+        build_telegram_callback_status_message(result, draft_id),
+        chat_id=chat_id,
+        message_thread_id=message_thread_id,
+    )
 
 
 def dispatch_telegram_approval_callback(callback_query, parsed_callback):
@@ -3914,14 +3960,7 @@ def build_openclaw_hook_payload(normalized_event, line_display=None):
         "deliver": True,
     }
 
-    sender_number_normalized = normalize_phone_number(normalized_event.get("sender_number"))
-    target_to = OPENCLAW_HOOKS_TO
-    if (
-        DIALPAD_PRIORITY_ROUTE_TO
-        and sender_number_normalized
-        and sender_number_normalized in PRIORITY_ROUTE_PHONES
-    ):
-        target_to = DIALPAD_PRIORITY_ROUTE_TO
+    target_to = resolve_openclaw_hook_target(normalized_event)
 
     if OPENCLAW_HOOKS_CHANNEL:
         payload["channel"] = OPENCLAW_HOOKS_CHANNEL

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -426,6 +426,20 @@ class LineTopicRoutingTests(unittest.TestCase):
         self.assertEqual(chat_id, "-1003882776023")
         self.assertEqual(thread_id, "3537")
 
+    def test_hook_payload_routes_by_recipient_line_topic(self):
+        with patch.object(webhook_server, "LINE_TOPIC_ROUTES", self._routes_map()), \
+                patch.object(webhook_server, "OPENCLAW_HOOKS_TO", "-1003882776023"), \
+                patch.object(webhook_server, "PRIORITY_ROUTE_PHONES", set()), \
+                patch.object(webhook_server, "DIALPAD_PRIORITY_ROUTE_TO", ""):
+            payload = webhook_server.build_openclaw_hook_payload({
+                "event_type": "sms",
+                "sender_number": "+17018333346",
+                "recipient_number": "+14155201316",
+                "text": "Hi I got a confirmation?",
+            })
+
+        self.assertEqual(payload["to"], "telegram:group:-1003882776023:topic:3530")
+
     def test_malformed_routes_behave_as_unset(self):
         with patch.object(
             webhook_server,
@@ -836,7 +850,7 @@ class TelegramCallbackHandlerTests(unittest.TestCase):
 
     def test_non_terminal_actor_failure_keeps_existing_approval_buttons(self):
         callback_query = {
-            "message": {"message_id": 99, "chat": {"id": "-100123"}},
+            "message": {"message_id": 99, "message_thread_id": 3530, "chat": {"id": "-100123"}},
         }
 
         with patch.object(webhook_server, "edit_telegram_message_reply_markup") as edit_markup, \
@@ -855,6 +869,8 @@ class TelegramCallbackHandlerTests(unittest.TestCase):
 
         edit_markup.assert_not_called()
         send_status.assert_called_once()
+        self.assertEqual(send_status.call_args.kwargs["chat_id"], "-100123")
+        self.assertEqual(send_status.call_args.kwargs["message_thread_id"], 3530)
 
 
 class CallWebhookHandlerTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
Dialpad Sales-line SMS and approval chatter now stay in the Sales forum topic instead of splitting between the correct review card and Dialpad #General. The OpenClaw hook target now reuses the same recipient-line topic mapping as the direct Telegram card, while preserving existing priority-sender hook routing ahead of the line fallback.

Approval callback status messages also preserve the originating Telegram chat and topic, so visible send/reject status lands beside the card that was acted on.

## Tests
- `python3 -m unittest tests.test_webhook_server.LineTopicRoutingTests.test_hook_payload_routes_by_recipient_line_topic tests.test_webhook_server.TelegramCallbackHandlerTests.test_non_terminal_actor_failure_keeps_existing_approval_buttons`
- `python3 -m unittest tests.test_webhook_server.LineTopicRoutingTests`
- `python3 -m unittest tests.test_webhook_server.TelegramCallbackHandlerTests`
- `python3 -m unittest tests.test_webhook_server`
- `curl -fsS http://127.0.0.1:8888/health`

## Live Verification
- Restarted `dialpad-webhook.service` after applying the hotfix on the NixOS host.
- Confirmed startup config still loads `+1 415 520 1316 -> telegram:group:-1003882776023:topic:3530`.
- Confirmed a local Sales-line hook payload resolves `to` as `telegram:group:-1003882776023:topic:3530`.

## AI Assistance
Implemented and verified with Codex.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
