### PR TITLE
docs: require Codex PR review before merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,9 @@
 # AGENTS.md - Dialpad OpenClaw Skill
 
-Inherits all rules from the parent workspace `../AGENTS.md`.
+## Scope
+
+This is the `dialpad-openclaw-skill` repo. It contains the Dialpad webhook server,
+SMS/call enrichment, and OpenClaw hook integration.
 
 ## PR Review Policy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS.md - Dialpad OpenClaw Skill
+
+Inherits all rules from the parent workspace `../AGENTS.md`.
+
+## PR Review Policy
+
+- Wait for the Codex automated review before merging. Codex reviews are triggered on PR open / ready-for-review.
+- Do not squash-merge until the Codex review has either posted findings (address them first) or reacted with 👍 (no findings).
+- If Codex does not review within 10 minutes, proceed without blocking.


### PR DESCRIPTION
## Summary

Adds a child `AGENTS.md` for the dialpad-openclaw-skill repo with a PR review policy: wait for Codex automated review before squash-merging.

## Why

PR #118 (the merged-flow feature) was squash-merged before Codex reviewed it, so no automated review ran. PRs #115, #116, #117 all received Codex reviews — #115 had 3 actionable P2 findings that were addressed. Going forward, the policy ensures Codex findings are surfaced before merge.

## Tests

Documentation-only. No code changes.
