### PR TITLE
fix(webhook): tighten pricing drafts and callback defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ export OPENCLAW_HOOKS_SMS_ENABLED="1"
 export OPENCLAW_HOOKS_CALL_ENABLED="1"
 
 # Optional merged-flow agent draft callback URL. The default is reachable from
-# the AlphaClaw/OpenClaw gateway container when the webhook binds 0.0.0.0:8081.
-export DIALPAD_DRAFT_CALLBACK_URL="http://host.docker.internal:8081/internal/draft-callback"
+# the AlphaClaw/OpenClaw gateway container when the webhook binds 0.0.0.0:8888.
+export DIALPAD_DRAFT_CALLBACK_URL="http://host.docker.internal:8888/internal/draft-callback"
 
 # Optional sales-line first-contact auto-replies (disabled by default)
 export DIALPAD_AUTO_REPLY_ENABLED="1"
@@ -110,7 +110,7 @@ When `OPENCLAW_HOOKS_TOKEN` is configured, inbound SMS and inbound missed-call e
 When `DIALPAD_MERGED_DRAFT_FLOW=1`, the webhook sends no immediate Telegram card for eligible inbound SMS or missed calls.
 It waits for `/internal/draft-callback` from the agent, then falls back to the deterministic draft after `DIALPAD_AGENT_DRAFT_TIMEOUT_SECONDS`.
 The webhook uses `DIALPAD_DRAFT_CALLBACK_URL` in the hook prompt; the `dialpad-draft-callback` OpenClaw plugin should use the same value through its `callbackUrl` config key.
-The default, `http://host.docker.internal:8081/internal/draft-callback`, is intended for the AlphaClaw container-to-host path.
+The default, `http://host.docker.internal:8888/internal/draft-callback`, is intended for the AlphaClaw container-to-host path.
 When OpenClaw hook delivery and the local Dialpad Telegram card route to the same Telegram target, the local Dialpad card owns the operator-visible notification by default because it carries the approval UI. The hook payload is still sent as structured context with `deliver=false` and ownership metadata so downstream agents do not post a second same-target operator message. Set `DIALPAD_ALLOW_DUPLICATE_OPERATOR_DELIVERY=1` only when intentional fanout to the same target is desired.
 If your gateway listens on a different port, change `OPENCLAW_GATEWAY_URL` accordingly.
 The local gateway allows explicit `niemand-work` routing and `hook:dialpad:` session keys.

--- a/SKILL.md
+++ b/SKILL.md
@@ -154,7 +154,7 @@ export DIALPAD_PROFILE_SALES_FROM="+14155201316"
 export DIALPAD_DEFAULT_PROFILE="work"
 export DIALPAD_DEFAULT_FROM_NUMBER="+14155201316"
 export DIALPAD_SMS_RECEIPT_LEDGER="/data/.openclaw/state/dialpad/sms-receipts.jsonl"
-export DIALPAD_DRAFT_CALLBACK_URL="http://host.docker.internal:8081/internal/draft-callback"
+export DIALPAD_DRAFT_CALLBACK_URL="http://host.docker.internal:8888/internal/draft-callback"
 ```
 
 For merged agent-draft flow, keep `DIALPAD_DRAFT_CALLBACK_URL` aligned with the

--- a/docs/plans/2026-07-06-001-fix-merged-flow-duplicates-callback-plan.md
+++ b/docs/plans/2026-07-06-001-fix-merged-flow-duplicates-callback-plan.md
@@ -33,9 +33,9 @@ Scope the webhook's immediate Telegram send to the non-merged path (single-send 
 Diagnosed in-session (2026-07-06). The merged flow (PRs #118/#120) intends: hook the agent with `deliver=false`, wait for its draft via `/internal/draft-callback`, render one rich card; fall back to the deterministic draft after 180s. Two defects ship instead:
 
 1. **Duplicates (SMS only):** the immediate card build + send block sits outside the SMS merged branch's `else` in `scripts/webhook_server.py`, so merged mode also sends immediately; the fallback then re-sends at +180s. Every inbound SMS posts twice (journal: paired sends 180s apart on every event). The missed-call merged branch is already correctly scoped — its immediate send lives inside the `else` — so missed-call work is regression coverage, not a code move.
-2. **Dead callback → generic drafts:** `path=fallback` on 22/22 merged renders in 7 days. Three independent blockers: (a) the gateway strips `submit_draft` from agent sessions via `tools.profile: "coding"`; (b) the plugin's default `callbackUrl` is `http://127.0.0.1:8081` — container loopback — and the live plugin config carries no override (the untracked manifest's `configSchema` would even reject one: `additionalProperties: false` with no properties); (c) the webhook embeds `http://127.0.0.1:{PORT}` as the raw-HTTP fallback URL in the hook message (both the SMS and missed-call sites).
+2. **Dead callback → generic drafts:** `path=fallback` on 22/22 merged renders in 7 days. Three independent blockers: (a) the gateway strips `submit_draft` from agent sessions via `tools.profile: "coding"`; (b) the plugin's previous default `callbackUrl` was `http://127.0.0.1:8081` — container loopback — and the live plugin config carried no override (the untracked manifest's `configSchema` would even reject one: `additionalProperties: false` with no properties); (c) the webhook embedded `http://127.0.0.1:{PORT}` as the raw-HTTP fallback URL in the hook message (both the SMS and missed-call sites).
 
-Verified environment facts the fixes rest on: the webhook binds `0.0.0.0:8081` (no bind change needed); the AlphaClaw compose already maps `host.docker.internal:host-gateway` (container→host works today); the hook agent is `niemand-work` (`hooks.allowedAgentIds`); per-agent `tools.alsoAllow` on top of the profile has a live precedent (`niemand` + `browser`); `/internal/draft-callback` enforces a per-job `X-Callback-Token` with constant-time compare (401 otherwise); `production-config-seed.mjs` repairs `openclaw.json` on every start, so durable config belongs in the seed.
+Verified environment facts the fixes rest on: the webhook binds `0.0.0.0:8888` (no bind change needed); the AlphaClaw compose already maps `host.docker.internal:host-gateway` (container→host works today); the hook agent is `niemand-work` (`hooks.allowedAgentIds`); per-agent `tools.alsoAllow` on top of the profile has a live precedent (`niemand` + `browser`); `/internal/draft-callback` enforces a per-job `X-Callback-Token` with constant-time compare (401 otherwise); `production-config-seed.mjs` repairs `openclaw.json` on every start, so durable config belongs in the seed.
 
 ### Requirements
 
@@ -71,7 +71,7 @@ Verified environment facts the fixes rest on: the webhook binds `0.0.0.0:8081` (
 ### Key Technical Decisions
 
 - KTD1 — **Enforce the single-send invariant structurally, not with a flag.** The immediate card build + send moves inside the non-merged branch (both flows); merged mode's only senders remain the claim-based renders (`claim_pending_draft` already makes callback/fallback mutually exclusive). No `if telegram_status == "merged_flow_waiting"` guards sprinkled around shared code.
-- KTD2 — **Reachability is a URL fix, not a network fix.** `host.docker.internal:8081` works today (compose `extra_hosts` present; webhook binds `0.0.0.0`). Both URL producers become configurable with that default: a webhook env var for the embedded fallback URL, and the plugin's `callbackUrl` config (manifest schema must gain the property — the current untracked manifest rejects unknown config keys).
+- KTD2 — **Reachability is a URL fix, not a network fix.** `host.docker.internal:8888` works today (compose `extra_hosts` present; webhook binds `0.0.0.0`). Both URL producers become configurable with that default: a webhook env var for the embedded fallback URL, and the plugin's `callbackUrl` config (manifest schema must gain the property — the current untracked manifest rejects unknown config keys).
 - KTD3 — **Tool exposure is per-agent and seed-durable — with replace-not-layer semantics respected.** Agent-level `tools.alsoAllow` SHADOWS the global list (nullish-coalescing in openclaw's policy resolution, not a union), so seeding `niemand-work.tools.alsoAllow` must write the union of the global `tools.alsoAllow` entries (currently browser + tavily) plus `submit_draft` — seeding `[submit_draft]` alone would strip the work lane's existing tools. Done via `production-config-seed.mjs` alongside `plugins.entries["dialpad-draft-callback"].config.callbackUrl`; live-JSON edits alone are wiped by restart repair.
 - KTD4 — **Security posture unchanged.** The endpoint was already LAN-exposed (`0.0.0.0` bind); the per-job token with constant-time compare stays mandatory and gets an explicit regression test (no token / wrong token → 401, no render).
 - KTD5 — **Draft quality is prompt-level.** Extend `format_hook_message`'s callback instructions with drafting guidance grounded in the context block the agent already receives; no new data sources.
@@ -92,7 +92,7 @@ flowchart TD
     P -.->|removed: dedented immediate send| X((was: second send))
 ```
 
-Callback reachability (all three URL surfaces converge on one value): plugin `callbackUrl` (seeded config) = webhook `DIALPAD_DRAFT_CALLBACK_URL` env default = `http://host.docker.internal:8081/internal/draft-callback`, reachable via the compose `host-gateway` mapping.
+Callback reachability (all three URL surfaces converge on one value): plugin `callbackUrl` (seeded config) = webhook `DIALPAD_DRAFT_CALLBACK_URL` env default = `http://host.docker.internal:8888/internal/draft-callback`, reachable via the compose `host-gateway` mapping.
 
 ---
 
@@ -122,7 +122,7 @@ Callback reachability (all three URL surfaces converge on one value): plugin `ca
 **Goal:** The hook message's raw-HTTP fallback URL is reachable from the container (R5).
 **Dependencies:** none.
 **Files:** `scripts/webhook_server.py` (both callback-URL construction sites — SMS and missed-call), `tests/test_webhook_merged_flow.py`, `README.md`/`SKILL.md` (env var doc).
-**Approach:** Per KTD2: one module-level env-resolved constant (e.g. `DIALPAD_DRAFT_CALLBACK_URL`) defaulting to the `host.docker.internal:8081` callback path; both sites use it.
+**Approach:** Per KTD2: one module-level env-resolved constant (e.g. `DIALPAD_DRAFT_CALLBACK_URL`) defaulting to the `host.docker.internal:8888` callback path; both sites use it.
 **Test scenarios:** default embeds `host.docker.internal` in the hook message; env override is respected at both sites.
 **Verification:** tests green.
 

--- a/extensions/dialpad-draft-callback/src/index.ts
+++ b/extensions/dialpad-draft-callback/src/index.ts
@@ -1,7 +1,7 @@
 import { Type } from "typebox";
 import { defineToolPlugin } from "openclaw/plugin-sdk/tool-plugin";
 
-const DEFAULT_CALLBACK_URL = "http://host.docker.internal:8081/internal/draft-callback";
+const DEFAULT_CALLBACK_URL = "http://host.docker.internal:8888/internal/draft-callback";
 
 export default defineToolPlugin({
   id: "dialpad-draft-callback",

--- a/scripts/webhook_server.py
+++ b/scripts/webhook_server.py
@@ -15,7 +15,7 @@ Features:
 - All secrets from environment variables
 
 Environment Variables:
-- PORT (default: 8081) - HTTP server port
+- PORT (default: 8888) - HTTP server port
 - DIALPAD_TELEGRAM_BOT_TOKEN - Telegram bot token (required for call/voicemail notifications)
 - DIALPAD_TELEGRAM_CHAT_ID - Telegram chat ID (required for call/voicemail notifications)
 - DIALPAD_TELEGRAM_APPROVAL_BUTTONS_ENABLED (default: disabled)
@@ -111,7 +111,7 @@ def parse_bool_env(raw_value, default=True):
 
 
 # Environment configuration (NO HARDCODED SECRETS)
-PORT = int(os.environ.get("PORT", "8081"))
+PORT = int(os.environ.get("PORT", "8888"))
 WEBHOOK_SECRET = os.environ.get("DIALPAD_WEBHOOK_SECRET", "")
 TELEGRAM_BOT_TOKEN = os.environ.get("DIALPAD_TELEGRAM_BOT_TOKEN", "")
 TELEGRAM_CHAT_ID = os.environ.get("DIALPAD_TELEGRAM_CHAT_ID", "")
@@ -2689,6 +2689,19 @@ def build_proactive_reply_message(normalized_event, sender_enrichment=None):
     return f"Hi {greeting_name}, {body}"
 
 
+_PRICING_KEYWORD_RE = re.compile(r"\b(price|pricing|cost|quote|lease|buyout|finance|financing|monthly|payment)\b")
+_PRICING_AMOUNT_RE = re.compile(r"\bhow\s+much\b")
+_PRICING_AMOUNT_CONTEXT_RE = re.compile(
+    r"\b(cad|usd|dollars?|canadian|quote|lease|buy|purchase|finance|financing|monthly|payment)\b|\$"
+)
+
+
+def _is_pricing_question(body):
+    if _PRICING_KEYWORD_RE.search(body):
+        return True
+    return bool(_PRICING_AMOUNT_RE.search(body) and _PRICING_AMOUNT_CONTEXT_RE.search(body))
+
+
 def classify_rich_sms_question(text, recent_thread=None):
     """Classify bounded Sales SMS questions that are safe candidates for richer drafts."""
     body = str(text or "").strip().lower()
@@ -2703,7 +2716,7 @@ def classify_rich_sms_question(text, recent_thread=None):
         return "link_issue"
     if re.search(r"\b(book|booking|schedule|demo|appointment|calendar|time)\b", body):
         return "booking"
-    if re.search(r"\b(price|pricing|cost|quote|lease|buyout|finance|financing|monthly|payment)\b", body):
+    if _is_pricing_question(body):
         return "pricing"
     if re.search(r"\b(business|consumer|version|scan|scanner|results|client|clients|how does|how it works)\b", body):
         return "product"
@@ -3049,7 +3062,7 @@ def _rich_reply_has_calendar_status(rich_reply):
 def _rich_reply_blocks_generic_fallback(rich_reply):
     return (
         isinstance(rich_reply, dict)
-        and rich_reply.get("category") == "scheduling_availability"
+        and rich_reply.get("category") in {"pricing", "scheduling_availability"}
         and rich_reply.get("usable") is not True
     )
 
@@ -4268,6 +4281,7 @@ _QMD_STOPWORDS = frozenset(
     thank hi hello there here just like into out up down over more most any some
     your shapescale shape scale""".split()
 )
+_PRICING_QUERY_STOPWORDS = frozenset("personal cad usd dollar dollars canadian use".split())
 # cost/costs/price/priced are NOT stopwords: they discriminate pricing docs from
 # availability docs that merely mention "pricing" in their heading. Keeping them
 # in the AND-query prevents a cost question from collapsing to the bare anchor.
@@ -4288,10 +4302,14 @@ def _knowledge_query_for_category(category, text):
     arbitrary doc across the whole collection.
     """
     anchor = {"pricing": "pricing", "booking": "book demo"}.get(category, "")
-    words = re.findall(r"[a-zA-Z]{3,}", str(text or "").lower())
+    body = str(text or "").lower()
+    words = re.findall(r"[a-zA-Z]{3,}", body)
+    stopwords = _QMD_STOPWORDS | (_PRICING_QUERY_STOPWORDS if category == "pricing" else frozenset())
+    if category == "pricing" and _is_pricing_question(body):
+        words.append("cost")
     # Longest content words first; lexicographic tie-break keeps the query stable
     # across processes (set iteration order is hash-randomized).
-    candidates = sorted({w for w in words if w not in _QMD_STOPWORDS}, key=lambda w: (-len(w), w))
+    candidates = sorted({w for w in words if w not in stopwords}, key=lambda w: (-len(w), w))
     # Dedup against the anchor's own words so we don't emit "book demo book demo".
     tokens = anchor.split()
     for word in candidates:

--- a/tests/test_sender_enrichment.py
+++ b/tests/test_sender_enrichment.py
@@ -1594,6 +1594,20 @@ def test_knowledge_query_extracts_salient_keywords_for_and_search():
     assert webhook_server._knowledge_query_for_category("pricing", "how much does it cost") == "pricing cost"
 
 
+def test_cad_how_much_question_classifies_as_pricing():
+    text = "Personal use\nHow\nMuch is it in CAD dollars?"
+
+    assert webhook_server.classify_rich_sms_question(text) == "pricing"
+    assert webhook_server._knowledge_query_for_category("pricing", text) == "pricing cost"
+
+
+def test_how_much_near_matches_do_not_force_pricing():
+    assert webhook_server._is_pricing_question("how much effort to pay attention") is False
+    assert webhook_server._is_pricing_question("how much time does it take") is False
+    assert webhook_server._is_pricing_question("how much data can it scan") is False
+    assert webhook_server.classify_rich_sms_question("how much data can it scan") == "product"
+
+
 def test_knowledge_query_keeps_cost_keyword_for_pricing_question():
     # Regression: "I want to know cost please" used to collapse to just "pricing"
     # because cost/want/know/please were all stopwords. The bare "pricing" query
@@ -1601,6 +1615,94 @@ def test_knowledge_query_keeps_cost_keyword_for_pricing_question():
     # "not available for new orders" disclaimer) instead of pricing details.
     # `cost` must survive stopword stripping so the AND query discriminates.
     assert webhook_server._knowledge_query_for_category("pricing", "I want to know cost please") == "pricing cost"
+
+
+def test_cad_pricing_question_uses_knowledge_before_crm(monkeypatch):
+    queries = []
+    crm_calls = []
+    monkeypatch.setattr(webhook_server, "lookup_recent_sms_thread", lambda *_args, **_kwargs: [])
+
+    def _knowledge(query):
+        queries.append(query)
+        return {
+            "usable": True,
+            "status": "ok",
+            "text": "ShapeScale pricing is quoted in USD. For CAD, we can confirm the current converted amount before you purchase.",
+        }
+
+    def _crm_context(*_args, **_kwargs):
+        crm_calls.append(_args)
+        return {
+            "usable": True,
+            "status": "ok",
+            "basis": "attio",
+            "company": "Prima Soins Maison",
+            "stage": "Qualifying Sequence",
+        }
+
+    monkeypatch.setattr(webhook_server, "lookup_shapescale_knowledge", _knowledge)
+    monkeypatch.setattr(webhook_server, "lookup_sales_crm_context", _crm_context)
+
+    rich_reply = webhook_server.build_rich_sms_reply(
+        {
+            "event_type": "sms",
+            "sender_number": "+15148179929",
+            "recipient_number": "+14155201316",
+            "text": "Personal use\nHow\nMuch is it in CAD dollars?",
+            "inbound_context": {
+                "identityConfidence": "high",
+                "contextDraftAllowed": True,
+            },
+        }
+    )
+
+    assert queries == ["pricing cost"]
+    assert crm_calls == []
+    assert rich_reply["usable"] is True
+    assert rich_reply["basis"] == "shapescale_knowledge"
+    assert rich_reply["category"] == "pricing"
+    assert "follow up shortly" not in rich_reply["message"]
+
+
+def test_pricing_question_with_unavailable_knowledge_does_not_use_generic_crm_fallback(monkeypatch):
+    monkeypatch.setattr(webhook_server, "DIALPAD_AUTO_REPLY_ENABLED", True)
+    monkeypatch.setattr(webhook_server, "DIALPAD_AUTO_REPLY_SALES_LINE", "4155201316")
+    monkeypatch.setattr(webhook_server, "lookup_recent_sms_thread", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        webhook_server,
+        "lookup_shapescale_knowledge",
+        lambda _query: {"usable": False, "status": "timeout", "text": ""},
+    )
+    monkeypatch.setattr(
+        webhook_server,
+        "lookup_sales_crm_context",
+        lambda *_args, **_kwargs: {
+            "usable": True,
+            "status": "ok",
+            "basis": "attio",
+            "company": "Prima Soins Maison",
+            "stage": "Qualifying Sequence",
+        },
+    )
+    normalized_event = {
+        "event_type": "sms",
+        "sender_number": "+15148179929",
+        "recipient_number": "+14155201316",
+        "text": "Personal use\nHow\nMuch is it in CAD dollars?",
+        "first_contact": {
+            "knownContact": True,
+            "needsDraftReply": True,
+            "lookup": {"status": "exact_match", "degraded": False},
+        },
+        "inbound_context": {
+            "identityConfidence": "high",
+            "contextDraftAllowed": True,
+        },
+    }
+
+    assert webhook_server.should_send_proactive_reply(normalized_event) is False
+    assert normalized_event["rich_reply"]["category"] == "pricing"
+    assert normalized_event["rich_reply"]["status"] == "knowledge_timeout"
 
 
 def test_compose_knowledge_sms_skips_availability_disclaimer_at_lead_for_pricing():
@@ -4327,6 +4429,7 @@ def test_hook_payload_deliver_respects_operator_notification_when_no_merge():
 
 def test_merged_flow_disabled_by_default(monkeypatch):
     """U5: DIALPAD_MERGED_DRAFT_FLOW defaults to False."""
+    assert webhook_server.PORT == 8888
     assert webhook_server.DIALPAD_MERGED_DRAFT_FLOW is False
     assert webhook_server.DIALPAD_AGENT_DRAFT_TIMEOUT_SECONDS == 180
 


### PR DESCRIPTION
## Summary

Dialpad pricing questions that say “how much” in currency terms now draft from ShapeScale knowledge instead of falling through to generic CRM copy. If pricing knowledge is unavailable, the webhook now fails closed for that question instead of suggesting a vague “I’ll follow up shortly” response.

The merged-flow callback defaults now converge on the live `8888` host callback path across the webhook, OpenClaw plugin, skill docs, README, and implementation plan.

## Validation

- `python3 -m pytest tests/test_webhook_merged_flow.py tests/test_sender_enrichment.py -q` (`146 passed`)
- `./node_modules/.bin/tsc --noEmit false`
- `git diff --check`
- Thermo-nuclear code-quality review: accepted structural cleanup, extracted pricing detection helper, scoped pricing query stopwords, and patched stale callback-port docs.
- `autoreview --mode local --engine opencode --model opencode/nemotron-3-ultra-free --thinking high --stream-engine-output` (`autoreview clean`)
- `autoreview --mode local --engine opencode --model opencode/hy3-free --thinking high --stream-engine-output` (`autoreview clean`)

## AI Assistance

Implemented and reviewed with Codex. Secondary structured reviews used OpenCode Nemotron 3 Ultra Free and Hy3 Free at high thinking as requested.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
