### PR TITLE
fix: replace stale /home/art/clawd/logs/ paths with /home/art/niemand/logs/

### DIFF
--- a/scripts/sms_approval.py
+++ b/scripts/sms_approval.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 
-DB_PATH = Path(os.environ.get("DIALPAD_SMS_APPROVAL_DB", "/home/art/clawd/logs/sms_approvals.db"))
+DB_PATH = Path(os.environ.get("DIALPAD_SMS_APPROVAL_DB", "/home/art/niemand/logs/sms_approvals.db"))
 DEFAULT_EMERGENCY_OPT_OUT_PATH = Path("/tmp/dialpad_sms_approval_emergency_opt_outs.jsonl")
 _EMERGENCY_OPT_OUT_MEMORY: set[str] = set()
 

--- a/scripts/sms_approval_eval.py
+++ b/scripts/sms_approval_eval.py
@@ -86,8 +86,8 @@ STALE_REASON_VERDICTS: dict[str, str] = {
 # silently counted as accept or reject.
 DEFAULT_STALE_VERDICT = VERDICT_EXCLUDED
 
-DEFAULT_APPROVAL_DB = "/home/art/clawd/logs/sms_approvals.db"
-DEFAULT_SMS_DB = "/home/art/clawd/logs/sms.db"
+DEFAULT_APPROVAL_DB = "/home/art/niemand/logs/sms_approvals.db"
+DEFAULT_SMS_DB = "/home/art/niemand/logs/sms.db"
 DEFAULT_WINDOW_DAYS = 7
 
 

--- a/scripts/sms_sqlite.py
+++ b/scripts/sms_sqlite.py
@@ -36,12 +36,12 @@ def redact_preview(text, **kwargs):
 
 # Database path
 def resolve_db_path() -> Path:
-    return Path(os.environ.get("DIALPAD_SMS_DB", "/home/art/clawd/logs/sms.db")).expanduser()
+    return Path(os.environ.get("DIALPAD_SMS_DB", "/home/art/niemand/logs/sms.db")).expanduser()
 
 
 DB_PATH = resolve_db_path()
-LEGACY_THREADS_DIR = Path("/home/art/clawd/logs/sms_threads")
-LEGACY_LOG = Path("/home/art/clawd/logs/dialpad_sms.jsonl")
+LEGACY_THREADS_DIR = Path("/home/art/niemand/logs/sms_threads")
+LEGACY_LOG = Path("/home/art/niemand/logs/dialpad_sms.jsonl")
 
 
 def init_db() -> sqlite3.Connection:

--- a/scripts/sms_storage.py
+++ b/scripts/sms_storage.py
@@ -11,8 +11,8 @@ from pathlib import Path
 from typing import Optional
 
 # Base paths
-THREADS_DIR = Path("/home/art/clawd/logs/sms_threads")
-LEGACY_LOG = Path("/home/art/clawd/logs/dialpad_sms.jsonl")
+THREADS_DIR = Path("/home/art/niemand/logs/sms_threads")
+LEGACY_LOG = Path("/home/art/niemand/logs/dialpad_sms.jsonl")
 
 
 def sanitize_number(number: str) -> str:

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -1587,7 +1587,7 @@ def _claim_dedupe_row(conn, table, retention_ms, key, timestamp_ms):
 def _missed_call_dedupe_db_path():
     if sms_approval is not None and getattr(sms_approval, "DB_PATH", None):
         return Path(sms_approval.DB_PATH)
-    return Path(os.environ.get("DIALPAD_MISSED_CALL_DEDUPE_DB", "/home/art/clawd/logs/sms_approvals.db"))
+    return Path(os.environ.get("DIALPAD_MISSED_CALL_DEDUPE_DB", "/home/art/niemand/logs/sms_approvals.db"))
 
 
 def _init_missed_call_dedupe_db(db_path=None):
@@ -1635,7 +1635,7 @@ def claim_missed_call_notification(dedupe_key, *, db_path=None, now_ms=None):
 def _sms_dedupe_db_path():
     if sms_approval is not None and getattr(sms_approval, "DB_PATH", None):
         return Path(sms_approval.DB_PATH)
-    return Path(os.environ.get("DIALPAD_SMS_DEDUPE_DB", "/home/art/clawd/logs/sms_approvals.db"))
+    return Path(os.environ.get("DIALPAD_SMS_DEDUPE_DB", "/home/art/niemand/logs/sms_approvals.db"))
 
 
 def _init_sms_dedupe_db(db_path=None):


### PR DESCRIPTION
## What

Replace all 10 hardcoded `/home/art/clawd/logs/` paths with `/home/art/niemand/logs/` across 5 files.

## Why

The `/home/art/clawd` symlink exists on the host (pointing to `/home/art/niemand`) but is **not mounted inside the AlphaClaw Docker container**. Only `/home/art/niemand` is volume-mounted. This caused `Permission denied: '/home/art/clawd'` errors when the Dialpad skill tried to access the SMS database or approval DB.

All env overrides (`DIALPAD_SMS_DB`, `DIALPAD_SMS_APPROVAL_DB`, `DIALPAD_MISSED_CALL_DEDUPE_DB`, `DIALPAD_SMS_DEDUPE_DB`) still take priority over the defaults.

## Files changed

- `scripts/sms_approval.py` — DB_PATH default
- `scripts/sms_approval_eval.py` — DEFAULT_APPROVAL_DB, DEFAULT_SMS_DB
- `scripts/sms_sqlite.py` — resolve_db_path default, LEGACY_THREADS_DIR, LEGACY_LOG
- `scripts/sms_storage.py` — THREADS_DIR, LEGACY_LOG
- `scripts/webhook_server.py` — missed call dedupe DB, SMS dedupe DB

## Tests

```bash
# Verify env override still works
DIALPAD_SMS_DB=/tmp/test.db python3 -c "from scripts.sms_sqlite import resolve_db_path; print(resolve_db_path())"
# Should print /tmp/test.db

# Verify default path is correct
python3 -c "from scripts.sms_sqlite import resolve_db_path; print(resolve_db_path())"
# Should print /home/art/niemand/logs/sms.db
```

## AI Assistance

Authored with AI assistance (OpenCode + GLM 5.2). Root cause traced from AlphaClaw session error logs showing `Permission denied: '/home/art/clawd'`.