### PR TITLE
docs: plan phone validation prospect enrichment

### DIFF
--- a/docs/brainstorms/2026-06-23-phone-validation-prospect-enrichment-requirements.md
+++ b/docs/brainstorms/2026-06-23-phone-validation-prospect-enrichment-requirements.md
@@ -1,0 +1,147 @@
+---
+date: 2026-06-23
+topic: phone-validation-prospect-enrichment
+---
+
+# Requirements — Phone validation and prospect enrichment for Dialpad inbound drafts
+
+## Summary
+
+Unknown Sales callers should get a shared phone-intelligence pass before SMS or missed-call drafts fall back to generic copy. The webhook should validate the number, expose caller-risk and reverse-lookup facts to the operator, optionally search public business context, and let the draft model use only compact tool facts when producing approval-gated replies.
+
+---
+
+## Problem Frame
+
+A low-confidence Sales missed call from a valid active wireless number currently appears as only the raw phone number. That protects against false personalization, but it also hides useful triage facts: whether the number is valid, active, likely mobile or VOIP, associated with spam, and whether a reverse name plus location can point to a business owner or prospect.
+
+IPQualityScore can provide phone validation, carrier, line type, active-line, risk, location, and reverse-name signals. Those signals are useful for operator triage, but they are not strong enough by themselves to make a customer-facing identity claim. Public web search can add business-prospect clues, but weak or personal-only results must not become draft personalization.
+
+---
+
+## Key Decisions
+
+- **Use a shared caller-intelligence layer.** SMS and missed-call webhooks should call the same logic so phone validation, risk labels, public-search context, and model facts stay consistent.
+- **Treat IPQS as operator evidence, not identity authority.** A reverse name can help the operator understand the caller, but it must not make identity confidence high by itself.
+- **Search for business relevance only after phone validation.** Web search should be bounded to validated, active numbers with usable reverse-name or location facts, and should look for public business/professional matches rather than personal background details.
+- **Keep model drafting fact-grounded and approval-gated.** The model should draft from compact tool facts and deterministic fallback text; it must fail closed when facts are weak, unsafe, or unsupported.
+
+---
+
+## Requirements
+
+**Phone intelligence**
+
+- R1. Inbound Sales SMS and Sales missed-call events must attempt shared phone validation when Dialpad contact lookup and CRM lookup do not produce high-confidence identity.
+- R2. Phone validation must surface compact operator-facing facts for validity, active-line status, country, city, region, carrier, line type, reverse name, and abusive/fraud status when the provider returns them.
+- R3. Phone validation status must distinguish `usable`, `not_configured`, `not_found`, `invalid`, `inactive`, `risky`, `unavailable`, `timeout`, `budget_exceeded`, `rate_limited`, and `unsafe_output`.
+- R4. Invalid, inactive, or abusive-number signals must be visible in Telegram and draft metadata before any operator approves a reply.
+- R5. Phone validation must fail closed to the existing generic or CRM-aware behavior when the provider is missing, slow, or unavailable.
+
+**Identity and prospect context**
+
+- R6. Reverse-name or location facts from phone validation must not raise customer-facing identity confidence to high without an exact CRM/Dialpad match or other strong owned-source evidence.
+- R7. When phone validation returns a reverse name and location for a valid active number, the system may run a bounded public web search for business/professional context.
+- R8. Public-search context must be summarized as operator-only prospect evidence only when bounded evidence ties the reverse name plus location to a business, role, or organization relevant to ShapeScale for Business.
+- R9. Public-search context must avoid sensitive personal details and must not store raw search-result pages or long snippets in approval metadata.
+- R10. The Telegram card must distinguish "possible caller identity" from "confirmed contact identity" so operators do not confuse reverse lookup with CRM identity.
+
+**Draft behavior**
+
+- R11. The customer-facing draft must remain generic when only phone validation facts are available.
+- R12. The draft model may use phone validation and public-search facts to choose tone and context, but it must not greet by reverse name or mention a business unless the final facts meet the same safety bar as other high-confidence personalization.
+- R13. For valid active unknown Sales callers with no risky signals, the generic fallback should remain helpful and human: acknowledge the missed call or inbound SMS and ask how Sales can help.
+- R14. For high-risk, inactive, or invalid numbers, the system must withhold generated customer-facing drafts and route the event to human-only handling.
+- R15. Model-generated drafts must be rejected when they introduce unsupported identity claims, unsupported business claims, raw internal source names, unapproved links, or sensitive personal details.
+
+**Operations and cost control**
+
+- R16. The IPQS API key must be loaded from secrets, not committed configuration; the observed 1Password item is `IPQUALITYSCORE IPQS API Key`.
+- R17. Phone validation must use short timeouts and bounded retries so webhook ACK-first behavior and Telegram delivery are not blocked by the provider.
+- R18. Results should be cached by normalized phone number for a bounded TTL so repeated webhook events do not burn unnecessary validation credits, with different TTLs for phone validation and public search.
+- R19. Public web search must be optional, bounded, budgeted, and separately statused from IPQS so a search failure or budget cap does not erase phone-validation facts.
+- R20. SMS and missed-call tests must cover the same shared helper contract rather than duplicating separate source logic.
+
+---
+
+## Actors
+
+- A1. **Caller** — the person or business contacting the Sales line.
+- A2. **Operator** — the human reviewing Telegram context and approving or rejecting SMS drafts.
+- A3. **Dialpad webhook service** — the service normalizing inbound SMS and missed-call events, enriching context, creating approval drafts, and forwarding OpenClaw hook payloads.
+- A4. **Phone intelligence provider** — IPQualityScore phone validation.
+- A5. **Public-search source** — bounded web search used only for business/prospect clues.
+- A6. **Draft model** — a cheap configured model that can rewrite approval drafts from compact facts but cannot send.
+
+---
+
+## Key Flows
+
+- F1. Unknown valid Sales missed call
+  - **Trigger:** A Sales missed call arrives from a number with no CRM or Dialpad exact match.
+  - **Actors:** A1, A2, A3, A4, A5, A6
+  - **Steps:** The webhook validates the number, surfaces valid/active/carrier/location/reverse-name facts, runs bounded business-context search when eligible, and creates an approval draft from deterministic fallback plus compact facts.
+  - **Outcome:** The operator sees why the caller may be a real prospect while the customer-facing text stays safe unless identity is confirmed.
+
+- F2. Unknown inbound Sales SMS
+  - **Trigger:** A first-contact Sales SMS arrives from an unknown number.
+  - **Actors:** A1, A2, A3, A4, A5, A6
+  - **Steps:** The webhook uses the same phone-intelligence helper as missed calls, adds phone and prospect facts to the operator context, and lets the draft model improve the generic reply only within the fact boundary.
+  - **Outcome:** SMS and missed-call cards expose the same source statuses and safety semantics.
+
+- F3. Risky or invalid caller
+  - **Trigger:** Phone validation says the number is invalid, inactive, VOIP/disposable with high risk, or reported abusive.
+  - **Actors:** A1, A2, A3, A4
+  - **Steps:** The webhook marks the risk in Telegram, avoids unsupported personalization, and withholds generated customer-facing drafts.
+  - **Outcome:** The operator can still act manually, but automation does not present a risky reply as routine.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R10, R11.** Given an unknown Sales missed call from a valid active wireless number with a reverse name, when the draft is created, then Telegram shows the phone intelligence and the customer-facing draft does not greet by that reverse name.
+- AE2. **Covers R7, R8, R12.** Given phone validation returns a reverse name and Fort Worth location, when bounded public search finds a strong business/professional match, then Telegram may show a possible prospect summary and the model may use it only if the identity safety bar is met.
+- AE3. **Covers R3, R4, R14.** Given IPQS marks a number invalid, inactive, or abusive, when the webhook processes the event, then the Telegram card shows the risk status and no generated customer-facing draft is created.
+- AE4. **Covers R5, R17, R19.** Given IPQS times out and web search is unavailable, when a Sales SMS arrives, then the webhook still ACKs, creates the existing safe fallback when eligible, and records phone intelligence as unavailable.
+- AE5. **Covers R20.** Given equivalent unknown caller facts for SMS and missed-call events, when tests run, then both paths use the same helper output and render consistent source statuses.
+
+---
+
+## Success Criteria
+
+- Unknown Sales callers no longer appear as raw phone numbers when IPQS can provide safe validation context.
+- Operators can distinguish valid active prospects from invalid, inactive, VOIP/disposable, or abuse-reported numbers before approving a reply or handling a high-risk caller manually.
+- Customer-facing drafts do not leak reverse-lookup names or public-search guesses.
+- SMS and missed-call webhook paths share source semantics, status labels, and model-fact boundaries.
+- Provider outages do not break webhook ACKs, Telegram notifications, or existing safe fallback drafts.
+
+---
+
+## Scope Boundaries
+
+- No autonomous SMS sending expansion.
+- No phone-number identity resolver that treats IPQS or web search as equivalent to CRM/Dialpad identity.
+- No voicemail support in the first version.
+- No generated customer-facing draft for high-risk, inactive, or invalid callers in the first version.
+- No storage of raw public-search pages, sensitive personal details, or full IPQS payloads in draft metadata.
+- No bulk lead enrichment outside inbound webhook-triggered Sales events.
+
+---
+
+## Dependencies / Assumptions
+
+- The IPQS secret exists in 1Password as `IPQUALITYSCORE IPQS API Key` and should be exposed to the runtime through an environment variable.
+- IPQS phone validation returns enough compact fields to support validity, active-line, carrier, line type, location, reverse-name, and fraud/abuse status.
+- Public web search may produce weak or personal-only matches; weak matches are useful operator clues at most and should not affect customer-facing personalization.
+- Existing low-confidence draft guardrails from the model-draft layer remain the safety boundary for names, companies, links, and unsupported claims.
+
+---
+
+## Sources / Research
+
+- `scripts/webhook_server.py` — shared inbound context, SMS webhook processing, missed-call webhook processing, approval-draft creation, and Telegram rendering.
+- `scripts/draft_model.py` — compact model fact boundary and draft rejection rules.
+- `docs/brainstorms/2026-06-22-missed-call-enrichment-requirements.md` — missed-call enrichment source-status and PII safety requirements.
+- `docs/brainstorms/2026-06-23-calendar-aware-demo-context-requirements.md` — compact tool facts and model-draft safety requirements.
+- IPQualityScore Phone Number Validation API documentation: `https://www.ipqualityscore.com/documentation/phone-number-validation-api/overview`
+- IPQualityScore advanced options documentation: `https://www.ipqualityscore.com/documentation/phone-number-validation-api/advanced-options`

--- a/docs/brainstorms/2026-06-23-phone-validation-prospect-enrichment-requirements.md
+++ b/docs/brainstorms/2026-06-23-phone-validation-prospect-enrichment-requirements.md
@@ -25,6 +25,7 @@ IPQualityScore can provide phone validation, carrier, line type, active-line, ri
 - **Treat IPQS as operator evidence, not identity authority.** A reverse name can help the operator understand the caller, but it must not make identity confidence high by itself.
 - **Search for business relevance only after phone validation.** Web search should be bounded to validated, active numbers with usable reverse-name or location facts, and should look for public business/professional matches rather than personal background details.
 - **Keep model drafting fact-grounded and approval-gated.** The model should draft from compact tool facts and deterministic fallback text; it must fail closed when facts are weak, unsafe, or unsupported.
+- **Sync Dialpad contacts only after the identity bar is met.** Enrichment should update or create Dialpad contact records automatically when the evidence is clear, but ambiguous reverse lookup or weak public search should only produce an operator-visible suggestion.
 
 ---
 
@@ -57,10 +58,17 @@ IPQualityScore can provide phone validation, carrier, line type, active-line, ri
 **Operations and cost control**
 
 - R16. The IPQS API key must be loaded from secrets, not committed configuration; the observed 1Password item is `IPQUALITYSCORE IPQS API Key`.
-- R17. Phone validation must use short timeouts and bounded retries so webhook ACK-first behavior and Telegram delivery are not blocked by the provider.
+- R17. Phone validation and public search must run only after the relevant idempotency claim and webhook ACK; short timeouts and bounded retries must keep Telegram delivery from being blocked by the provider.
 - R18. Results should be cached by normalized phone number for a bounded TTL so repeated webhook events do not burn unnecessary validation credits, with different TTLs for phone validation and public search.
 - R19. Public web search must be optional, bounded, budgeted, and separately statused from IPQS so a search failure or budget cap does not erase phone-validation facts.
 - R20. SMS and missed-call tests must cover the same shared helper contract rather than duplicating separate source logic.
+
+**Dialpad contact sync**
+
+- R21. When enrichment produces high-confidence owned-source identity or an unambiguous public business/professional match for the validated phone number, the system should automatically create or update the Dialpad contact using the existing contact wrappers.
+- R22. Automatic contact sync must never use IPQS reverse name alone, area code, weak public search, or same-name personal results as the basis for a contact name, company, or merge.
+- R23. Automatic updates must fill missing non-sensitive fields or append confirmed identifiers, not overwrite populated Dialpad fields with lower-confidence data.
+- R24. Ambiguous, conflicting, risky, inactive, invalid, or budget-degraded enrichment must produce an operator-visible contact-sync suggestion or warning instead of a writeback.
 
 ---
 
@@ -72,6 +80,7 @@ IPQualityScore can provide phone validation, carrier, line type, active-line, ri
 - A4. **Phone intelligence provider** — IPQualityScore phone validation.
 - A5. **Public-search source** — bounded web search used only for business/prospect clues.
 - A6. **Draft model** — a cheap configured model that can rewrite approval drafts from compact facts but cannot send.
+- A7. **Dialpad contact sync** — existing create/update wrappers used only after identity and ambiguity gates pass.
 
 ---
 
@@ -85,9 +94,9 @@ IPQualityScore can provide phone validation, carrier, line type, active-line, ri
 
 - F2. Unknown inbound Sales SMS
   - **Trigger:** A first-contact Sales SMS arrives from an unknown number.
-  - **Actors:** A1, A2, A3, A4, A5, A6
-  - **Steps:** The webhook uses the same phone-intelligence helper as missed calls, adds phone and prospect facts to the operator context, and lets the draft model improve the generic reply only within the fact boundary.
-  - **Outcome:** SMS and missed-call cards expose the same source statuses and safety semantics.
+  - **Actors:** A1, A2, A3, A4, A5, A6, A7
+  - **Steps:** The webhook uses the same phone-intelligence helper as missed calls, adds phone and prospect facts to the operator context, lets the draft model improve the generic reply only within the fact boundary, and runs contact sync only if the identity/writeback bar is met.
+  - **Outcome:** SMS and missed-call cards expose the same source statuses and safety semantics, and clear matches can keep Dialpad contacts current without manual data entry.
 
 - F3. Risky or invalid caller
   - **Trigger:** Phone validation says the number is invalid, inactive, VOIP/disposable with high risk, or reported abusive.
@@ -104,6 +113,7 @@ IPQualityScore can provide phone validation, carrier, line type, active-line, ri
 - AE3. **Covers R3, R4, R14.** Given IPQS marks a number invalid, inactive, or abusive, when the webhook processes the event, then the Telegram card shows the risk status and no generated customer-facing draft is created.
 - AE4. **Covers R5, R17, R19.** Given IPQS times out and web search is unavailable, when a Sales SMS arrives, then the webhook still ACKs, creates the existing safe fallback when eligible, and records phone intelligence as unavailable.
 - AE5. **Covers R20.** Given equivalent unknown caller facts for SMS and missed-call events, when tests run, then both paths use the same helper output and render consistent source statuses.
+- AE6. **Covers R21-R24.** Given a validated active number and a single unambiguous owned-source/public-business match, when enrichment completes, then Dialpad contact sync fills missing confirmed fields; given only reverse-name or conflicting evidence, then no writeback occurs and Telegram shows a suggested contact update.
 
 ---
 
@@ -114,6 +124,7 @@ IPQualityScore can provide phone validation, carrier, line type, active-line, ri
 - Customer-facing drafts do not leak reverse-lookup names or public-search guesses.
 - SMS and missed-call webhook paths share source semantics, status labels, and model-fact boundaries.
 - Provider outages do not break webhook ACKs, Telegram notifications, or existing safe fallback drafts.
+- Clear enriched identities can update Dialpad contacts automatically, while ambiguous or risky matches stay human-reviewed.
 
 ---
 
@@ -123,6 +134,7 @@ IPQualityScore can provide phone validation, carrier, line type, active-line, ri
 - No phone-number identity resolver that treats IPQS or web search as equivalent to CRM/Dialpad identity.
 - No voicemail support in the first version.
 - No generated customer-facing draft for high-risk, inactive, or invalid callers in the first version.
+- No automatic contact overwrite or merge from reverse-name-only, same-name, area-code, or weak public-search evidence.
 - No storage of raw public-search pages, sensitive personal details, or full IPQS payloads in draft metadata.
 - No bulk lead enrichment outside inbound webhook-triggered Sales events.
 
@@ -134,6 +146,7 @@ IPQualityScore can provide phone validation, carrier, line type, active-line, ri
 - IPQS phone validation returns enough compact fields to support validity, active-line, carrier, line type, location, reverse-name, and fraud/abuse status.
 - Public web search may produce weak or personal-only matches; weak matches are useful operator clues at most and should not affect customer-facing personalization.
 - Existing low-confidence draft guardrails from the model-draft layer remain the safety boundary for names, companies, links, and unsupported claims.
+- Existing `bin/create_contact.py` and `bin/update_contact.py` wrappers remain the supported Dialpad writeback surface.
 
 ---
 
@@ -141,6 +154,8 @@ IPQualityScore can provide phone validation, carrier, line type, active-line, ri
 
 - `scripts/webhook_server.py` — shared inbound context, SMS webhook processing, missed-call webhook processing, approval-draft creation, and Telegram rendering.
 - `scripts/draft_model.py` — compact model fact boundary and draft rejection rules.
+- `bin/create_contact.py` and `bin/update_contact.py` — existing Dialpad contact writeback wrappers.
+- `docs/ideation/2026-03-26-dialpad-contact-merge-ambiguity-ideation.md` — ambiguity and writeback guardrails.
 - `docs/brainstorms/2026-06-22-missed-call-enrichment-requirements.md` — missed-call enrichment source-status and PII safety requirements.
 - `docs/brainstorms/2026-06-23-calendar-aware-demo-context-requirements.md` — compact tool facts and model-draft safety requirements.
 - IPQualityScore Phone Number Validation API documentation: `https://www.ipqualityscore.com/documentation/phone-number-validation-api/overview`

--- a/docs/brainstorms/2026-06-23-phone-validation-prospect-enrichment-requirements.md
+++ b/docs/brainstorms/2026-06-23-phone-validation-prospect-enrichment-requirements.md
@@ -34,7 +34,7 @@ IPQualityScore can provide phone validation, carrier, line type, active-line, ri
 **Phone intelligence**
 
 - R1. Inbound Sales SMS and Sales missed-call events must attempt shared phone validation when Dialpad contact lookup and CRM lookup do not produce high-confidence identity.
-- R2. Phone validation must surface compact operator-facing facts for validity, active-line status, country, city, region, carrier, line type, reverse name, and abusive/fraud status when the provider returns them.
+- R2. Phone validation must surface compact operator-facing facts for validity, active-line status, country, city, region, carrier, line type, reverse name, and abusive/fraud status when the provider returns them; missing active-line fields must remain unknown, not inactive.
 - R3. Phone validation status must distinguish `usable`, `not_configured`, `not_found`, `invalid`, `inactive`, `risky`, `unavailable`, `timeout`, `budget_exceeded`, `rate_limited`, and `unsafe_output`.
 - R4. Invalid, inactive, or abusive-number signals must be visible in Telegram and draft metadata before any operator approves a reply.
 - R5. Phone validation must fail closed to the existing generic or CRM-aware behavior when the provider is missing, slow, or unavailable.
@@ -42,7 +42,7 @@ IPQualityScore can provide phone validation, carrier, line type, active-line, ri
 **Identity and prospect context**
 
 - R6. Reverse-name or location facts from phone validation must not raise customer-facing identity confidence to high without an exact CRM/Dialpad match or other strong owned-source evidence.
-- R7. When phone validation returns a reverse name and location for a valid active number, the system may run a bounded public web search for business/professional context.
+- R7. When phone validation returns a reverse name and location for a valid, not-inactive, low-risk number, the system may run a bounded public web search for business/professional context.
 - R8. Public-search context must be summarized as operator-only prospect evidence only when bounded evidence ties the reverse name plus location to a business, role, or organization relevant to ShapeScale for Business.
 - R9. Public-search context must avoid sensitive personal details and must not store raw search-result pages or long snippets in approval metadata.
 - R10. The Telegram card must distinguish "possible caller identity" from "confirmed contact identity" so operators do not confuse reverse lookup with CRM identity.
@@ -51,7 +51,7 @@ IPQualityScore can provide phone validation, carrier, line type, active-line, ri
 
 - R11. The customer-facing draft must remain generic when only phone validation facts are available.
 - R12. The draft model may use phone validation and public-search facts to choose tone and context, but it must not greet by reverse name or mention a business unless the final facts meet the same safety bar as other high-confidence personalization.
-- R13. For valid active unknown Sales callers with no risky signals, the generic fallback should remain helpful and human: acknowledge the missed call or inbound SMS and ask how Sales can help.
+- R13. For valid, not-inactive, low-risk unknown Sales callers, the generic fallback should remain helpful and human: acknowledge the missed call or inbound SMS and ask how Sales can help.
 - R14. For high-risk, inactive, or invalid numbers, the system must withhold generated customer-facing drafts and route the event to human-only handling.
 - R15. Model-generated drafts must be rejected when they introduce unsupported identity claims, unsupported business claims, raw internal source names, unapproved links, or sensitive personal details.
 
@@ -65,9 +65,9 @@ IPQualityScore can provide phone validation, carrier, line type, active-line, ri
 
 **Dialpad contact sync**
 
-- R21. When enrichment produces high-confidence owned-source identity or an unambiguous public business/professional match for the validated phone number, the system should automatically create or update the Dialpad contact using the existing contact wrappers.
+- R21. When enrichment produces high-confidence owned-source identity or public business/professional evidence that directly corroborates the validated phone number, the system should automatically create or update the Dialpad contact using the existing contact wrappers.
 - R22. Automatic contact sync must never use IPQS reverse name alone, area code, weak public search, or same-name personal results as the basis for a contact name, company, or merge.
-- R23. Automatic updates must fill missing non-sensitive fields or append confirmed identifiers, not overwrite populated Dialpad fields with lower-confidence data.
+- R23. Automatic updates must fill missing non-sensitive fields or append confirmed identifiers by merging current contact values before writeback, not overwrite populated Dialpad fields with lower-confidence data.
 - R24. Ambiguous, conflicting, risky, inactive, invalid, or budget-degraded enrichment must produce an operator-visible contact-sync suggestion or warning instead of a writeback.
 
 ---
@@ -113,7 +113,7 @@ IPQualityScore can provide phone validation, carrier, line type, active-line, ri
 - AE3. **Covers R3, R4, R14.** Given IPQS marks a number invalid, inactive, or abusive, when the webhook processes the event, then the Telegram card shows the risk status and no generated customer-facing draft is created.
 - AE4. **Covers R5, R17, R19.** Given IPQS times out and web search is unavailable, when a Sales SMS arrives, then the webhook still ACKs, creates the existing safe fallback when eligible, and records phone intelligence as unavailable.
 - AE5. **Covers R20.** Given equivalent unknown caller facts for SMS and missed-call events, when tests run, then both paths use the same helper output and render consistent source statuses.
-- AE6. **Covers R21-R24.** Given a validated active number and a single unambiguous owned-source/public-business match, when enrichment completes, then Dialpad contact sync fills missing confirmed fields; given only reverse-name or conflicting evidence, then no writeback occurs and Telegram shows a suggested contact update.
+- AE6. **Covers R21-R24.** Given a validated active number and a single unambiguous owned-source or phone-corroborated public-business match, when enrichment completes, then Dialpad contact sync fills missing confirmed fields; given only reverse-name/location or conflicting evidence, then no writeback occurs and Telegram shows a suggested contact update.
 
 ---
 

--- a/docs/brainstorms/2026-06-23-phone-validation-prospect-enrichment-requirements.md
+++ b/docs/brainstorms/2026-06-23-phone-validation-prospect-enrichment-requirements.md
@@ -35,8 +35,8 @@ IPQualityScore can provide phone validation, carrier, line type, active-line, ri
 
 - R1. Inbound Sales SMS and Sales missed-call events must attempt shared phone validation when Dialpad contact lookup and CRM lookup do not produce high-confidence identity.
 - R2. Phone validation must surface compact operator-facing facts for validity, active-line status, country, city, region, carrier, line type, reverse name, and abusive/fraud status when the provider returns them; missing active-line fields must remain unknown, not inactive.
-- R3. Phone validation status must distinguish `usable`, `not_configured`, `not_found`, `invalid`, `inactive`, `risky`, `unavailable`, `timeout`, `budget_exceeded`, `rate_limited`, and `unsafe_output`.
-- R4. Invalid, inactive, or abusive-number signals must be visible in Telegram and draft metadata before any operator approves a reply.
+- R3. Phone validation status must distinguish `usable`, `not_configured`, `not_found`, `invalid`, `inactive`, `disposable`, `risky`, `unavailable`, `timeout`, `budget_exceeded`, `rate_limited`, and `unsafe_output`.
+- R4. Invalid, inactive, disposable/temporary, or abusive-number signals must be visible in Telegram and draft metadata before any operator approves a reply.
 - R5. Phone validation must fail closed to the existing generic or CRM-aware behavior when the provider is missing, slow, or unavailable.
 
 **Identity and prospect context**
@@ -52,7 +52,7 @@ IPQualityScore can provide phone validation, carrier, line type, active-line, ri
 - R11. The customer-facing draft must remain generic when only phone validation facts are available.
 - R12. The draft model may use phone validation and public-search facts to choose tone and context, but it must not greet by reverse name or mention a business unless the final facts meet the same safety bar as other high-confidence personalization.
 - R13. For valid, not-inactive, low-risk unknown Sales callers, the generic fallback should remain helpful and human: acknowledge the missed call or inbound SMS and ask how Sales can help.
-- R14. For high-risk, inactive, or invalid numbers, the system must withhold generated customer-facing drafts and route the event to human-only handling.
+- R14. For high-risk, inactive, invalid, or disposable/temporary numbers, the system must withhold generated customer-facing drafts and route the event to human-only handling.
 - R15. Model-generated drafts must be rejected when they introduce unsupported identity claims, unsupported business claims, raw internal source names, unapproved links, or sensitive personal details.
 
 **Operations and cost control**
@@ -110,7 +110,7 @@ IPQualityScore can provide phone validation, carrier, line type, active-line, ri
 
 - AE1. **Covers R1, R2, R10, R11.** Given an unknown Sales missed call from a valid active wireless number with a reverse name, when the draft is created, then Telegram shows the phone intelligence and the customer-facing draft does not greet by that reverse name.
 - AE2. **Covers R7, R8, R12.** Given phone validation returns a reverse name and Fort Worth location, when bounded public search finds a strong business/professional match, then Telegram may show a possible prospect summary and the model may use it only if the identity safety bar is met.
-- AE3. **Covers R3, R4, R14.** Given IPQS marks a number invalid, inactive, or abusive, when the webhook processes the event, then the Telegram card shows the risk status and no generated customer-facing draft is created.
+- AE3. **Covers R3, R4, R14.** Given IPQS marks a number invalid, inactive, disposable/temporary, or abusive, when the webhook processes the event, then the Telegram card shows the risk status and no generated customer-facing draft is created.
 - AE4. **Covers R5, R17, R19.** Given IPQS times out and web search is unavailable, when a Sales SMS arrives, then the webhook still ACKs, creates the existing safe fallback when eligible, and records phone intelligence as unavailable.
 - AE5. **Covers R20.** Given equivalent unknown caller facts for SMS and missed-call events, when tests run, then both paths use the same helper output and render consistent source statuses.
 - AE6. **Covers R21-R24.** Given a validated active number and a single unambiguous owned-source or phone-corroborated public-business match, when enrichment completes, then Dialpad contact sync fills missing confirmed fields; given only reverse-name/location or conflicting evidence, then no writeback occurs and Telegram shows a suggested contact update.

--- a/docs/plans/2026-06-23-001-feat-phone-validation-prospect-enrichment-plan.md
+++ b/docs/plans/2026-06-23-001-feat-phone-validation-prospect-enrichment-plan.md
@@ -22,7 +22,7 @@ The current fallback path handles unknown callers conservatively:
 - Dialpad contact lookup can provide only webhook-level identity.
 - Attio can be missing or not match the number.
 - Calendar and comms context are only useful after a stronger identity signal exists.
-- Generic fallback drafts are safe, but they miss useful signals such as valid active number, city/state, line type, carrier, abuse risk, and possible reverse-name context.
+- Generic fallback drafts are safe, but they miss useful signals such as validity, active-line status, city/state, line type, carrier, abuse risk, and possible reverse-name context.
 
 For example, an unknown Fort Worth wireless caller can currently produce only:
 
@@ -40,7 +40,7 @@ That is safe, but it leaves the operator without evidence that the number is act
 - R2. Run phone intelligence only for external inbound Sales contacts after owned-source identity resolution, primarily when Dialpad/CRM identity confidence is not high.
 - R3. Validate and normalize IPQS phone data: valid, active status, fraud/risk signals, carrier, line type, country, region, city, timezone, local format, and reverse name when available.
 - R4. Keep IPQS reverse name as possible caller evidence, not confirmed identity.
-- R5. Add optional bounded public prospect enrichment when a valid active low-risk number has enough public signals to search, such as reverse name plus city/state.
+- R5. Add optional bounded public prospect enrichment when a valid, not-inactive, low-risk number has enough public signals to search, such as reverse name plus city/state.
 - R6. Treat public search output as operator context unless another owned source confirms it.
 - R7. Feed the draft model a compact fact set that includes safe caller-intelligence facts and explicit constraints.
 - R8. Let the model produce the final draft text from tool-call facts, but preserve existing safety validators and deterministic fallbacks.
@@ -73,7 +73,7 @@ That is safe, but it leaves the operator without evidence that the number is act
 
 ### KTD-1: Use the existing context-adapter pattern
 
-Add a focused phone-intelligence adapter instead of embedding IPQS calls inside webhook handlers. The repo already uses subprocess JSON adapters for Attio and calendar context, with a fail-closed contract and compact returned payloads. The owned-source identity gate should reuse the existing `scripts/adapters/identity_resolver.py` path before deciding whether caller intelligence is eligible.
+Add a focused phone-intelligence adapter instead of embedding IPQS calls inside webhook handlers. The repo already uses subprocess JSON adapters for Attio and calendar context, with a fail-closed contract and compact returned payloads. The owned-source identity gate should reuse the existing `scripts/adapters/identity_resolver.py` path before deciding whether caller intelligence is eligible, while preserving the resolver's wrong-match warning.
 
 Decision:
 
@@ -81,6 +81,7 @@ Decision:
 - Wire it through a shared helper in `scripts/webhook_server.py`.
 - Configure it with environment variables and make it optional by default.
 - Use the existing identity resolver/CRM confidence before invoking phone intelligence; keep IPQS and public search in a separate operator-only `callerIntelligence` lane.
+- Re-apply the wrong-match/collision guard from `docs/solutions/ungate-enrichment-customer-pii.md` before treating a resolver `high` result as customer-facing identity or writeback authority.
 
 Rationale:
 
@@ -88,6 +89,7 @@ Rationale:
 - Avoids duplicating lookup behavior between SMS and missed calls.
 - Matches existing degraded-source behavior in `lookup_sales_crm_context`, `lookup_sales_calendar_context`, and adapter docs.
 - Prevents phone validation from becoming a parallel identity resolver with conflicting provenance.
+- Prevents a single stale/shared Attio phone match from suppressing caller intelligence or authorizing personalization/writeback on its own.
 
 ### KTD-2: Use IPQS as validation evidence, not identity authority
 
@@ -112,7 +114,7 @@ The webhook service should not hardwire live web search or browser automation. I
 Decision:
 
 - Add optional `DIALPAD_PUBLIC_PROSPECT_SEARCH_COMMAND`.
-- Invoke it only after phone validation produces a usable, active, low-risk number with enough search inputs.
+- Invoke it only after phone validation produces a usable, not-inactive, low-risk number with enough search inputs.
 - Require the command response to include bounded evidence entries: source type, domain or title, matched terms, and no page snippets.
 - Mark `publicProspect.usable` true only when at least one evidence entry ties the reverse name plus location to a business, role, or organization relevant to ShapeScale for Business.
 - Cap and sanitize summaries, sources, and evidence before model facts; strip instruction-like text and sensitive personal details.
@@ -153,6 +155,7 @@ The model should not decide whether a caller is safe or abusive.
 Decision:
 
 - Normalize deterministic risk first.
+- Treat `active == null` or missing `active_status` as `activeStatus:"unknown"`; do not classify unknown active-line state as inactive or high-risk by itself.
 - Mark invalid, inactive, known spammer, recent-abuse, risky, or `fraud_score >= 85` numbers as `riskLevel:"high"`.
 - Mark `fraud_score >= 75` and `< 85` as `riskLevel:"medium"` when no high-risk flag is present.
 - Mark all remaining usable numbers as `riskLevel:"low"`.
@@ -192,9 +195,10 @@ Decision:
 - Use existing `bin/create_contact.py` and `bin/update_contact.py` wrappers for writeback.
 - Run contact sync only after the enrichment/idempotency path has settled, never before webhook ACK.
 - Automatically update an existing Dialpad contact only when the contact ID or exact phone match is unambiguous and the new field is confirmed by owned-source identity or bounded business/professional evidence with no conflict.
-- Automatically create a contact only when duplicate checks find no existing match and the evidence supplies the required safe fields; otherwise render a suggested contact sync in Telegram/metadata.
-- Never overwrite populated Dialpad fields with lower-confidence data; only fill missing fields or append confirmed phone/email/URL identifiers.
-- Treat reverse-name-only, area-code, weak public search, same-name personal search, risky, inactive, invalid, or budget-degraded cases as suggestion-only.
+- Automatically create a contact only when duplicate checks find no existing match, the create wrapper is create-only or its returned action is verified as `created`, and the evidence supplies the required safe fields; otherwise render a suggested contact sync in Telegram/metadata.
+- Never overwrite populated Dialpad fields with lower-confidence data; fetch current contact values and merge phones, emails, and URLs before calling `bin/update_contact.py`.
+- Treat reverse-name-only, reverse-name-plus-location, area-code, weak public search, same-name personal search, risky, inactive, invalid, or budget-degraded cases as suggestion-only.
+- Require public writeback evidence to directly corroborate the validated phone number or be backed by owned-source identity; name/location public matches are operator context only.
 
 Rationale:
 
@@ -215,7 +219,7 @@ flowchart TD
   E -- yes --> F[Use confirmed identity plus calendar/comms facts]
   E -- no --> G[Phone intelligence helper]
   G --> H[IPQS adapter and sanitized cache]
-  H --> I{Valid active low risk with search inputs?}
+  H --> I{Valid not-inactive low risk with search inputs?}
   I -- yes --> J[Optional public prospect search command]
   I -- no --> K[Skip public search]
   J --> L[Caller intelligence context]
@@ -308,6 +312,7 @@ Work:
 - Normalize provider output into compact statused fields.
 - Return exit code `0` for expected misses/degraded states with `usable:false`.
 - Add cache support for sanitized normalized results.
+- Add optional `enhanced_line_check` configuration, but handle `active == null` or missing `active_status` as `activeStatus:"unknown"` when enhanced checks are unavailable.
 - Add `DIALPAD_PHONE_INTELLIGENCE_CACHE_DB`, `DIALPAD_PHONE_INTELLIGENCE_CACHE_TTL_SECONDS` with a 24-hour default, and `DIALPAD_PUBLIC_PROSPECT_SEARCH_CACHE_TTL_SECONDS` with a 6-hour default.
 - Store cache entries with a lookup-policy version that covers endpoint, strictness, country hint, and risk-threshold version.
 - Create cache parent directories with `0700`, cache files with `0600`, expired-row purging, and the existing SQLite `busy_timeout`/best-effort-WAL pattern.
@@ -316,6 +321,7 @@ Work:
 Tests:
 
 - valid active wireless number normalizes expected fields;
+- valid number with unknown active-line fields remains usable with `activeStatus:"unknown"` and does not become inactive/high-risk by that fact alone;
 - invalid number returns unusable/high-risk context;
 - high risk is assigned for invalid, inactive, `recent_abuse`, `risky`, `spammer`, or `fraud_score >= 85`;
 - medium risk is assigned for `fraud_score >= 75` and `< 85` when no high-risk flag is present;
@@ -341,7 +347,7 @@ Work:
 - Add one shared `lookup_caller_intelligence` helper used by both inbound Sales SMS and missed-call flows.
 - Claim the relevant inbound/user-visible idempotency key before webhook ACK, storage, draft creation, hooks, or Telegram side effects.
 - Run caller intelligence only after webhook receipt acknowledgement and after the relevant idempotency claim succeeds.
-- Define one shared Sales enrichment order: Dialpad contact enrichment, owned-source identity check through the existing resolver/CRM path, caller-intelligence eligibility, then metadata/Telegram/model-facts threading from the same enriched context object.
+- Define one shared Sales enrichment order: Dialpad contact enrichment, owned-source identity check through the existing resolver/CRM path plus wrong-match/collision guard, caller-intelligence eligibility, then metadata/Telegram/model-facts threading from the same enriched context object.
 - Run caller intelligence only for inbound external Sales numbers and only when owned-source identity is not already high confidence.
 - Thread `callerIntelligence` into approval metadata, hook payloads, and Telegram context.
 - Add source-status reporting alongside CRM, calendar, comms, and QMD.
@@ -354,6 +360,7 @@ Tests:
 - missed call with low identity confidence gets the same context shape;
 - idempotency claim occurs before ACK, while IPQS/public search occurs after ACK and after a successful claim;
 - the owned-source resolver/CRM gate runs before caller intelligence eligibility;
+- resolver `high` without the wrong-match/collision guard cannot authorize customer-facing personalization or contact writeback;
 - high-confidence CRM/Dialpad identity does not rely on IPQS for identity;
 - duplicate missed call does not create duplicate phone-intelligence-rendered drafts;
 - source status renders degraded/missing states without breaking draft creation;
@@ -377,13 +384,14 @@ Work:
 - Reject `publicProspect.usable` unless at least one evidence entry ties the reverse name plus location to a business, role, or organization relevant to ShapeScale for Business.
 - Sanitize all public-search output before prompt/model facts: cap field lengths, strip instruction-like text, strip sensitive personal details, and never keep page snippets.
 - Cache sanitized search summaries separately from IPQS results.
-- Do not call public search for invalid, inactive, high-risk, or insufficient-input cases.
+- Do not call public search for invalid, inactive, medium-risk, high-risk, or insufficient-input cases.
 - Distinguish search miss, timeout, unavailable, unsafe output, `budget_exceeded`, and `rate_limited` statuses.
 
 Tests:
 
 - command timeout degrades cleanly;
 - high-risk number skips public search;
+- medium-risk number skips public search;
 - public search summary appears only in operator context/model facts with low-confidence labeling;
 - malformed command output is ignored safely;
 - malicious search summaries cannot alter model instructions or customer-facing draft behavior;
@@ -458,17 +466,21 @@ Work:
 - Add a post-enrichment contact-sync helper that uses existing contact create/update wrappers.
 - Run the helper only after the idempotency claim, webhook ACK, and caller-intelligence/owned-source context assembly.
 - Update existing Dialpad contacts only when an exact contact ID or exact phone match is unambiguous.
-- Create contacts only when duplicate checks find no existing contact and the evidence supplies safe required fields.
+- Create contacts only when duplicate checks find no existing contact, the wrapper path is create-only or the wrapper result is verified as `created`, and the evidence supplies safe required fields.
+- Before updating identifiers, fetch the existing contact and merge current phones/emails/URLs with newly confirmed identifiers before invoking `bin/update_contact.py`.
 - Fill missing non-sensitive fields or append confirmed identifiers; never overwrite populated fields with lower-confidence values.
-- Treat reverse-name-only, weak public search, same-name personal results, risky, inactive, invalid, conflict, timeout, or budget-degraded cases as suggestion-only.
+- Treat reverse-name-only, reverse-name-plus-location, weak public search, same-name personal results, risky, inactive, invalid, conflict, timeout, or budget-degraded cases as suggestion-only.
+- Require public business/professional writeback evidence to directly corroborate the validated phone number or have owned-source corroboration.
 - Include contact-sync status in approval metadata, hook payloads, and Telegram context.
 
 Tests:
 
 - high-confidence owned-source identity fills a missing Dialpad contact field through `bin/update_contact.py`;
-- validated low-risk public business evidence can create a contact only when duplicate checks are clean and required fields are present;
-- reverse-name-only evidence produces a suggested contact update and no wrapper invocation;
+- validated low-risk public business evidence can create a contact only when it directly corroborates the validated phone number, duplicate checks are clean, required fields are present, and the create wrapper result is `created`;
+- reverse-name-only or reverse-name-plus-location evidence produces a suggested contact update and no wrapper invocation;
 - conflicting or ambiguous contact candidates block writeback and surface a warning;
+- create wrapper returning `updated` from an upsert path is rejected for create-only sync;
+- identifier updates merge existing phones/emails/URLs instead of replacing them;
 - populated Dialpad fields are not overwritten by lower-confidence enrichment;
 - contact-sync failure degrades to operator context without blocking drafts, hooks, or Telegram.
 
@@ -496,12 +508,13 @@ Customer-facing draft text may not:
 Dialpad contact writeback may:
 
 - fill missing fields from confirmed owned-source evidence;
-- append confirmed phone, email, or URL identifiers;
-- create a new contact only after duplicate checks find no existing match and required safe fields are present.
+- append confirmed phone, email, or URL identifiers after merging existing contact values;
+- create a new contact only after duplicate checks find no existing match, required safe fields are present, and the wrapper result confirms a create action.
 
 Dialpad contact writeback may not:
 
 - use IPQS reverse name alone as a contact name;
+- use reverse-name-plus-location public matches as identity unless public evidence directly corroborates the validated phone number;
 - use same-name personal search results as identity;
 - overwrite populated fields with lower-confidence enrichment;
 - run when evidence is ambiguous, conflicting, risky, inactive, invalid, timed out, or budget-degraded.
@@ -525,6 +538,9 @@ Operator-facing Telegram context may show:
 - Risk: Public search finds a same-name person in the same area.
   Mitigation: Require at least one business/professional evidence entry tied to reverse name plus location, and treat it as low-confidence operator context unless owned sources confirm it.
 
+- Risk: Public search plus stale reverse lookup writes the wrong Dialpad contact.
+  Mitigation: Keep name/location public matches suggestion-only for writeback; require owned-source corroboration or public evidence that directly corroborates the validated phone number.
+
 - Risk: Provider latency slows webhook handling.
   Mitigation: Run provider calls only after webhook ACK and idempotency claim, use strict timeouts, cache sanitized results, and fail closed.
 
@@ -532,7 +548,10 @@ Operator-facing Telegram context may show:
   Mitigation: Normalize allowlisted fields only, sanitize public-search output before model facts, avoid storing raw payloads, and avoid logging cached values.
 
 - Risk: Risk scoring blocks useful prospects.
-  Mitigation: Use explicit thresholds; high-risk callers become human-only, while medium-risk callers can still get conservative generic drafts with operator warnings.
+  Mitigation: Use explicit thresholds and keep unknown active-line status separate from inactive; high-risk callers become human-only, while medium-risk callers can still get conservative generic drafts with operator warnings.
+
+- Risk: Contact wrapper upsert or array replacement overwrites data.
+  Mitigation: Require create-only behavior or verify a `created` result for create paths, and fetch/merge existing identifier arrays before update paths.
 
 - Risk: Unique-number spam burns provider credits.
   Mitigation: Add deterministic per-window budgets with `budget_exceeded` or `rate_limited` source statuses and existing fallback behavior.

--- a/docs/plans/2026-06-23-001-feat-phone-validation-prospect-enrichment-plan.md
+++ b/docs/plans/2026-06-23-001-feat-phone-validation-prospect-enrichment-plan.md
@@ -46,7 +46,7 @@ That is safe, but it leaves the operator without evidence that the number is act
 - R8. Let the model produce the final draft text from tool-call facts, but preserve existing safety validators and deterministic fallbacks.
 - R9. Suppress customer-facing personalization from low-confidence phone intelligence: no named greeting, no unconfirmed company claim, no "I saw your business" claim.
 - R10. Escalate risky or invalid numbers in operator context and avoid warmer prospect drafts for those cases.
-- R11. Treat high-risk, invalid, or inactive callers as human-only in v1: create operator context and metadata, but do not generate a customer-facing draft.
+- R11. Treat high-risk, invalid, inactive, or disposable/temporary callers as human-only in v1: create operator context and metadata, but do not generate a customer-facing draft.
 - R12. Fail closed on missing secrets, provider errors, timeouts, malformed responses, search misses, and enrichment budget exhaustion.
 - R13. Cache sanitized phone-intelligence results to reduce latency and vendor calls without storing raw provider payloads.
 - R14. Add deterministic per-window provider-call budgets so unique-number spam cannot burn unbounded IPQS or public-search credits.
@@ -115,7 +115,7 @@ Decision:
 
 - Add optional `DIALPAD_PUBLIC_PROSPECT_SEARCH_COMMAND`.
 - Invoke it only after phone validation produces a usable, not-inactive, low-risk number with enough search inputs.
-- Require the command response to include bounded evidence entries: source type, domain or title, matched terms, and no page snippets.
+- Require the command response to include bounded evidence entries: source type, domain or title, matched terms, explicit normalized-phone corroboration status, and no page snippets.
 - Mark `publicProspect.usable` true only when at least one evidence entry ties the reverse name plus location to a business, role, or organization relevant to ShapeScale for Business.
 - Cap and sanitize summaries, sources, and evidence before model facts; strip instruction-like text and sensitive personal details.
 - Treat search misses as `{usable:false,status:"not_found"}`. Treat search timeouts as `{usable:false,status:"timeout"}` and provider failures as a degraded unavailable status.
@@ -138,9 +138,9 @@ Decision:
 - Exclude sensitive expanded identity payloads if enabled by account tier, including addresses, emails, birthdates, and unrelated identity data.
 - Default phone-validation TTL to 24 hours and public-prospect-search TTL to 6 hours, with environment overrides.
 - Store cache files under the configured private runtime state/log directory; create parent directories with `0700` and SQLite files with `0600`.
-- Use the repo's SQLite concurrency pattern: `busy_timeout` plus best-effort WAL.
+- Use the repo's SQLite concurrency pattern: `busy_timeout` plus best-effort WAL, with private permissions for `*.db`, `*.db-wal`, and `*.db-shm` files or a private process umask before enabling WAL.
 - Purge expired rows on read/write and avoid logging cached values.
-- Include a lookup-policy version in the cache key or stored metadata covering provider endpoint, strictness, country hint, and risk-threshold version.
+- Include a lookup-policy version in the cache key or stored metadata covering provider endpoint, strictness, country hint, `enhanced_line_check`, and risk-threshold version.
 
 Rationale:
 
@@ -156,7 +156,7 @@ Decision:
 
 - Normalize deterministic risk first.
 - Treat `active == null` or missing `active_status` as `activeStatus:"unknown"`; do not classify unknown active-line state as inactive or high-risk by itself.
-- Mark invalid, inactive, known spammer, recent-abuse, risky, or `fraud_score >= 85` numbers as `riskLevel:"high"`.
+- Mark invalid, inactive, disposable/temporary, known spammer, recent-abuse, risky, or `fraud_score >= 85` numbers as `riskLevel:"high"`.
 - Mark `fraud_score >= 75` and `< 85` as `riskLevel:"medium"` when no high-risk flag is present.
 - Mark all remaining usable numbers as `riskLevel:"low"`.
 - High-risk callers are human-only in v1: render the reason for the operator and do not generate a customer-facing draft.
@@ -275,7 +275,12 @@ Add a new `callerIntelligence` object to inbound context metadata:
       {
         "sourceType": "business_directory",
         "domainOrTitle": "Example public business profile",
-        "matchedTerms": ["JORDAN EXAMPLE", "Washington"]
+        "matchedTerms": ["JORDAN EXAMPLE", "Washington"],
+        "phoneCorroboration": {
+          "matched": true,
+          "normalizedPhone": "+12025550142",
+          "basis": "public_page_lists_validated_phone"
+        }
       }
     ]
   }
@@ -314,8 +319,8 @@ Work:
 - Add cache support for sanitized normalized results.
 - Add optional `enhanced_line_check` configuration, but handle `active == null` or missing `active_status` as `activeStatus:"unknown"` when enhanced checks are unavailable.
 - Add `DIALPAD_PHONE_INTELLIGENCE_CACHE_DB`, `DIALPAD_PHONE_INTELLIGENCE_CACHE_TTL_SECONDS` with a 24-hour default, and `DIALPAD_PUBLIC_PROSPECT_SEARCH_CACHE_TTL_SECONDS` with a 6-hour default.
-- Store cache entries with a lookup-policy version that covers endpoint, strictness, country hint, and risk-threshold version.
-- Create cache parent directories with `0700`, cache files with `0600`, expired-row purging, and the existing SQLite `busy_timeout`/best-effort-WAL pattern.
+- Store cache entries with a lookup-policy version that covers endpoint, strictness, country hint, `enhanced_line_check`, and risk-threshold version.
+- Create cache parent directories with `0700`, cache files with `0600`, expired-row purging, private permissions for SQLite `*.db-wal`/`*.db-shm` sidecars or a private umask, and the existing SQLite `busy_timeout`/best-effort-WAL pattern.
 - Add provider-call budget checks for unique-number floods before making paid or external calls, using `DIALPAD_CALLER_INTELLIGENCE_BUDGET_WINDOW_SECONDS`, `DIALPAD_PHONE_INTELLIGENCE_MAX_CALLS_PER_WINDOW`, and `DIALPAD_PUBLIC_PROSPECT_SEARCH_MAX_CALLS_PER_WINDOW`.
 
 Tests:
@@ -323,13 +328,14 @@ Tests:
 - valid active wireless number normalizes expected fields;
 - valid number with unknown active-line fields remains usable with `activeStatus:"unknown"` and does not become inactive/high-risk by that fact alone;
 - invalid number returns unusable/high-risk context;
-- high risk is assigned for invalid, inactive, `recent_abuse`, `risky`, `spammer`, or `fraud_score >= 85`;
+- high risk is assigned for invalid, inactive, disposable/temporary, `recent_abuse`, `risky`, `spammer`, or `fraud_score >= 85`;
 - medium risk is assigned for `fraud_score >= 75` and `< 85` when no high-risk flag is present;
 - provider timeout returns degraded unusable context;
 - malformed response returns degraded unusable context;
 - secret is never printed or stored in cached payload;
 - cache hit avoids provider call and returns the same normalized shape;
-- cache entries invalidate when the lookup-policy version changes;
+- cache entries invalidate when the lookup-policy version changes, including `enhanced_line_check` toggles;
+- SQLite WAL sidecar files inherit private cache permissions or are created under a private umask;
 - budget exhaustion returns a `budget_exceeded` or `rate_limited` status without a provider call.
 
 ### Unit 2: Shared Webhook Integration
@@ -377,25 +383,27 @@ Files:
 Work:
 
 - Add optional `DIALPAD_PUBLIC_PROSPECT_SEARCH_COMMAND`.
-- Pass only minimal inputs: phone local format, reverse name, city, region, country, and risk classification.
+- Pass only minimal inputs: normalized phone, phone local format, reverse name, city, region, country, and risk classification.
 - Check `DIALPAD_PUBLIC_PROSPECT_SEARCH_MAX_CALLS_PER_WINDOW` before invoking the command and return `budget_exceeded` or `rate_limited` when the cap is hit.
 - Use a strict timeout and compact JSON response.
-- Require returned confidence plus bounded evidence entries with source type, domain or title, and matched terms.
-- Reject `publicProspect.usable` unless at least one evidence entry ties the reverse name plus location to a business, role, or organization relevant to ShapeScale for Business.
+- Require returned confidence plus bounded evidence entries with source type, domain or title, matched terms, and an explicit `phoneCorroboration` object showing whether the evidence directly listed the validated normalized phone.
+- Reject `publicProspect.usable` unless at least one evidence entry ties the reverse name plus location to a business, role, or organization relevant to ShapeScale for Business; reserve automatic contact writeback for evidence whose `phoneCorroboration.matched` is true.
 - Sanitize all public-search output before prompt/model facts: cap field lengths, strip instruction-like text, strip sensitive personal details, and never keep page snippets.
 - Cache sanitized search summaries separately from IPQS results.
-- Do not call public search for invalid, inactive, medium-risk, high-risk, or insufficient-input cases.
+- Do not call public search for invalid, inactive, disposable/temporary, medium-risk, high-risk, or insufficient-input cases.
 - Distinguish search miss, timeout, unavailable, unsafe output, `budget_exceeded`, and `rate_limited` statuses.
 
 Tests:
 
 - command timeout degrades cleanly;
 - high-risk number skips public search;
+- disposable/temporary number is high-risk and skips public search;
 - medium-risk number skips public search;
 - public search summary appears only in operator context/model facts with low-confidence labeling;
 - malformed command output is ignored safely;
 - malicious search summaries cannot alter model instructions or customer-facing draft behavior;
 - same-name personal results without business/professional evidence are rejected as unusable;
+- same-name/location business evidence without `phoneCorroboration.matched` remains operator context and cannot authorize contact creation;
 - public-search budget exhaustion skips the command and preserves the generic fallback/source-status behavior.
 
 ### Unit 4: Model Draft Facts and Safety
@@ -415,14 +423,14 @@ Work:
 - Treat public-search facts as untrusted data that arrive after sanitization and under explicit constraints.
 - Keep existing URL allowlist and unsupported-claim validators.
 - Add deterministic fallback drafts for degraded, low-risk, and medium-risk cases.
-- For high-risk, invalid, or inactive callers, produce operator metadata and human-only Telegram context without a generated customer-facing draft.
+- For high-risk, invalid, inactive, or disposable/temporary callers, produce operator metadata and human-only Telegram context without a generated customer-facing draft.
 
 Tests:
 
 - model facts include low-risk phone validation context;
 - low-confidence reverse name cannot appear as a greeting;
 - unconfirmed business/professional search result cannot appear as a confirmed company claim;
-- high-risk, invalid, or inactive caller produces human-only escalation with no generated customer-facing draft;
+- high-risk, invalid, inactive, or disposable/temporary caller produces human-only escalation with no generated customer-facing draft;
 - medium-risk caller produces only the conservative generic approval draft with an operator warning;
 - unsafe model output falls back to the deterministic draft.
 
@@ -503,7 +511,7 @@ Customer-facing draft text may not:
 - use low-confidence phone intelligence to claim the caller's profession;
 - state that ShapeScale looked the caller up publicly;
 - state that a public-search result is definitely the caller;
-- generate any reply for high-risk, invalid, or inactive callers in v1.
+- generate any reply for high-risk, invalid, inactive, or disposable/temporary callers in v1.
 
 Dialpad contact writeback may:
 
@@ -526,7 +534,7 @@ Operator-facing Telegram context may show:
 - fraud/risk signals;
 - possible reverse name;
 - sanitized public-search evidence with low-confidence labeling;
-- human-only escalation for high-risk, invalid, or inactive callers.
+- human-only escalation for high-risk, invalid, inactive, or disposable/temporary callers.
 
 ---
 
@@ -547,8 +555,11 @@ Operator-facing Telegram context may show:
 - Risk: Raw provider data leaks into prompts or logs.
   Mitigation: Normalize allowlisted fields only, sanitize public-search output before model facts, avoid storing raw payloads, and avoid logging cached values.
 
+- Risk: SQLite WAL sidecar files expose cached phone-intelligence data.
+  Mitigation: Require a private cache directory plus `0600` permissions for main and sidecar files, or set a private umask before enabling WAL.
+
 - Risk: Risk scoring blocks useful prospects.
-  Mitigation: Use explicit thresholds and keep unknown active-line status separate from inactive; high-risk callers become human-only, while medium-risk callers can still get conservative generic drafts with operator warnings.
+  Mitigation: Use explicit thresholds, classify disposable/temporary phone signals as high risk, and keep unknown active-line status separate from inactive; high-risk callers become human-only, while medium-risk callers can still get conservative generic drafts with operator warnings.
 
 - Risk: Contact wrapper upsert or array replacement overwrites data.
   Mitigation: Require create-only behavior or verify a `created` result for create paths, and fetch/merge existing identifier arrays before update paths.

--- a/docs/plans/2026-06-23-001-feat-phone-validation-prospect-enrichment-plan.md
+++ b/docs/plans/2026-06-23-001-feat-phone-validation-prospect-enrichment-plan.md
@@ -52,12 +52,18 @@ That is safe, but it leaves the operator without evidence that the number is act
 - R14. Add deterministic per-window provider-call budgets so unique-number spam cannot burn unbounded IPQS or public-search credits.
 - R15. Document secrets and runtime configuration using environment references, not literal keys.
 - R16. Add tests that prove both webhook surfaces use the same logic and preserve low-confidence safety invariants.
+- R17. Automatically create or update Dialpad contacts from enriched information only when identity and writeback confidence is clear.
+- R18. Never use IPQS reverse name alone, area code, same-name personal search, or weak public search to overwrite or create a Dialpad contact.
+- R19. Fill missing Dialpad contact fields or append confirmed identifiers; do not overwrite populated fields with lower-confidence data.
+- R20. Surface ambiguous contact-sync suggestions in Telegram/metadata instead of writing back automatically.
 
 ### Non-Goals
 
 - No voicemail transcription or call recording analysis in this PR.
 - No automatic CRM write-back.
 - No automatic sending based only on IPQS or public search.
+- No automatic Dialpad contact overwrite or merge from reverse-name-only, same-name, area-code, or weak public-search evidence.
+- No automatic Dialpad contact writeback before webhook ACK or before the idempotency claim succeeds.
 - No broad person-search dossier, home address enrichment, relatives, age, or other sensitive identity expansion.
 - No direct browser automation inside the webhook request path.
 
@@ -147,8 +153,8 @@ The model should not decide whether a caller is safe or abusive.
 Decision:
 
 - Normalize deterministic risk first.
-- Mark invalid, inactive, known spammer, recent-abuse, risky, or `fraud_score >= 90` numbers as `riskLevel:"high"`.
-- Mark `fraud_score >= 75` as `riskLevel:"medium"` when no high-risk flag is present.
+- Mark invalid, inactive, known spammer, recent-abuse, risky, or `fraud_score >= 85` numbers as `riskLevel:"high"`.
+- Mark `fraud_score >= 75` and `< 85` as `riskLevel:"medium"` when no high-risk flag is present.
 - Mark all remaining usable numbers as `riskLevel:"low"`.
 - High-risk callers are human-only in v1: render the reason for the operator and do not generate a customer-facing draft.
 - Medium-risk callers may receive only the conservative generic approval draft, with a visible operator warning.
@@ -158,14 +164,15 @@ Rationale:
 - IPQS documents high-risk interpretations for invalid/inactive numbers and high fraud scores.
 - This is routing and safety policy, not prose generation.
 
-### KTD-6: External enrichment runs after ACK and inside budgets
+### KTD-6: External enrichment runs after the idempotency claim and ACK
 
 IPQS and public search must not become part of webhook receipt availability.
 
 Decision:
 
+- Claim the inbound/user-visible idempotency key before webhook ACK, storage, draft creation, hooks, or Telegram side effects.
 - Acknowledge webhook receipt before IPQS or public-search calls.
-- Run missed-call enrichment only after the missed-call idempotency claim succeeds.
+- Run missed-call and SMS caller-intelligence enrichment only after the relevant idempotency claim succeeds and the webhook ACK has been sent.
 - Use deterministic per-window budgets for IPQS and public search; expose `budget_exceeded` or `rate_limited` source statuses when a cap is hit.
 - Use `DIALPAD_CALLER_INTELLIGENCE_BUDGET_WINDOW_SECONDS` for the budget window, defaulting to one hour.
 - Use `DIALPAD_PHONE_INTELLIGENCE_MAX_CALLS_PER_WINDOW` and `DIALPAD_PUBLIC_PROSPECT_SEARCH_MAX_CALLS_PER_WINDOW`, initially defaulting to 120 IPQS validations/hour and 30 public searches/hour.
@@ -176,15 +183,33 @@ Rationale:
 - Preserves the ACK-first/idempotency invariant from `docs/solutions/ack-first-webhook-idempotency.md`.
 - Prevents provider stalls or unique-number spam from delaying receipt handling or burning unbounded credits.
 
+### KTD-7: Dialpad contact writeback is confidence-gated
+
+Enrichment should keep Dialpad contacts current, but contact mutation has higher blast radius than operator context or approval drafts.
+
+Decision:
+
+- Use existing `bin/create_contact.py` and `bin/update_contact.py` wrappers for writeback.
+- Run contact sync only after the enrichment/idempotency path has settled, never before webhook ACK.
+- Automatically update an existing Dialpad contact only when the contact ID or exact phone match is unambiguous and the new field is confirmed by owned-source identity or bounded business/professional evidence with no conflict.
+- Automatically create a contact only when duplicate checks find no existing match and the evidence supplies the required safe fields; otherwise render a suggested contact sync in Telegram/metadata.
+- Never overwrite populated Dialpad fields with lower-confidence data; only fill missing fields or append confirmed phone/email/URL identifiers.
+- Treat reverse-name-only, area-code, weak public search, same-name personal search, risky, inactive, invalid, or budget-degraded cases as suggestion-only.
+
+Rationale:
+
+- Reuses the repo's supported Dialpad writeback wrappers instead of inventing a new API surface.
+- Preserves the ambiguity guardrail from `docs/ideation/2026-03-26-dialpad-contact-merge-ambiguity-ideation.md`.
+
 ---
 
 ## High-Level Technical Design
 
 ```mermaid
 flowchart TD
-  A[Inbound Sales SMS or missed call] --> AA[ACK webhook receipt]
-  AA --> AB[Claim idempotency for user-visible output]
-  AB --> B[Dialpad contact enrichment]
+  A[Inbound Sales SMS or missed call] --> AB[Claim idempotency for user-visible output]
+  AB --> AA[ACK webhook receipt]
+  AA --> B[Dialpad contact enrichment]
   B --> C[Owned-source identity gate: identity resolver and CRM]
   C --> E{Identity confidence high?}
   E -- yes --> F[Use confirmed identity plus calendar/comms facts]
@@ -199,6 +224,7 @@ flowchart TD
   L --> M
   M --> N[Existing safety validators]
   N --> O[Approval draft and Telegram context]
+  L --> P[Confidence-gated Dialpad contact sync]
 ```
 
 ### Data Contract
@@ -208,15 +234,15 @@ Add a new `callerIntelligence` object to inbound context metadata:
 ```json
 {
   "usable": true,
-  "status": "found",
+  "status": "usable",
   "source": "ipqs",
   "phone": {
-    "e164": "+18178460085",
-    "localFormat": "(817) 846-0085",
+    "e164": "+12025550142",
+    "localFormat": "(202) 555-0142",
     "country": "US",
-    "region": "TX",
-    "city": "FORT WORTH",
-    "timezone": "America/Chicago"
+    "region": "DC",
+    "city": "WASHINGTON",
+    "timezone": "America/New_York"
   },
   "line": {
     "carrier": "Verizon Wireless",
@@ -232,20 +258,20 @@ Add a new `callerIntelligence` object to inbound context metadata:
     "spammer": false
   },
   "possibleIdentity": {
-    "reverseName": "BILL H HARTIN",
+    "reverseName": "JORDAN EXAMPLE",
     "basis": "ipqs_reverse_lookup",
     "confidence": "low"
   },
   "publicProspect": {
     "usable": true,
-    "status": "found",
-    "summary": "Possible Fort Worth business/professional match.",
+    "status": "usable",
+    "summary": "Possible Washington business/professional match.",
     "confidence": "low",
     "evidence": [
       {
         "sourceType": "business_directory",
         "domainOrTitle": "Example public business profile",
-        "matchedTerms": ["BILL H HARTIN", "Fort Worth"]
+        "matchedTerms": ["JORDAN EXAMPLE", "Washington"]
       }
     ]
   }
@@ -291,8 +317,8 @@ Tests:
 
 - valid active wireless number normalizes expected fields;
 - invalid number returns unusable/high-risk context;
-- high risk is assigned for invalid, inactive, `recent_abuse`, `risky`, `spammer`, or `fraud_score >= 90`;
-- medium risk is assigned for `fraud_score >= 75` when no high-risk flag is present;
+- high risk is assigned for invalid, inactive, `recent_abuse`, `risky`, `spammer`, or `fraud_score >= 85`;
+- medium risk is assigned for `fraud_score >= 75` and `< 85` when no high-risk flag is present;
 - provider timeout returns degraded unusable context;
 - malformed response returns degraded unusable context;
 - secret is never printed or stored in cached payload;
@@ -313,7 +339,8 @@ Files:
 Work:
 
 - Add one shared `lookup_caller_intelligence` helper used by both inbound Sales SMS and missed-call flows.
-- Run it only after webhook receipt acknowledgement and, for missed calls, after the missed-call idempotency claim succeeds.
+- Claim the relevant inbound/user-visible idempotency key before webhook ACK, storage, draft creation, hooks, or Telegram side effects.
+- Run caller intelligence only after webhook receipt acknowledgement and after the relevant idempotency claim succeeds.
 - Define one shared Sales enrichment order: Dialpad contact enrichment, owned-source identity check through the existing resolver/CRM path, caller-intelligence eligibility, then metadata/Telegram/model-facts threading from the same enriched context object.
 - Run caller intelligence only for inbound external Sales numbers and only when owned-source identity is not already high confidence.
 - Thread `callerIntelligence` into approval metadata, hook payloads, and Telegram context.
@@ -325,6 +352,7 @@ Tests:
 
 - Sales SMS with low identity confidence gets caller-intelligence context;
 - missed call with low identity confidence gets the same context shape;
+- idempotency claim occurs before ACK, while IPQS/public search occurs after ACK and after a successful claim;
 - the owned-source resolver/CRM gate runs before caller intelligence eligibility;
 - high-confidence CRM/Dialpad identity does not rely on IPQS for identity;
 - duplicate missed call does not create duplicate phone-intelligence-rendered drafts;
@@ -343,13 +371,14 @@ Work:
 
 - Add optional `DIALPAD_PUBLIC_PROSPECT_SEARCH_COMMAND`.
 - Pass only minimal inputs: phone local format, reverse name, city, region, country, and risk classification.
+- Check `DIALPAD_PUBLIC_PROSPECT_SEARCH_MAX_CALLS_PER_WINDOW` before invoking the command and return `budget_exceeded` or `rate_limited` when the cap is hit.
 - Use a strict timeout and compact JSON response.
 - Require returned confidence plus bounded evidence entries with source type, domain or title, and matched terms.
 - Reject `publicProspect.usable` unless at least one evidence entry ties the reverse name plus location to a business, role, or organization relevant to ShapeScale for Business.
 - Sanitize all public-search output before prompt/model facts: cap field lengths, strip instruction-like text, strip sensitive personal details, and never keep page snippets.
 - Cache sanitized search summaries separately from IPQS results.
 - Do not call public search for invalid, inactive, high-risk, or insufficient-input cases.
-- Distinguish search miss, timeout, unavailable, unsafe output, and budget-exhausted statuses.
+- Distinguish search miss, timeout, unavailable, unsafe output, `budget_exceeded`, and `rate_limited` statuses.
 
 Tests:
 
@@ -358,7 +387,8 @@ Tests:
 - public search summary appears only in operator context/model facts with low-confidence labeling;
 - malformed command output is ignored safely;
 - malicious search summaries cannot alter model instructions or customer-facing draft behavior;
-- same-name personal results without business/professional evidence are rejected as unusable.
+- same-name personal results without business/professional evidence are rejected as unusable;
+- public-search budget exhaustion skips the command and preserves the generic fallback/source-status behavior.
 
 ### Unit 4: Model Draft Facts and Safety
 
@@ -402,6 +432,7 @@ Work:
 - Document the IPQS secret setup using env var references only.
 - Document optional public prospect search command contract.
 - Document cache DB, TTL, policy-version, file-permission, purge, and rate-budget configuration.
+- Document automatic Dialpad contact sync guardrails and the suggestion-only fallback for ambiguous matches.
 - Document source-status behavior and draft safety boundaries.
 - Add a concise operational example for an unknown Fort Worth caller.
 - Run focused unit tests plus the existing webhook/enrichment safety suite.
@@ -411,6 +442,35 @@ Verification commands:
 - `python -m pytest tests/test_phone_intelligence.py`
 - `python -m pytest tests/test_sender_enrichment.py tests/test_webhook_hooks.py tests/test_ungate_provenance.py`
 - `python -m pytest tests/test_auto_send_shadow.py tests/test_deal_segment.py`
+
+### Unit 6: Dialpad Contact Sync Writeback
+
+Files:
+
+- `scripts/webhook_server.py`
+- `bin/create_contact.py`
+- `bin/update_contact.py`
+- `tests/test_sender_enrichment.py`
+- `tests/test_webhook_hooks.py`
+
+Work:
+
+- Add a post-enrichment contact-sync helper that uses existing contact create/update wrappers.
+- Run the helper only after the idempotency claim, webhook ACK, and caller-intelligence/owned-source context assembly.
+- Update existing Dialpad contacts only when an exact contact ID or exact phone match is unambiguous.
+- Create contacts only when duplicate checks find no existing contact and the evidence supplies safe required fields.
+- Fill missing non-sensitive fields or append confirmed identifiers; never overwrite populated fields with lower-confidence values.
+- Treat reverse-name-only, weak public search, same-name personal results, risky, inactive, invalid, conflict, timeout, or budget-degraded cases as suggestion-only.
+- Include contact-sync status in approval metadata, hook payloads, and Telegram context.
+
+Tests:
+
+- high-confidence owned-source identity fills a missing Dialpad contact field through `bin/update_contact.py`;
+- validated low-risk public business evidence can create a contact only when duplicate checks are clean and required fields are present;
+- reverse-name-only evidence produces a suggested contact update and no wrapper invocation;
+- conflicting or ambiguous contact candidates block writeback and surface a warning;
+- populated Dialpad fields are not overwritten by lower-confidence enrichment;
+- contact-sync failure degrades to operator context without blocking drafts, hooks, or Telegram.
 
 ---
 
@@ -432,6 +492,19 @@ Customer-facing draft text may not:
 - state that ShapeScale looked the caller up publicly;
 - state that a public-search result is definitely the caller;
 - generate any reply for high-risk, invalid, or inactive callers in v1.
+
+Dialpad contact writeback may:
+
+- fill missing fields from confirmed owned-source evidence;
+- append confirmed phone, email, or URL identifiers;
+- create a new contact only after duplicate checks find no existing match and required safe fields are present.
+
+Dialpad contact writeback may not:
+
+- use IPQS reverse name alone as a contact name;
+- use same-name personal search results as identity;
+- overwrite populated fields with lower-confidence enrichment;
+- run when evidence is ambiguous, conflicting, risky, inactive, invalid, timed out, or budget-degraded.
 
 Operator-facing Telegram context may show:
 
@@ -478,6 +551,8 @@ Operator-facing Telegram context may show:
 - Brainstorm requirements: `docs/brainstorms/2026-06-23-phone-validation-prospect-enrichment-requirements.md`
 - Existing adapter pattern: `docs/reference/enrichment-adapters.md`
 - Existing identity resolver: `scripts/adapters/identity_resolver.py`
+- Existing Dialpad contact writeback wrappers: `bin/create_contact.py`, `bin/update_contact.py`
+- Contact ambiguity guardrails: `docs/ideation/2026-03-26-dialpad-contact-merge-ambiguity-ideation.md`
 - PII and low-confidence safety: `docs/solutions/ungate-enrichment-customer-pii.md`
 - ACK/idempotency behavior: `docs/solutions/ack-first-webhook-idempotency.md`
 - IPQS Phone Number Validation overview: `https://www.ipqualityscore.com/documentation/phone-number-validation-api/overview`

--- a/docs/plans/2026-06-23-001-feat-phone-validation-prospect-enrichment-plan.md
+++ b/docs/plans/2026-06-23-001-feat-phone-validation-prospect-enrichment-plan.md
@@ -1,0 +1,485 @@
+---
+title: "feat: Add phone validation prospect enrichment"
+type: feat
+date: 2026-06-23
+origin: docs/brainstorms/2026-06-23-phone-validation-prospect-enrichment-requirements.md
+---
+
+# feat: Add phone validation prospect enrichment
+
+## Summary
+
+Add a shared caller-intelligence layer for inbound Sales SMS and missed-call workflows. When owned sources do not identify the caller with high confidence, the skill should validate the phone number, classify risk, optionally enrich likely business context, and feed a compact, safety-filtered fact set into the existing draft model path.
+
+The change must improve operator context and draft quality without treating reverse lookup or public search as authoritative identity. Confirmed owned-source evidence, including CRM and Dialpad exact matches, remains the only basis for high-confidence customer-facing personalization.
+
+---
+
+## Problem Frame
+
+The current fallback path handles unknown callers conservatively:
+
+- Dialpad contact lookup can provide only webhook-level identity.
+- Attio can be missing or not match the number.
+- Calendar and comms context are only useful after a stronger identity signal exists.
+- Generic fallback drafts are safe, but they miss useful signals such as valid active number, city/state, line type, carrier, abuse risk, and possible reverse-name context.
+
+For example, an unknown Fort Worth wireless caller can currently produce only:
+
+> Hi there, you've reached ShapeScale for Business Sales. Sorry we missed your call. How can we help?
+
+That is safe, but it leaves the operator without evidence that the number is active, non-abusive, wireless, and possibly associated with a named person who may be searchable as a business owner.
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+- R1. Use one shared phone-intelligence path for both Sales SMS webhooks and Sales missed-call webhooks.
+- R2. Run phone intelligence only for external inbound Sales contacts after owned-source identity resolution, primarily when Dialpad/CRM identity confidence is not high.
+- R3. Validate and normalize IPQS phone data: valid, active status, fraud/risk signals, carrier, line type, country, region, city, timezone, local format, and reverse name when available.
+- R4. Keep IPQS reverse name as possible caller evidence, not confirmed identity.
+- R5. Add optional bounded public prospect enrichment when a valid active low-risk number has enough public signals to search, such as reverse name plus city/state.
+- R6. Treat public search output as operator context unless another owned source confirms it.
+- R7. Feed the draft model a compact fact set that includes safe caller-intelligence facts and explicit constraints.
+- R8. Let the model produce the final draft text from tool-call facts, but preserve existing safety validators and deterministic fallbacks.
+- R9. Suppress customer-facing personalization from low-confidence phone intelligence: no named greeting, no unconfirmed company claim, no "I saw your business" claim.
+- R10. Escalate risky or invalid numbers in operator context and avoid warmer prospect drafts for those cases.
+- R11. Treat high-risk, invalid, or inactive callers as human-only in v1: create operator context and metadata, but do not generate a customer-facing draft.
+- R12. Fail closed on missing secrets, provider errors, timeouts, malformed responses, search misses, and enrichment budget exhaustion.
+- R13. Cache sanitized phone-intelligence results to reduce latency and vendor calls without storing raw provider payloads.
+- R14. Add deterministic per-window provider-call budgets so unique-number spam cannot burn unbounded IPQS or public-search credits.
+- R15. Document secrets and runtime configuration using environment references, not literal keys.
+- R16. Add tests that prove both webhook surfaces use the same logic and preserve low-confidence safety invariants.
+
+### Non-Goals
+
+- No voicemail transcription or call recording analysis in this PR.
+- No automatic CRM write-back.
+- No automatic sending based only on IPQS or public search.
+- No broad person-search dossier, home address enrichment, relatives, age, or other sensitive identity expansion.
+- No direct browser automation inside the webhook request path.
+
+---
+
+## Key Technical Decisions
+
+### KTD-1: Use the existing context-adapter pattern
+
+Add a focused phone-intelligence adapter instead of embedding IPQS calls inside webhook handlers. The repo already uses subprocess JSON adapters for Attio and calendar context, with a fail-closed contract and compact returned payloads. The owned-source identity gate should reuse the existing `scripts/adapters/identity_resolver.py` path before deciding whether caller intelligence is eligible.
+
+Decision:
+
+- Add `scripts/adapters/phone_intelligence.py`.
+- Wire it through a shared helper in `scripts/webhook_server.py`.
+- Configure it with environment variables and make it optional by default.
+- Use the existing identity resolver/CRM confidence before invoking phone intelligence; keep IPQS and public search in a separate operator-only `callerIntelligence` lane.
+
+Rationale:
+
+- Keeps provider logic testable outside webhook delivery.
+- Avoids duplicating lookup behavior between SMS and missed calls.
+- Matches existing degraded-source behavior in `lookup_sales_crm_context`, `lookup_sales_calendar_context`, and adapter docs.
+- Prevents phone validation from becoming a parallel identity resolver with conflicting provenance.
+
+### KTD-2: Use IPQS as validation evidence, not identity authority
+
+IPQS can return reverse names and owner-style fields, but those are not strong enough to identify the caller for customer-facing copy.
+
+Decision:
+
+- IPQS may contribute `callerIntelligence`.
+- IPQS cannot upgrade `identityConfidence` to `high`.
+- Reverse name can appear in Telegram/operator context as "possible reverse lookup".
+- Draft facts must distinguish confirmed CRM/Dialpad facts from possible phone-intelligence facts.
+
+Rationale:
+
+- This preserves the existing safety rule from `docs/solutions/ungate-enrichment-customer-pii.md`.
+- It prevents a stale reverse lookup from becoming a named greeting or company claim.
+
+### KTD-3: Public prospect search is a bounded command seam
+
+The webhook service should not hardwire live web search or browser automation. It should call an optional command that accepts compact input and returns compact JSON.
+
+Decision:
+
+- Add optional `DIALPAD_PUBLIC_PROSPECT_SEARCH_COMMAND`.
+- Invoke it only after phone validation produces a usable, active, low-risk number with enough search inputs.
+- Require the command response to include bounded evidence entries: source type, domain or title, matched terms, and no page snippets.
+- Mark `publicProspect.usable` true only when at least one evidence entry ties the reverse name plus location to a business, role, or organization relevant to ShapeScale for Business.
+- Cap and sanitize summaries, sources, and evidence before model facts; strip instruction-like text and sensitive personal details.
+- Treat search misses as `{usable:false,status:"not_found"}`. Treat search timeouts as `{usable:false,status:"timeout"}` and provider failures as a degraded unavailable status.
+
+Rationale:
+
+- Keeps provider choice replaceable.
+- Keeps latency bounded.
+- Lets the runtime use a cheap model/search pipeline without making the webhook server own that implementation.
+- Keeps untrusted search output from becoming prompt instructions or unauditable prospect claims.
+
+### KTD-4: Cache sanitized results only
+
+The IPQS response can contain more data than this workflow needs.
+
+Decision:
+
+- Cache only normalized fields used by operator context and drafting.
+- Do not store raw IPQS JSON.
+- Exclude sensitive expanded identity payloads if enabled by account tier, including addresses, emails, birthdates, and unrelated identity data.
+- Default phone-validation TTL to 24 hours and public-prospect-search TTL to 6 hours, with environment overrides.
+- Store cache files under the configured private runtime state/log directory; create parent directories with `0700` and SQLite files with `0600`.
+- Use the repo's SQLite concurrency pattern: `busy_timeout` plus best-effort WAL.
+- Purge expired rows on read/write and avoid logging cached values.
+- Include a lookup-policy version in the cache key or stored metadata covering provider endpoint, strictness, country hint, and risk-threshold version.
+
+Rationale:
+
+- Reduces vendor calls and request latency.
+- Limits privacy exposure and accidental prompt leakage.
+- Prevents stale results from surviving changes to provider options or risk thresholds.
+
+### KTD-5: Risk policy is deterministic before model drafting
+
+The model should not decide whether a caller is safe or abusive.
+
+Decision:
+
+- Normalize deterministic risk first.
+- Mark invalid, inactive, known spammer, recent-abuse, risky, or `fraud_score >= 90` numbers as `riskLevel:"high"`.
+- Mark `fraud_score >= 75` as `riskLevel:"medium"` when no high-risk flag is present.
+- Mark all remaining usable numbers as `riskLevel:"low"`.
+- High-risk callers are human-only in v1: render the reason for the operator and do not generate a customer-facing draft.
+- Medium-risk callers may receive only the conservative generic approval draft, with a visible operator warning.
+
+Rationale:
+
+- IPQS documents high-risk interpretations for invalid/inactive numbers and high fraud scores.
+- This is routing and safety policy, not prose generation.
+
+### KTD-6: External enrichment runs after ACK and inside budgets
+
+IPQS and public search must not become part of webhook receipt availability.
+
+Decision:
+
+- Acknowledge webhook receipt before IPQS or public-search calls.
+- Run missed-call enrichment only after the missed-call idempotency claim succeeds.
+- Use deterministic per-window budgets for IPQS and public search; expose `budget_exceeded` or `rate_limited` source statuses when a cap is hit.
+- Use `DIALPAD_CALLER_INTELLIGENCE_BUDGET_WINDOW_SECONDS` for the budget window, defaulting to one hour.
+- Use `DIALPAD_PHONE_INTELLIGENCE_MAX_CALLS_PER_WINDOW` and `DIALPAD_PUBLIC_PROSPECT_SEARCH_MAX_CALLS_PER_WINDOW`, initially defaulting to 120 IPQS validations/hour and 30 public searches/hour.
+- If post-ACK enrichment exceeds its configured time or budget, continue with the existing generic fallback or human-only behavior and never replay user-visible output.
+
+Rationale:
+
+- Preserves the ACK-first/idempotency invariant from `docs/solutions/ack-first-webhook-idempotency.md`.
+- Prevents provider stalls or unique-number spam from delaying receipt handling or burning unbounded credits.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TD
+  A[Inbound Sales SMS or missed call] --> AA[ACK webhook receipt]
+  AA --> AB[Claim idempotency for user-visible output]
+  AB --> B[Dialpad contact enrichment]
+  B --> C[Owned-source identity gate: identity resolver and CRM]
+  C --> E{Identity confidence high?}
+  E -- yes --> F[Use confirmed identity plus calendar/comms facts]
+  E -- no --> G[Phone intelligence helper]
+  G --> H[IPQS adapter and sanitized cache]
+  H --> I{Valid active low risk with search inputs?}
+  I -- yes --> J[Optional public prospect search command]
+  I -- no --> K[Skip public search]
+  J --> L[Caller intelligence context]
+  K --> L
+  F --> M[Draft model facts builder]
+  L --> M
+  M --> N[Existing safety validators]
+  N --> O[Approval draft and Telegram context]
+```
+
+### Data Contract
+
+Add a new `callerIntelligence` object to inbound context metadata:
+
+```json
+{
+  "usable": true,
+  "status": "found",
+  "source": "ipqs",
+  "phone": {
+    "e164": "+18178460085",
+    "localFormat": "(817) 846-0085",
+    "country": "US",
+    "region": "TX",
+    "city": "FORT WORTH",
+    "timezone": "America/Chicago"
+  },
+  "line": {
+    "carrier": "Verizon Wireless",
+    "type": "wireless",
+    "active": true,
+    "activeStatus": "active"
+  },
+  "risk": {
+    "level": "low",
+    "fraudScore": 0,
+    "recentAbuse": false,
+    "risky": false,
+    "spammer": false
+  },
+  "possibleIdentity": {
+    "reverseName": "BILL H HARTIN",
+    "basis": "ipqs_reverse_lookup",
+    "confidence": "low"
+  },
+  "publicProspect": {
+    "usable": true,
+    "status": "found",
+    "summary": "Possible Fort Worth business/professional match.",
+    "confidence": "low",
+    "evidence": [
+      {
+        "sourceType": "business_directory",
+        "domainOrTitle": "Example public business profile",
+        "matchedTerms": ["BILL H HARTIN", "Fort Worth"]
+      }
+    ]
+  }
+}
+```
+
+The exact field names can be adjusted during implementation, but the boundaries must remain:
+
+- confirmed identity stays separate from possible identity;
+- risk is deterministic;
+- public prospect facts are explicitly low confidence unless confirmed elsewhere;
+- public prospect evidence is bounded and sanitized before it reaches model facts.
+
+---
+
+## Implementation Units
+
+### Unit 1: Phone Intelligence Adapter
+
+Files:
+
+- `scripts/adapters/phone_intelligence.py`
+- `tests/test_phone_intelligence.py`
+- `docs/reference/enrichment-adapters.md`
+
+Work:
+
+- Add an import-safe adapter with a CLI JSON contract matching the existing adapter pattern.
+- Read `IPQS_API_KEY` or a narrowly named equivalent from the environment.
+- Call IPQS Phone Number Validation with a bounded timeout.
+- Prefer the `IPQS-KEY` header so the API key is not present in URLs or logs.
+- Default `strictness` to `0`; allow env override for stricter future tuning.
+- Support a country hint, defaulting to US for NANP numbers.
+- Normalize provider output into compact statused fields.
+- Return exit code `0` for expected misses/degraded states with `usable:false`.
+- Add cache support for sanitized normalized results.
+- Add `DIALPAD_PHONE_INTELLIGENCE_CACHE_DB`, `DIALPAD_PHONE_INTELLIGENCE_CACHE_TTL_SECONDS` with a 24-hour default, and `DIALPAD_PUBLIC_PROSPECT_SEARCH_CACHE_TTL_SECONDS` with a 6-hour default.
+- Store cache entries with a lookup-policy version that covers endpoint, strictness, country hint, and risk-threshold version.
+- Create cache parent directories with `0700`, cache files with `0600`, expired-row purging, and the existing SQLite `busy_timeout`/best-effort-WAL pattern.
+- Add provider-call budget checks for unique-number floods before making paid or external calls, using `DIALPAD_CALLER_INTELLIGENCE_BUDGET_WINDOW_SECONDS`, `DIALPAD_PHONE_INTELLIGENCE_MAX_CALLS_PER_WINDOW`, and `DIALPAD_PUBLIC_PROSPECT_SEARCH_MAX_CALLS_PER_WINDOW`.
+
+Tests:
+
+- valid active wireless number normalizes expected fields;
+- invalid number returns unusable/high-risk context;
+- high risk is assigned for invalid, inactive, `recent_abuse`, `risky`, `spammer`, or `fraud_score >= 90`;
+- medium risk is assigned for `fraud_score >= 75` when no high-risk flag is present;
+- provider timeout returns degraded unusable context;
+- malformed response returns degraded unusable context;
+- secret is never printed or stored in cached payload;
+- cache hit avoids provider call and returns the same normalized shape;
+- cache entries invalidate when the lookup-policy version changes;
+- budget exhaustion returns a `budget_exceeded` or `rate_limited` status without a provider call.
+
+### Unit 2: Shared Webhook Integration
+
+Files:
+
+- `scripts/webhook_server.py`
+- `scripts/adapters/identity_resolver.py`
+- `tests/test_sender_enrichment.py`
+- `tests/test_webhook_hooks.py`
+- `tests/test_deal_segment.py`
+
+Work:
+
+- Add one shared `lookup_caller_intelligence` helper used by both inbound Sales SMS and missed-call flows.
+- Run it only after webhook receipt acknowledgement and, for missed calls, after the missed-call idempotency claim succeeds.
+- Define one shared Sales enrichment order: Dialpad contact enrichment, owned-source identity check through the existing resolver/CRM path, caller-intelligence eligibility, then metadata/Telegram/model-facts threading from the same enriched context object.
+- Run caller intelligence only for inbound external Sales numbers and only when owned-source identity is not already high confidence.
+- Thread `callerIntelligence` into approval metadata, hook payloads, and Telegram context.
+- Add source-status reporting alongside CRM, calendar, comms, and QMD.
+- Preserve idempotency gates: duplicate missed calls must not re-run user-visible output paths.
+- Preserve fallback behavior when post-ACK caller intelligence exceeds timeout or budget.
+
+Tests:
+
+- Sales SMS with low identity confidence gets caller-intelligence context;
+- missed call with low identity confidence gets the same context shape;
+- the owned-source resolver/CRM gate runs before caller intelligence eligibility;
+- high-confidence CRM/Dialpad identity does not rely on IPQS for identity;
+- duplicate missed call does not create duplicate phone-intelligence-rendered drafts;
+- source status renders degraded/missing states without breaking draft creation;
+- provider timeout or budget exhaustion after ACK still produces the existing fallback path without replay.
+
+### Unit 3: Public Prospect Enrichment Command Seam
+
+Files:
+
+- `scripts/webhook_server.py`
+- `tests/test_webhook_hooks.py`
+- `docs/reference/enrichment-adapters.md`
+
+Work:
+
+- Add optional `DIALPAD_PUBLIC_PROSPECT_SEARCH_COMMAND`.
+- Pass only minimal inputs: phone local format, reverse name, city, region, country, and risk classification.
+- Use a strict timeout and compact JSON response.
+- Require returned confidence plus bounded evidence entries with source type, domain or title, and matched terms.
+- Reject `publicProspect.usable` unless at least one evidence entry ties the reverse name plus location to a business, role, or organization relevant to ShapeScale for Business.
+- Sanitize all public-search output before prompt/model facts: cap field lengths, strip instruction-like text, strip sensitive personal details, and never keep page snippets.
+- Cache sanitized search summaries separately from IPQS results.
+- Do not call public search for invalid, inactive, high-risk, or insufficient-input cases.
+- Distinguish search miss, timeout, unavailable, unsafe output, and budget-exhausted statuses.
+
+Tests:
+
+- command timeout degrades cleanly;
+- high-risk number skips public search;
+- public search summary appears only in operator context/model facts with low-confidence labeling;
+- malformed command output is ignored safely;
+- malicious search summaries cannot alter model instructions or customer-facing draft behavior;
+- same-name personal results without business/professional evidence are rejected as unusable.
+
+### Unit 4: Model Draft Facts and Safety
+
+Files:
+
+- `scripts/draft_model.py`
+- `scripts/webhook_server.py`
+- `tests/test_ungate_provenance.py`
+- `tests/test_auto_send_shadow.py`
+
+Work:
+
+- Extend the model facts builder with `callerIntelligence`.
+- Preserve the current rule that low-confidence facts cannot create named greetings or confirmed business claims.
+- Add explicit model constraints for possible reverse-name and public-search facts.
+- Treat public-search facts as untrusted data that arrive after sanitization and under explicit constraints.
+- Keep existing URL allowlist and unsupported-claim validators.
+- Add deterministic fallback drafts for degraded, low-risk, and medium-risk cases.
+- For high-risk, invalid, or inactive callers, produce operator metadata and human-only Telegram context without a generated customer-facing draft.
+
+Tests:
+
+- model facts include low-risk phone validation context;
+- low-confidence reverse name cannot appear as a greeting;
+- unconfirmed business/professional search result cannot appear as a confirmed company claim;
+- high-risk, invalid, or inactive caller produces human-only escalation with no generated customer-facing draft;
+- medium-risk caller produces only the conservative generic approval draft with an operator warning;
+- unsafe model output falls back to the deterministic draft.
+
+### Unit 5: Runtime Configuration, Docs, and Verification
+
+Files:
+
+- `README.md`
+- `docs/reference/enrichment-adapters.md`
+- `docs/solutions/ungate-enrichment-customer-pii.md`
+- relevant tests listed above
+
+Work:
+
+- Document the IPQS secret setup using env var references only.
+- Document optional public prospect search command contract.
+- Document cache DB, TTL, policy-version, file-permission, purge, and rate-budget configuration.
+- Document source-status behavior and draft safety boundaries.
+- Add a concise operational example for an unknown Fort Worth caller.
+- Run focused unit tests plus the existing webhook/enrichment safety suite.
+
+Verification commands:
+
+- `python -m pytest tests/test_phone_intelligence.py`
+- `python -m pytest tests/test_sender_enrichment.py tests/test_webhook_hooks.py tests/test_ungate_provenance.py`
+- `python -m pytest tests/test_auto_send_shadow.py tests/test_deal_segment.py`
+
+---
+
+## Scope Boundaries
+
+Customer-facing draft text may use:
+
+- generic business-safe wording;
+- callback intent;
+- confirmed owned-source facts;
+- booking-link or next-step language already allowed by current draft safety rules;
+- conservative generic wording for low-risk and medium-risk unknown callers only.
+
+Customer-facing draft text may not:
+
+- use low-confidence phone intelligence to claim the caller's name;
+- use low-confidence phone intelligence to claim the caller's company;
+- use low-confidence phone intelligence to claim the caller's profession;
+- state that ShapeScale looked the caller up publicly;
+- state that a public-search result is definitely the caller;
+- generate any reply for high-risk, invalid, or inactive callers in v1.
+
+Operator-facing Telegram context may show:
+
+- phone validity and active status;
+- carrier, line type, city/state, country;
+- fraud/risk signals;
+- possible reverse name;
+- sanitized public-search evidence with low-confidence labeling;
+- human-only escalation for high-risk, invalid, or inactive callers.
+
+---
+
+## Risks and Mitigations
+
+- Risk: Reverse lookup is stale or wrong.
+  Mitigation: Keep it out of identity confidence and label it as possible evidence.
+
+- Risk: Public search finds a same-name person in the same area.
+  Mitigation: Require at least one business/professional evidence entry tied to reverse name plus location, and treat it as low-confidence operator context unless owned sources confirm it.
+
+- Risk: Provider latency slows webhook handling.
+  Mitigation: Run provider calls only after webhook ACK and idempotency claim, use strict timeouts, cache sanitized results, and fail closed.
+
+- Risk: Raw provider data leaks into prompts or logs.
+  Mitigation: Normalize allowlisted fields only, sanitize public-search output before model facts, avoid storing raw payloads, and avoid logging cached values.
+
+- Risk: Risk scoring blocks useful prospects.
+  Mitigation: Use explicit thresholds; high-risk callers become human-only, while medium-risk callers can still get conservative generic drafts with operator warnings.
+
+- Risk: Unique-number spam burns provider credits.
+  Mitigation: Add deterministic per-window budgets with `budget_exceeded` or `rate_limited` source statuses and existing fallback behavior.
+
+---
+
+## Open Questions
+
+- Which runtime command will implement public prospect search first: an existing local search wrapper, a browser/search skill wrapper, or a provider-specific script?
+- Should the phone-intelligence source status be shown in the compact Telegram brief even when the number is already high-confidence in CRM?
+
+---
+
+## Sources
+
+- Brainstorm requirements: `docs/brainstorms/2026-06-23-phone-validation-prospect-enrichment-requirements.md`
+- Existing adapter pattern: `docs/reference/enrichment-adapters.md`
+- Existing identity resolver: `scripts/adapters/identity_resolver.py`
+- PII and low-confidence safety: `docs/solutions/ungate-enrichment-customer-pii.md`
+- ACK/idempotency behavior: `docs/solutions/ack-first-webhook-idempotency.md`
+- IPQS Phone Number Validation overview: `https://www.ipqualityscore.com/documentation/phone-number-validation-api/overview`
+- IPQS advanced options: `https://www.ipqualityscore.com/documentation/phone-number-validation-api/advanced-options`
+- IPQS response parameters: `https://www.ipqualityscore.com/documentation/phone-number-validation-api/response-parameters`


### PR DESCRIPTION
What
- Add requirements for IPQS phone validation and bounded prospect enrichment on inbound Sales SMS and missed-call events.
- Add automatic Dialpad contact sync requirements and plan details, gated by owned-source/public-business confidence and ambiguity checks.
- Add a reviewed implementation plan for a shared caller-intelligence path, owned-source identity gating, sanitized public-search evidence, cache controls, risk policy, contact writeback, and model-draft safety.
- Resolve Codex review feedback: keep idempotency claims before ACK, use synthetic examples, classify 85+ fraud scores as high-risk, align status vocabulary, and budget public-search command calls.

Why
- Unknown Sales callers should surface validation, risk, and possible business context to the operator without leaking low-confidence reverse lookup or public-search guesses into customer-facing drafts.
- Clear enriched identities should keep Dialpad contacts current, while ambiguous or risky matches stay human-reviewed.
- SMS and missed-call enrichment need one shared contract so implementation does not drift between webhook surfaces.

Tests
- git diff --check
- git diff --check HEAD~1..HEAD

AI Assistance
- Drafted and reviewed with AI assistance. ce-doc-review and Codex findings were used to patch P1/P2 documentation issues before requesting another review.