### PR TITLE
fix(contacts): merge identifier lists on upsert update instead of replacing

### DIFF
--- a/bin/create_contact.py
+++ b/bin/create_contact.py
@@ -223,6 +223,92 @@ def find_matching_contact(
     return matches[0] if matches else None
 
 
+def _existing_list_values(match: dict[str, Any], keys: tuple[str, ...], primary_key: str) -> list[str]:
+    # Same non-string contract as get_contact_list_values (match detection):
+    # Dialpad list fields can carry dict/None entries, and str()-ing those
+    # would replay fabricated identifiers into the update payload.
+    values: list[str] = []
+    primary = match.get(primary_key) if primary_key else None
+    if isinstance(primary, str) and primary.strip():
+        values.append(primary.strip())
+    for key in keys:
+        raw = match.get(key) or []
+        if isinstance(raw, str):
+            raw = [raw]
+        if isinstance(raw, list):
+            values.extend(item.strip() for item in raw if isinstance(item, str) and item.strip())
+    return values
+
+
+def _coerce_e164(value: str) -> str:
+    """Best-effort E.164 coercion for phones replayed from an existing contact.
+
+    contacts.update requires E.164 for every submitted phone, but only
+    caller-supplied phones pass validate_args — a legacy formatted entry like
+    "(415) 555-0100" replayed verbatim would fail the whole PATCH and drop
+    every identifier, which is worse than normalizing one entry. Only shapes
+    with a defensible mapping are coerced (already-E.164, 10-digit NANP,
+    11-digit leading-1); anything else returns "" and is dropped — a bare
+    "+<digits>" guess would PASS the API's E.164 check while being a
+    fabricated wrong number, which is worse than losing the entry.
+    """
+    value = (value or "").strip()
+    if PHONE_RE.fullmatch(value):
+        return value
+    digits = normalize_phone(value)
+    if value.startswith("+") and 7 <= len(digits) <= 15:
+        # Explicit country code, formatting only ("+44 20 7183 8750") —
+        # stripping separators cannot fabricate a different number.
+        return f"+{digits}"
+    if len(digits) == 10 and digits[0] not in "01":
+        # NANP shape only: a 10-digit non-NANP local format ("0412 345 678")
+        # prefixed with +1 would be a different, fabricated number.
+        return f"+1{digits}"
+    if len(digits) == 11 and digits.startswith("1"):
+        return f"+{digits}"
+    return ""
+
+
+def _merge_unique(existing: list[str], new: list[str], key_of) -> list[str]:
+    """Union existing-first, dropping values whose key repeats or is empty."""
+    merged: list[str] = []
+    seen: set[str] = set()
+    for value in existing + new:
+        key = key_of(value)
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        merged.append(value)
+    return merged
+
+
+def merged_update_payload(match: dict[str, Any], base_payload: dict[str, Any]) -> dict[str, Any]:
+    """Merge the matched contact's identifier lists into an update payload.
+
+    PATCH /contacts/{id} replaces list fields wholesale, so an upsert that
+    matched by email and sent only its own phone silently dropped every number
+    other engines had attached (2026-07-20: a calendar-sourced demo phone was
+    clobbered by a later Attio-sourced upsert, and the lead's texts showed as a
+    raw number). Existing values come first so the contact's primary phone and
+    primary email stay primary; new values are appended, deduped (phones by
+    digit normalization, emails case-insensitively, urls exact).
+    """
+    payload = dict(base_payload)
+    merges = (
+        ("phones", ("phones", "phone_numbers"), "primary_phone", normalize_phone, _coerce_e164),
+        ("emails", ("emails",), "primary_email", lambda value: value.strip().lower(), None),
+        ("urls", ("urls",), "", lambda value: value.strip(), None),
+    )
+    for field, keys, primary_key, key_of, coerce in merges:
+        existing = _existing_list_values(match, keys, primary_key)
+        if coerce:
+            existing = [coerced for coerced in (coerce(value) for value in existing) if coerced]
+        merged = _merge_unique(existing, list(base_payload.get(field) or []), key_of)
+        if merged:
+            payload[field] = merged
+    return payload
+
+
 def create_contact(payload: dict[str, Any]) -> dict[str, Any]:
     return run_generated_json(build_create_contact_command_args(payload))
 
@@ -270,7 +356,7 @@ def sync_shared_contact(
     match = find_matching_contact(phones, emails, owner_id=None, max_pages=max_pages, include_local=False)
     if not match:
         return "created", create_contact(base_payload)
-    return "updated", update_contact(str(match.get("id")), base_payload)
+    return "updated", update_contact(str(match.get("id")), merged_update_payload(match, base_payload))
 
 
 def sync_local_contact(
@@ -293,7 +379,7 @@ def sync_local_contact(
         include_local="true",
     )
     if match:
-        return "updated", update_contact(str(match.get("id")), base_payload)
+        return "updated", update_contact(str(match.get("id")), merged_update_payload(match, base_payload))
 
     payload = {**base_payload, "owner_id": owner_id}
     return "created", create_contact(payload)

--- a/tests/test_create_contact.py
+++ b/tests/test_create_contact.py
@@ -144,6 +144,140 @@ class CreateContactTests(unittest.TestCase):
         payload = self._get_json_option(calls[1], "--data")
         self.assertEqual(payload["first_name"], "New")
         self.assertEqual(payload["last_name"], "Contact")
+        # phone-matched update: the (identical) phone must not duplicate
+        self.assertEqual(payload["phones"], ["+14155550123"])
+
+    def test_email_matched_update_merges_new_phone_keeps_existing_primary(self):
+        """Regression for the 2026-07-20 clobber: PATCH replaces `phones`
+        wholesale, so an email-matched upsert carrying a different phone used
+        to DROP every number already on the contact (a CRM-sourced upsert
+        erased the calendar-sourced demo phone, and the lead's texts showed
+        as a raw number). Synthetic identifiers — the incident shape, not the
+        incident data."""
+        calls: list[list[str]] = []
+
+        def fake_run_generated(cmd: list[str]):
+            calls.append(cmd)
+            if cmd[:2] == ["contacts", "contacts.list"]:
+                return {
+                    "items": [
+                        {
+                            "id": "contact-77",
+                            "first_name": "Dana",
+                            "last_name": "Example",
+                            "primary_phone": "+14155550100",
+                            "phones": ["+14155550100"],
+                            "primary_email": "dana@clinic.example",
+                            "emails": ["dana@clinic.example"],
+                            "urls": ["https://crm.example/person/1"],
+                        }
+                    ]
+                }
+            if cmd[:2] == ["contacts", "contacts.update"]:
+                return {"id": "contact-77"}
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        with patch("create_contact.require_generated_cli"), \
+                patch("create_contact.require_api_key"), \
+                patch("create_contact.run_generated_json", side_effect=fake_run_generated):
+            code, out, err = self._run_main([
+                "--first-name", "Dana",
+                "--last-name", "Example",
+                "--phone", "+15035550111",
+                "--email", "DANA@clinic.example",
+                "--url", "https://example.com/deal",
+            ])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(err, "")
+        self.assertEqual(calls[1][:2], ["contacts", "contacts.update"])
+        payload = self._get_json_option(calls[1], "--data")
+        # existing primary stays first; the new phone is appended, never dropped
+        self.assertEqual(payload["phones"], ["+14155550100", "+15035550111"])
+        # emails dedupe case-insensitively, keeping the existing casing/primary
+        self.assertEqual(payload["emails"], ["dana@clinic.example"])
+        # urls union, existing first
+        self.assertEqual(payload["urls"], ["https://crm.example/person/1", "https://example.com/deal"])
+
+    def test_merged_update_payload_coerces_legacy_phones_to_e164(self):
+        # contacts.update requires E.164; a legacy formatted entry replayed
+        # verbatim would fail the whole PATCH. Coerce what can be coerced,
+        # drop what the API would reject anyway.
+        match = {
+            "primary_phone": "(415) 555-0100",
+            "phones": ["(415) 555-0100", "ext. 12"],
+        }
+        base = {"first_name": "A", "last_name": "B", "phones": ["+15035550111"]}
+        merged = create_contact.merged_update_payload(match, base)
+        self.assertEqual(merged["phones"], ["+14155550100", "+15035550111"])
+
+    def test_merged_update_payload_ignores_non_string_api_entries(self):
+        # Dialpad list fields can carry dict/None entries; str()-ing those
+        # would replay fabricated identifiers ("{'number': ...}", "None")
+        # into the CRM. Same contract as get_contact_list_values.
+        match = {
+            "primary_phone": "+14155550100",
+            "phones": [{"number": "+14155550100", "extension": "12"}, None, 4155550100],
+            "primary_email": "dana@clinic.example",
+            "emails": [{"email": "dana@clinic.example"}, None],
+        }
+        base = {"first_name": "A", "last_name": "B", "phones": ["+15035550111"], "emails": []}
+        merged = create_contact.merged_update_payload(match, base)
+        self.assertEqual(merged["phones"], ["+14155550100", "+15035550111"])
+        self.assertEqual(merged["emails"], ["dana@clinic.example"])
+
+    def test_coerce_e164_drops_shapes_without_a_defensible_mapping(self):
+        # A bare "+<digits>" guess passes the API's E.164 regex while being a
+        # fabricated wrong number — drop instead of inventing.
+        self.assertEqual(create_contact._coerce_e164("(415) 555-0100 x12"), "")  # 11 digits, not 1-leading
+        self.assertEqual(create_contact._coerce_e164("555-0100"), "")  # 7-digit local
+        self.assertEqual(create_contact._coerce_e164("1-415-555-0100"), "+14155550100")
+        self.assertEqual(create_contact._coerce_e164("+442071838750"), "+442071838750")  # already E.164
+        # explicit + with formatting: strip separators, keep the country code
+        self.assertEqual(create_contact._coerce_e164("+44 20 7183 8750"), "+442071838750")
+        # 10-digit NON-NANP local format must not be fabricated into +1...
+        self.assertEqual(create_contact._coerce_e164("0412 345 678"), "")
+
+    def test_local_update_payload_carries_no_owner_id(self):
+        calls: list[list[str]] = []
+
+        def fake_run_generated(cmd: list[str]):
+            calls.append(cmd)
+            if cmd[:2] == ["contacts", "contacts.list"]:
+                return {"items": [{"id": "local-5", "phones": ["+14155550100"]}]}
+            if cmd[:2] == ["contacts", "contacts.update"]:
+                return {"id": "local-5"}
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        with patch("create_contact.require_generated_cli"), \
+                patch("create_contact.require_api_key"), \
+                patch("create_contact.run_generated_json", side_effect=fake_run_generated):
+            code, _out, err = self._run_main([
+                "--first-name", "A",
+                "--last-name", "B",
+                "--phone", "+14155550100",
+                "--scope", "local",
+                "--owner-id", "owner-9",
+            ])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(err, "")
+        update_calls = [c for c in calls if c[:2] == ["contacts", "contacts.update"]]
+        self.assertEqual(len(update_calls), 1)
+        payload = self._get_json_option(update_calls[0], "--data")
+        self.assertNotIn("owner_id", payload)
+
+    def test_merged_update_payload_dedupes_by_digit_normalization(self):
+        # Same digit string in different formatting dedupes after E.164
+        # coercion (key = exact normalized digits, matching the
+        # is_duplicate_contact semantics).
+        match = {
+            "primary_phone": "+14155550123",
+            "phones": ["+14155550123", "1-415-555-0123"],
+        }
+        base = {"first_name": "A", "last_name": "B", "phones": ["+14155550123"]}
+        merged = create_contact.merged_update_payload(match, base)
+        self.assertEqual(merged["phones"], ["+14155550123"])
 
     def test_create_contact_auto_scope_with_owner_targets_shared_and_local(self):
         calls: list[list[str]] = []


### PR DESCRIPTION
## What Problem This Solves
Dialpad's PATCH /contacts/{id} replaces list fields wholesale. `create_contact.py`'s upsert, on matching an existing contact (by email OR phone), sent only the caller's own identifiers — so an email-matched update carrying a different phone silently DROPPED every number already on the contact. Live casualty 2026-07-20: a CRM-sourced upsert erased the calendar-sourced demo phone from a shared contact, so the lead's calls/texts displayed as a raw number even though the workflow ledger said `synced/updated`.

## Why This Change Was Made
Multiple engines (pre-demo prep, demo-request recovery, reply watcher, Attio backfills) upsert the same shared contacts with different single phones — last writer won and identifiers were lost. `merged_update_payload()` now unions phones/emails/urls with the matched contact's existing values before the PATCH: existing-first (primary phone/email stay primary), new values appended, deduped (phones by normalized digit string — same semantics as `is_duplicate_contact` — emails case-insensitively, urls exact). Existing phones are best-effort coerced to E.164 before replay, since `contacts.update` rejects non-E.164 and failing the whole PATCH would drop every identifier. Applied to both shared and local update paths.

## User Impact
Cross-engine contact syncs are now additive: a lead texting from their intake-form number resolves by name even after a CRM-sourced sync wrote a different number.

## Evidence
- `python3 -m pytest tests/ -q` → all passing (696 incl. new)
- New regression tests (synthetic identifiers): email-matched update merges the new phone and keeps the existing primary first; identical-phone update does not duplicate; legacy formatted existing phones coerce to E.164 and unparseable entries drop; digit-normalization dedupe pinned
- Live proof: ran the fixed script against the real 2026-07-20 casualty — the contact now carries both numbers and lookup by the previously-dropped phone resolves to the contact's display name (was NO_MATCH)

## Review
Codex P1 (PII in fixture) — fixed: fixture synthesized, branch history squashed and force-pushed to purge the identifiers, PR body scrubbed. Codex P2 (non-E.164 replay) — fixed via `_coerce_e164` on preserved phones + regression test.

## AI Assistance
Used — Claude Code (Fable 5), /ce-debug session (root cause traced from lobster-workflows pre-demo state → Dialpad API behavior). Testing level: full pytest suite locally + live verification against production Dialpad. I understand this code.