### PR TITLE
fix(outreach): block non-NANP Dialpad destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ NANP territories; non-NANP international destinations are rejected before any
 Dialpad API request.
 The generated `message schedules.send_now` command is disabled because its
 stored recipients cannot be validated locally. Schedule updates must repeat
-their recipients for the same reason; use a supported SMS wrapper.
+their phone recipients for the same reason; use a supported SMS wrapper.
 Generated meeting updates must explicitly set `call_out`; enabling call-out on
 an existing meeting is disabled because stored participants cannot be validated.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ export ELEVENLABS_API_KEY="your-elevenlabs-key"
 ## Common Commands
 
 Use `bin/` wrappers for all normal agent work. They are the stable, supported command contract.
+Outbound SMS and calls are limited to NANP (`+1`) destinations, including all
+NANP territories; non-NANP international destinations are rejected before any
+Dialpad API request.
+The generated `message schedules.send_now` command is disabled because its
+stored recipients cannot be validated locally. Schedule updates must repeat
+their recipients for the same reason; use a supported SMS wrapper.
+Generated meeting updates must explicitly set `call_out`; call-out updates must
+also repeat participant details so phone destinations can be validated.
 
 ```bash
 # Send SMS (recommended: explicit sender)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The generated `message schedules.send_now` command is disabled because its
 stored recipients cannot be validated locally. Schedule updates must repeat
 their phone recipients for the same reason; use a supported SMS wrapper.
 Generated meeting updates must explicitly set `call_out`; enabling call-out on
-an existing meeting is disabled because stored participants cannot be validated.
+meeting create or update is disabled because effective participants cannot be
+validated locally.
 
 ```bash
 # Send SMS (recommended: explicit sender)

--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ NANP territories; non-NANP international destinations are rejected before any
 Dialpad API request.
 The generated `message schedules.send_now` command is disabled because its
 stored recipients cannot be validated locally. Schedule updates must repeat
-their phone recipients for the same reason; use a supported SMS wrapper.
-Generated meeting updates must explicitly set `call_out`; enabling call-out on
-meeting create or update is disabled because effective participants cannot be
-validated locally.
+their phone recipients through `--data` as a JSON array for the same reason;
+use a supported SMS wrapper for normal agent work. Generated meeting updates
+must explicitly set `call_out` through `--data` as a JSON boolean; enabling
+call-out on meeting create or update is disabled because effective participants
+cannot be validated locally.
 
 ```bash
 # Send SMS (recommended: explicit sender)

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Dialpad API request.
 The generated `message schedules.send_now` command is disabled because its
 stored recipients cannot be validated locally. Schedule updates must repeat
 their recipients for the same reason; use a supported SMS wrapper.
-Generated meeting updates must explicitly set `call_out`; call-out updates must
-also repeat participant details so phone destinations can be validated.
+Generated meeting updates must explicitly set `call_out`; enabling call-out on
+an existing meeting is disabled because stored participants cannot be validated.
 
 ```bash
 # Send SMS (recommended: explicit sender)

--- a/SKILL.md
+++ b/SKILL.md
@@ -86,7 +86,7 @@ bin/update_contact.py --id "contact_123" --phone "+14155550123" --job-title "VP"
 
 ## Key Rules
 
-1. **Format:** Always use E.164 format for numbers (e.g., `+14155551234`).
+1. **Destination policy:** Outbound SMS and calls support NANP (`+1`) destinations only, including all NANP territories. Non-NANP international destinations are rejected before any Dialpad API request. Always use E.164 format (e.g., `+14155551234`). The generated `message schedules.send_now` command is disabled because stored recipients cannot be validated locally, schedule updates must repeat their recipients, and meeting updates must explicitly set `call_out` plus participant details when enabled.
 2. **Escaping:** Use single quotes for inline `--message` values containing `$` to prevent shell expansion (e.g., `'Price is $10'`).
 3. **Safer message input:** Prefer `--message-file` or `--message-stdin` for pricing text, multi-line copy, or anything shell-sensitive.
 4. **Supported agent interface:** use `bin/*.py` wrappers for normal work. They are the stable command contract for agents.

--- a/SKILL.md
+++ b/SKILL.md
@@ -86,7 +86,7 @@ bin/update_contact.py --id "contact_123" --phone "+14155550123" --job-title "VP"
 
 ## Key Rules
 
-1. **Destination policy:** Outbound SMS and calls support NANP (`+1`) destinations only, including all NANP territories. Non-NANP international destinations are rejected before any Dialpad API request. Always use E.164 format (e.g., `+14155551234`). The generated `message schedules.send_now` command is disabled because stored recipients cannot be validated locally, schedule updates must repeat their recipients, and meeting updates must explicitly set `call_out` plus participant details when enabled.
+1. **Destination policy:** Outbound SMS and calls support NANP (`+1`) destinations only, including all NANP territories. Non-NANP international destinations are rejected before any Dialpad API request. Always use E.164 format (e.g., `+14155551234`); SMS country inference normalizes ten-digit NANP input to explicit `+1` E.164. The generated `message schedules.send_now` command is disabled because stored recipients cannot be validated locally, schedule updates must repeat their phone or channel destination, and meeting updates cannot enable call-out.
 2. **Escaping:** Use single quotes for inline `--message` values containing `$` to prevent shell expansion (e.g., `'Price is $10'`).
 3. **Safer message input:** Prefer `--message-file` or `--message-stdin` for pricing text, multi-line copy, or anything shell-sensitive.
 4. **Supported agent interface:** use `bin/*.py` wrappers for normal work. They are the stable command contract for agents.

--- a/SKILL.md
+++ b/SKILL.md
@@ -86,7 +86,7 @@ bin/update_contact.py --id "contact_123" --phone "+14155550123" --job-title "VP"
 
 ## Key Rules
 
-1. **Destination policy:** Outbound SMS and calls support NANP (`+1`) destinations only, including all NANP territories. Non-NANP international destinations are rejected before any Dialpad API request. Always use E.164 format (e.g., `+14155551234`); SMS country inference normalizes ten-digit NANP input to explicit `+1` E.164. The generated `message schedules.send_now` command is disabled because stored recipients cannot be validated locally, schedule updates must repeat their phone recipients, and generated meeting create/update commands cannot enable call-out.
+1. **Destination policy:** Outbound SMS and calls support NANP (`+1`) destinations only, including all NANP territories. Non-NANP international destinations are rejected before any Dialpad API request. Always use E.164 format (e.g., `+14155551234`); SMS country inference normalizes ten-digit NANP input to explicit `+1` E.164. The generated `message schedules.send_now` command is disabled because stored recipients cannot be validated locally; schedule updates must repeat phone recipients through `--data` as a JSON array; meeting updates must set `call_out` through `--data` as a JSON boolean; and generated meeting create/update commands cannot enable call-out.
 2. **Escaping:** Use single quotes for inline `--message` values containing `$` to prevent shell expansion (e.g., `'Price is $10'`).
 3. **Safer message input:** Prefer `--message-file` or `--message-stdin` for pricing text, multi-line copy, or anything shell-sensitive.
 4. **Supported agent interface:** use `bin/*.py` wrappers for normal work. They are the stable command contract for agents.

--- a/SKILL.md
+++ b/SKILL.md
@@ -86,7 +86,7 @@ bin/update_contact.py --id "contact_123" --phone "+14155550123" --job-title "VP"
 
 ## Key Rules
 
-1. **Destination policy:** Outbound SMS and calls support NANP (`+1`) destinations only, including all NANP territories. Non-NANP international destinations are rejected before any Dialpad API request. Always use E.164 format (e.g., `+14155551234`); SMS country inference normalizes ten-digit NANP input to explicit `+1` E.164. The generated `message schedules.send_now` command is disabled because stored recipients cannot be validated locally, schedule updates must repeat their phone recipients, and meeting updates cannot enable call-out.
+1. **Destination policy:** Outbound SMS and calls support NANP (`+1`) destinations only, including all NANP territories. Non-NANP international destinations are rejected before any Dialpad API request. Always use E.164 format (e.g., `+14155551234`); SMS country inference normalizes ten-digit NANP input to explicit `+1` E.164. The generated `message schedules.send_now` command is disabled because stored recipients cannot be validated locally, schedule updates must repeat their phone recipients, and generated meeting create/update commands cannot enable call-out.
 2. **Escaping:** Use single quotes for inline `--message` values containing `$` to prevent shell expansion (e.g., `'Price is $10'`).
 3. **Safer message input:** Prefer `--message-file` or `--message-stdin` for pricing text, multi-line copy, or anything shell-sensitive.
 4. **Supported agent interface:** use `bin/*.py` wrappers for normal work. They are the stable command contract for agents.

--- a/SKILL.md
+++ b/SKILL.md
@@ -86,7 +86,7 @@ bin/update_contact.py --id "contact_123" --phone "+14155550123" --job-title "VP"
 
 ## Key Rules
 
-1. **Destination policy:** Outbound SMS and calls support NANP (`+1`) destinations only, including all NANP territories. Non-NANP international destinations are rejected before any Dialpad API request. Always use E.164 format (e.g., `+14155551234`); SMS country inference normalizes ten-digit NANP input to explicit `+1` E.164. The generated `message schedules.send_now` command is disabled because stored recipients cannot be validated locally, schedule updates must repeat their phone or channel destination, and meeting updates cannot enable call-out.
+1. **Destination policy:** Outbound SMS and calls support NANP (`+1`) destinations only, including all NANP territories. Non-NANP international destinations are rejected before any Dialpad API request. Always use E.164 format (e.g., `+14155551234`); SMS country inference normalizes ten-digit NANP input to explicit `+1` E.164. The generated `message schedules.send_now` command is disabled because stored recipients cannot be validated locally, schedule updates must repeat their phone recipients, and meeting updates cannot enable call-out.
 2. **Escaping:** Use single quotes for inline `--message` values containing `$` to prevent shell expansion (e.g., `'Price is $10'`).
 3. **Safer message input:** Prefer `--message-file` or `--message-stdin` for pricing text, multi-line copy, or anything shell-sensitive.
 4. **Supported agent interface:** use `bin/*.py` wrappers for normal work. They are the stable command contract for agents.

--- a/bin/make_call.py
+++ b/bin/make_call.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import sys
+from pathlib import Path
 
 from _dialpad_compat import (
     COMMAND_IDS,
@@ -19,6 +20,11 @@ from _dialpad_compat import (
     run_generated_json,
     WrapperError,
 )
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "scripts"))
+
+from outbound_destination_policy import require_supported_outbound_destinations
 
 # Map of E.164 phone numbers to Dialpad user IDs.
 # Set via DIALPAD_USER_MAP env var as JSON, e.g.:
@@ -78,6 +84,10 @@ def main() -> int:
     try:
         args = build_parser().parse_args()
         json_mode = args.json
+        try:
+            require_supported_outbound_destinations((args.to,))
+        except ValueError as exc:
+            raise WrapperError(str(exc), code="invalid_argument", retryable=False) from exc
         require_generated_cli()
         require_api_key()
         user_id = resolve_user_id(args.from_number, args.user_id)

--- a/bin/send_group_intro.py
+++ b/bin/send_group_intro.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from pathlib import Path
 
 from _dialpad_compat import (
     COMMAND_IDS,
@@ -21,6 +22,11 @@ from _dialpad_compat import (
     take_receipt_meta,
     WrapperError,
 )
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "scripts"))
+
+from outbound_destination_policy import require_supported_outbound_destinations
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -92,13 +98,17 @@ def main() -> int:
     wrapper = "send_group_intro.py"
     json_mode = "--json" in sys.argv
     try:
-        require_generated_cli()
         args = build_parser().parse_args()
         json_mode = args.json
         if not args.confirm_share:
             raise WrapperError(
                 "Refusing to send group intro without --confirm-share because it shares phone numbers."
             )
+        try:
+            require_supported_outbound_destinations((args.prospect, args.reference))
+        except ValueError as exc:
+            raise WrapperError(str(exc), code="invalid_argument", retryable=False) from exc
+        require_generated_cli()
         sender_number, sender_source = resolve_sender(
             args.from_number, args.profile, allow_profile_mismatch=args.allow_profile_mismatch
         )

--- a/bin/send_sms.py
+++ b/bin/send_sms.py
@@ -28,7 +28,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
 import sms_approval
-from outbound_destination_policy import require_supported_outbound_destinations
+from outbound_destination_policy import normalize_supported_outbound_destinations
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -354,7 +354,7 @@ def main() -> int:
         args = build_parser().parse_args()
         json_mode = args.json
         try:
-            require_supported_outbound_destinations(
+            args.to = normalize_supported_outbound_destinations(
                 args.to,
                 allow_nanp_national=args.infer_country_code,
             )

--- a/bin/send_sms.py
+++ b/bin/send_sms.py
@@ -28,6 +28,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
 import sms_approval
+from outbound_destination_policy import require_supported_outbound_destinations
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -352,6 +353,13 @@ def main() -> int:
     try:
         args = build_parser().parse_args()
         json_mode = args.json
+        try:
+            require_supported_outbound_destinations(
+                args.to,
+                allow_nanp_national=args.infer_country_code,
+            )
+        except ValueError as exc:
+            raise WrapperError(str(exc), code="invalid_argument", retryable=False) from exc
         require_generated_cli()
         sender_number, sender_source = resolve_sender(
             args.from_number, args.profile, allow_profile_mismatch=args.allow_profile_mismatch

--- a/generated/dialpad
+++ b/generated/dialpad
@@ -19,6 +19,7 @@ if str(SCRIPTS_DIR) not in sys.path:
 
 from generated_outbound_preflight import (
     preflight_outbound_destination as _preflight_outbound_destination,
+    subcommand_help_requested,
 )
 
 RAW_CLI = Path(__file__).with_name("dialpad.openapi")
@@ -115,6 +116,10 @@ def main() -> int:
         return proc.returncode
 
     translated = _translate(sys.argv[1:])
+    if subcommand_help_requested(translated):
+        runner = _raw_cli_runner()
+        proc = subprocess.run([*runner, str(RAW_CLI), *translated], env=_auth_env())
+        return proc.returncode
     try:
         _preflight_outbound_destination(translated)
     except (ValueError, TypeError) as exc:

--- a/generated/dialpad
+++ b/generated/dialpad
@@ -13,6 +13,14 @@ import subprocess
 import sys
 from pathlib import Path
 
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.append(str(SCRIPTS_DIR))
+
+from generated_outbound_preflight import (
+    preflight_outbound_destination as _preflight_outbound_destination,
+)
+
 RAW_CLI = Path(__file__).with_name("dialpad.openapi")
 ALIASES = {
     ("sms", "send"): ("sms", "sms.send"),
@@ -101,12 +109,18 @@ def main() -> int:
         print(_usage(), file=sys.stderr)
         return 2
 
-    runner = _raw_cli_runner()
     if sys.argv[1] in {"-h", "--help"}:
+        runner = _raw_cli_runner()
         proc = subprocess.run([*runner, str(RAW_CLI), "--help"], env=_auth_env())
         return proc.returncode
 
     translated = _translate(sys.argv[1:])
+    try:
+        _preflight_outbound_destination(translated)
+    except (ValueError, TypeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+    runner = _raw_cli_runner()
     proc = subprocess.run([*runner, str(RAW_CLI), *translated], env=_auth_env())
     return proc.returncode
 

--- a/scripts/generated_outbound_preflight.py
+++ b/scripts/generated_outbound_preflight.py
@@ -39,7 +39,6 @@ DESTINATION_RULES: dict[Command, DestinationRule] = {
     ("message", "schedules.update"): DestinationRule(
         "to_numbers",
         requires_explicit_destination=True,
-        alternate_internal_field="channel_hashtag",
     ),
     ("call", "call.call"): DestinationRule("phone_number"),
     ("call", "call.initiate_ivr_call"): DestinationRule("phone_number"),

--- a/scripts/generated_outbound_preflight.py
+++ b/scripts/generated_outbound_preflight.py
@@ -155,30 +155,46 @@ def _parse_click_bool(value: object) -> bool:
     raise ValueError(f"Invalid boolean value: {value!r}")
 
 
-def _body_from_args(command_args: list[str]) -> dict[str, object]:
+def _body_from_args(command_args: list[str]) -> tuple[dict[str, object], bool]:
     data_value = _option_value(command_args, "--data")
     if data_value is None:
-        return {}
+        return {}, False
     # generated/dialpad.openapi replaces its option-built body with --data
     # wholesale, so preflight must use the same precedence rather than merge.
     decoded = json.loads(data_value)
     if not isinstance(decoded, dict):
         raise ValueError("--data must be a JSON object")
-    return decoded
+    return decoded, True
+
+
+def _effective_value(
+    field: str,
+    command_args: list[str],
+    body: dict[str, object],
+    data_supplied: bool,
+) -> object | None:
+    if data_supplied:
+        return body.get(field)
+    return _option_value(command_args, f"--{field.replace('_', '-')}")
 
 
 def _preflight_meeting(
     command: Command,
     command_args: list[str],
     body: dict[str, object],
+    data_supplied: bool,
 ) -> None:
-    call_out_value = body.get(
+    call_out_value = _effective_value(
         "call_out",
-        _option_value(command_args, "--call-out"),
+        command_args,
+        body,
+        data_supplied,
     )
-    participants_value = body.get(
+    participants_value = _effective_value(
         "participants_info",
-        _option_value(command_args, "--participants-info"),
+        command_args,
+        body,
+        data_supplied,
     )
     if command == ("meetings", "meetings.update") and call_out_value is None:
         raise ValueError(
@@ -232,26 +248,28 @@ def preflight_outbound_destination(argv: list[str]) -> None:
             "validate stored recipients; use a validated SMS wrapper instead."
         )
 
-    body = _body_from_args(command_args)
+    body, data_supplied = _body_from_args(command_args)
     if command in {("meetings", "meetings.create"), ("meetings", "meetings.update")}:
-        _preflight_meeting(command, command_args, body)
+        _preflight_meeting(command, command_args, body, data_supplied)
         return
 
     rule = DESTINATION_RULES.get(command)
     if rule is None:
         return
 
-    option_name = f"--{rule.field.replace('_', '-')}"
-    recipient_value = body.get(
+    recipient_value = _effective_value(
         rule.field,
-        _option_value(command_args, option_name),
+        command_args,
+        body,
+        data_supplied,
     )
     alternate_value = None
     if rule.alternate_internal_field is not None:
-        alternate_option = f"--{rule.alternate_internal_field.replace('_', '-')}"
-        alternate_value = body.get(
+        alternate_value = _effective_value(
             rule.alternate_internal_field,
-            _option_value(command_args, alternate_option),
+            command_args,
+            body,
+            data_supplied,
         )
     has_alternate_destination = (
         isinstance(alternate_value, str)

--- a/scripts/generated_outbound_preflight.py
+++ b/scripts/generated_outbound_preflight.py
@@ -159,6 +159,8 @@ def _body_from_args(command_args: list[str]) -> dict[str, object]:
     data_value = _option_value(command_args, "--data")
     if data_value is None:
         return {}
+    # generated/dialpad.openapi replaces its option-built body with --data
+    # wholesale, so preflight must use the same precedence rather than merge.
     decoded = json.loads(data_value)
     if not isinstance(decoded, dict):
         raise ValueError("--data must be a JSON object")
@@ -195,7 +197,10 @@ def _preflight_meeting(
     if not _parse_click_bool(call_out_value):
         return
     if participants_value is None:
-        return
+        raise ValueError(
+            "Meeting call-out requires explicit participants because implicit "
+            "recipients cannot be validated locally."
+        )
     if isinstance(participants_value, str):
         participants_value = json.loads(participants_value)
     if not isinstance(participants_value, list) or any(

--- a/scripts/generated_outbound_preflight.py
+++ b/scripts/generated_outbound_preflight.py
@@ -14,22 +14,26 @@ Command = tuple[str, str]
 @dataclass(frozen=True)
 class DestinationRule:
     field: str
-    supports_country_inference: bool = False
     allows_internal_target: bool = False
     requires_explicit_destination: bool = False
+    alternate_internal_field: str | None = None
     internal_variants: tuple[frozenset[str], ...] = ()
 
 
 DESTINATION_RULES: dict[Command, DestinationRule] = {
     ("sms", "sms.send"): DestinationRule(
         "to_numbers",
-        supports_country_inference=True,
+        alternate_internal_field="channel_hashtag",
     ),
     ("message", "bulk_messages.send"): DestinationRule("to_numbers"),
-    ("message", "schedules.create"): DestinationRule("to_numbers"),
+    ("message", "schedules.create"): DestinationRule(
+        "to_numbers",
+        alternate_internal_field="channel_hashtag",
+    ),
     ("message", "schedules.update"): DestinationRule(
         "to_numbers",
         requires_explicit_destination=True,
+        alternate_internal_field="channel_hashtag",
     ),
     ("call", "call.call"): DestinationRule("phone_number"),
     ("call", "call.initiate_ivr_call"): DestinationRule("phone_number"),
@@ -167,13 +171,15 @@ def _preflight_meeting(
             "Meeting updates must explicitly set call_out because stored "
             "call-out state and participants cannot be validated locally."
         )
+    if command == ("meetings", "meetings.update"):
+        if _is_true(call_out_value):
+            raise ValueError(
+                "Enabling meeting call-out is disabled because stored "
+                "participants cannot be validated locally."
+            )
+        return
     if not _is_true(call_out_value):
         return
-    if command == ("meetings", "meetings.update") and participants_value is None:
-        raise ValueError(
-            "Call-out meeting updates must include explicit participants "
-            "because stored participants cannot be validated locally."
-        )
     if participants_value is None:
         return
     if isinstance(participants_value, str):
@@ -221,11 +227,22 @@ def preflight_outbound_destination(argv: list[str]) -> None:
         rule.field,
         _option_value(command_args, option_name),
     )
-    if rule.requires_explicit_destination and recipient_value is None:
-        raise ValueError(
-            "Schedule updates must include explicit recipients because stored "
-            "recipients cannot be validated locally."
+    alternate_value = None
+    if rule.alternate_internal_field is not None:
+        alternate_option = f"--{rule.alternate_internal_field.replace('_', '-')}"
+        alternate_value = body.get(
+            rule.alternate_internal_field,
+            _option_value(command_args, alternate_option),
         )
+    if recipient_value is None and alternate_value is not None:
+        return
+    if recipient_value is None and rule.requires_explicit_destination:
+        raise ValueError(
+            "Schedule updates must include explicit phone or channel recipients "
+            "because stored recipients cannot be validated locally."
+        )
+    if recipient_value is None:
+        return
     structured_numbers = _structured_destination_numbers(recipient_value, rule)
     if structured_numbers is not None:
         recipients = structured_numbers
@@ -233,10 +250,10 @@ def preflight_outbound_destination(argv: list[str]) -> None:
         recipients = _recipient_list(recipient_value)
     else:
         recipients = [str(recipient_value)] if recipient_value is not None else []
-    if rule.requires_explicit_destination and not recipients:
+    if rule.requires_explicit_destination and not recipients and alternate_value is None:
         raise ValueError(
-            "Schedule updates must include explicit recipients because stored "
-            "recipients cannot be validated locally."
+            "Schedule updates must include explicit phone or channel recipients "
+            "because stored recipients cannot be validated locally."
         )
     if (
         rule.allows_internal_target
@@ -245,14 +262,4 @@ def preflight_outbound_destination(argv: list[str]) -> None:
     ):
         return
     if recipients:
-        infer_country_code = body.get(
-            "infer_country_code",
-            _option_value(command_args, "--infer-country-code"),
-        )
-        require_supported_outbound_destinations(
-            recipients,
-            allow_nanp_national=(
-                rule.supports_country_inference
-                and _is_true(infer_country_code)
-            ),
-        )
+        require_supported_outbound_destinations(recipients)

--- a/scripts/generated_outbound_preflight.py
+++ b/scripts/generated_outbound_preflight.py
@@ -1,0 +1,187 @@
+"""Fail-closed destination checks for the generated Dialpad CLI facade."""
+
+from __future__ import annotations
+
+import json
+
+from outbound_destination_policy import require_supported_outbound_destinations
+
+
+def _command_start(argv: list[str]) -> int:
+    """Return the index of the first command, skipping global options."""
+
+    value_options = {"--output", "-o", "--base-url", "-b", "--token", "--api-key"}
+    skip_next = False
+    for index, arg in enumerate(argv):
+        if skip_next:
+            skip_next = False
+            continue
+        if arg in value_options:
+            skip_next = True
+            continue
+        if arg.startswith("-"):
+            continue
+        return index
+    return len(argv)
+
+
+def _option_value(argv: list[str], option: str) -> str | None:
+    for index in range(len(argv) - 1, -1, -1):
+        arg = argv[index]
+        if arg == option:
+            return argv[index + 1] if index + 1 < len(argv) else None
+        prefix = f"{option}="
+        if arg.startswith(prefix):
+            return arg[len(prefix) :]
+    return None
+
+
+def _recipient_list(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if not isinstance(value, str):
+        raise ValueError(
+            "Outbound recipients must be a phone number or list of phone numbers"
+        )
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError:
+        return [item for item in value.split(",") if item]
+    if isinstance(decoded, list):
+        return [str(item) for item in decoded]
+    if isinstance(decoded, str):
+        return [decoded]
+    raise ValueError(
+        "Outbound recipients must be a phone number or list of phone numbers"
+    )
+
+
+def _is_true(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _body_from_args(command_args: list[str]) -> dict[str, object]:
+    data_value = _option_value(command_args, "--data")
+    if data_value is None:
+        return {}
+    decoded = json.loads(data_value)
+    if not isinstance(decoded, dict):
+        raise ValueError("--data must be a JSON object")
+    return decoded
+
+
+def _preflight_meeting(
+    command: tuple[str, str],
+    command_args: list[str],
+    body: dict[str, object],
+) -> None:
+    call_out_value = body.get(
+        "call_out",
+        _option_value(command_args, "--call-out"),
+    )
+    participants_value = body.get(
+        "participants_info",
+        _option_value(command_args, "--participants-info"),
+    )
+    if command == ("meetings", "meetings.update") and call_out_value is None:
+        raise ValueError(
+            "Meeting updates must explicitly set call_out because stored "
+            "call-out state and participants cannot be validated locally."
+        )
+    if not _is_true(call_out_value):
+        return
+    if command == ("meetings", "meetings.update") and participants_value is None:
+        raise ValueError(
+            "Call-out meeting updates must include explicit participants "
+            "because stored participants cannot be validated locally."
+        )
+    if participants_value is None:
+        return
+    if isinstance(participants_value, str):
+        participants_value = json.loads(participants_value)
+    if not isinstance(participants_value, list) or any(
+        not isinstance(participant, dict) for participant in participants_value
+    ):
+        raise ValueError("Meeting participants must be a JSON list of objects")
+    phone_numbers = [
+        str(participant[field])
+        for participant in participants_value
+        for field in ("phone", "phone_number")
+        if participant.get(field) is not None
+    ]
+    if phone_numbers:
+        require_supported_outbound_destinations(phone_numbers)
+
+
+def preflight_outbound_destination(argv: list[str]) -> None:
+    """Reject unsupported outbound destinations before invoking generated code."""
+
+    command_start = _command_start(argv)
+    if len(argv) < command_start + 2:
+        return
+    command = (argv[command_start], argv[command_start + 1])
+    command_args = argv[command_start + 2 :]
+
+    if command == ("message", "schedules.send_now"):
+        raise ValueError(
+            "The generated schedule send command is disabled because it cannot "
+            "validate stored recipients; use a validated SMS wrapper instead."
+        )
+
+    body = _body_from_args(command_args)
+    if command in {("meetings", "meetings.create"), ("meetings", "meetings.update")}:
+        _preflight_meeting(command, command_args, body)
+        return
+
+    recipient_field = {
+        ("sms", "sms.send"): "to_numbers",
+        ("message", "bulk_messages.send"): "to_numbers",
+        ("message", "schedules.create"): "to_numbers",
+        ("message", "schedules.update"): "to_numbers",
+        ("call", "call.call"): "phone_number",
+        ("call", "call.initiate_ivr_call"): "phone_number",
+        ("callback", "call.callback"): "phone_number",
+        ("users", "users.initiate_call"): "phone_number",
+        ("call", "call.transfer_call"): "to",
+        ("call", "call.participants.add"): "participant",
+    }.get(command)
+    if recipient_field is None:
+        return
+
+    option_name = f"--{recipient_field.replace('_', '-')}"
+    recipient_value = body.get(
+        recipient_field,
+        _option_value(command_args, option_name),
+    )
+    if command == ("message", "schedules.update") and recipient_value is None:
+        raise ValueError(
+            "Schedule updates must include explicit recipients because stored "
+            "recipients cannot be validated locally."
+        )
+    recipients = (
+        _recipient_list(recipient_value)
+        if recipient_field == "to_numbers"
+        else ([str(recipient_value)] if recipient_value is not None else [])
+    )
+    if command == ("message", "schedules.update") and not recipients:
+        raise ValueError(
+            "Schedule updates must include explicit recipients because stored "
+            "recipients cannot be validated locally."
+        )
+    if (
+        recipient_field in {"to", "participant"}
+        and recipients
+        and not recipients[0].startswith("+")
+    ):
+        return
+    if recipients:
+        infer_country_code = body.get(
+            "infer_country_code",
+            _option_value(command_args, "--infer-country-code"),
+        )
+        require_supported_outbound_destinations(
+            recipients,
+            allow_nanp_national=_is_true(infer_country_code),
+        )

--- a/scripts/generated_outbound_preflight.py
+++ b/scripts/generated_outbound_preflight.py
@@ -3,8 +3,46 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 
 from outbound_destination_policy import require_supported_outbound_destinations
+
+
+Command = tuple[str, str]
+
+
+@dataclass(frozen=True)
+class DestinationRule:
+    field: str
+    supports_country_inference: bool = False
+    allows_internal_target: bool = False
+    requires_explicit_destination: bool = False
+
+
+DESTINATION_RULES: dict[Command, DestinationRule] = {
+    ("sms", "sms.send"): DestinationRule(
+        "to_numbers",
+        supports_country_inference=True,
+    ),
+    ("message", "bulk_messages.send"): DestinationRule("to_numbers"),
+    ("message", "schedules.create"): DestinationRule("to_numbers"),
+    ("message", "schedules.update"): DestinationRule(
+        "to_numbers",
+        requires_explicit_destination=True,
+    ),
+    ("call", "call.call"): DestinationRule("phone_number"),
+    ("call", "call.initiate_ivr_call"): DestinationRule("phone_number"),
+    ("callback", "call.callback"): DestinationRule("phone_number"),
+    ("users", "users.initiate_call"): DestinationRule("phone_number"),
+    ("call", "call.transfer_call"): DestinationRule(
+        "to",
+        allows_internal_target=True,
+    ),
+    ("call", "call.participants.add"): DestinationRule(
+        "participant",
+        allows_internal_target=True,
+    ),
+}
 
 
 def _command_start(argv: list[str]) -> int:
@@ -73,7 +111,7 @@ def _body_from_args(command_args: list[str]) -> dict[str, object]:
 
 
 def _preflight_meeting(
-    command: tuple[str, str],
+    command: Command,
     command_args: list[str],
     body: dict[str, object],
 ) -> None:
@@ -135,43 +173,32 @@ def preflight_outbound_destination(argv: list[str]) -> None:
         _preflight_meeting(command, command_args, body)
         return
 
-    recipient_field = {
-        ("sms", "sms.send"): "to_numbers",
-        ("message", "bulk_messages.send"): "to_numbers",
-        ("message", "schedules.create"): "to_numbers",
-        ("message", "schedules.update"): "to_numbers",
-        ("call", "call.call"): "phone_number",
-        ("call", "call.initiate_ivr_call"): "phone_number",
-        ("callback", "call.callback"): "phone_number",
-        ("users", "users.initiate_call"): "phone_number",
-        ("call", "call.transfer_call"): "to",
-        ("call", "call.participants.add"): "participant",
-    }.get(command)
-    if recipient_field is None:
+    rule = DESTINATION_RULES.get(command)
+    if rule is None:
         return
 
-    option_name = f"--{recipient_field.replace('_', '-')}"
+    option_name = f"--{rule.field.replace('_', '-')}"
     recipient_value = body.get(
-        recipient_field,
+        rule.field,
         _option_value(command_args, option_name),
     )
-    if command == ("message", "schedules.update") and recipient_value is None:
+    if rule.requires_explicit_destination and recipient_value is None:
         raise ValueError(
             "Schedule updates must include explicit recipients because stored "
             "recipients cannot be validated locally."
         )
     recipients = (
         _recipient_list(recipient_value)
-        if recipient_field == "to_numbers"
+        if rule.field == "to_numbers"
         else ([str(recipient_value)] if recipient_value is not None else [])
     )
-    if command == ("message", "schedules.update") and not recipients:
+    if rule.requires_explicit_destination and not recipients:
         raise ValueError(
             "Schedule updates must include explicit recipients because stored "
             "recipients cannot be validated locally."
         )
     if (
-        recipient_field in {"to", "participant"}
+        rule.allows_internal_target
         and recipients
         and not recipients[0].startswith("+")
     ):
@@ -183,5 +210,8 @@ def preflight_outbound_destination(argv: list[str]) -> None:
         )
         require_supported_outbound_destinations(
             recipients,
-            allow_nanp_national=_is_true(infer_country_code),
+            allow_nanp_national=(
+                rule.supports_country_inference
+                and _is_true(infer_country_code)
+            ),
         )

--- a/scripts/generated_outbound_preflight.py
+++ b/scripts/generated_outbound_preflight.py
@@ -278,6 +278,8 @@ def preflight_outbound_destination(argv: list[str]) -> None:
         and recipients
         and not recipients[0].startswith("+")
     ):
-        return
+        raise ValueError(
+            "Internal call destinations must use a supported structured object"
+        )
     if recipients:
         require_supported_outbound_destinations(recipients)

--- a/scripts/generated_outbound_preflight.py
+++ b/scripts/generated_outbound_preflight.py
@@ -20,6 +20,12 @@ class DestinationRule:
     internal_variants: tuple[frozenset[str], ...] = ()
 
 
+@dataclass(frozen=True)
+class DestinationSelection:
+    phone_numbers: list[str]
+    is_internal: bool
+
+
 DESTINATION_RULES: dict[Command, DestinationRule] = {
     ("sms", "sms.send"): DestinationRule(
         "to_numbers",
@@ -75,17 +81,19 @@ def _command_start(argv: list[str]) -> int:
 
 
 def subcommand_help_requested(argv: list[str]) -> bool:
-    """Return whether Click will treat a trailing help token as an option."""
+    """Return whether Click will treat a help token as an eager option."""
 
-    if not argv or argv[-1] not in {"-h", "--help"}:
-        return False
     command_start = _command_start(argv)
-    previous = argv[-2] if len(argv) >= 2 else ""
-    return (
-        len(argv) == command_start + 3
-        or not previous.startswith("-")
-        or "=" in previous
-    )
+    skip_value = False
+    for arg in argv[command_start + 2 :]:
+        if skip_value:
+            skip_value = False
+            continue
+        if arg in {"-h", "--help"}:
+            return True
+        if arg.startswith("-") and "=" not in arg:
+            skip_value = True
+    return False
 
 
 def _option_value(argv: list[str], option: str) -> str | None:
@@ -122,7 +130,7 @@ def _recipient_list(value: object) -> list[str]:
 def _structured_destination_numbers(
     value: object,
     rule: DestinationRule,
-) -> list[str] | None:
+) -> DestinationSelection | None:
     if not rule.allows_internal_target:
         return None
     if isinstance(value, str) and value.lstrip().startswith("{"):
@@ -130,10 +138,10 @@ def _structured_destination_numbers(
     if not isinstance(value, dict):
         return None
     if "number" in value:
-        return [str(value["number"])]
+        return DestinationSelection([str(value["number"])], is_internal=False)
     keys = frozenset(value)
     if any(required_keys <= keys for required_keys in rule.internal_variants):
-        return []
+        return DestinationSelection([], is_internal=True)
     raise ValueError("Structured call destination has no supported variant")
 
 
@@ -234,7 +242,12 @@ def preflight_outbound_destination(argv: list[str]) -> None:
             rule.alternate_internal_field,
             _option_value(command_args, alternate_option),
         )
-    if recipient_value is None and alternate_value is not None:
+    has_alternate_destination = (
+        isinstance(alternate_value, str)
+        and bool(alternate_value)
+        and alternate_value == alternate_value.strip()
+    )
+    if recipient_value is None and has_alternate_destination:
         return
     if recipient_value is None and rule.requires_explicit_destination:
         raise ValueError(
@@ -245,18 +258,23 @@ def preflight_outbound_destination(argv: list[str]) -> None:
         return
     structured_numbers = _structured_destination_numbers(recipient_value, rule)
     if structured_numbers is not None:
-        recipients = structured_numbers
+        recipients = structured_numbers.phone_numbers
     elif rule.field == "to_numbers":
         recipients = _recipient_list(recipient_value)
     else:
         recipients = [str(recipient_value)] if recipient_value is not None else []
-    if rule.requires_explicit_destination and not recipients and alternate_value is None:
+    if (
+        rule.requires_explicit_destination
+        and not recipients
+        and not has_alternate_destination
+    ):
         raise ValueError(
             "Schedule updates must include explicit phone or channel recipients "
             "because stored recipients cannot be validated locally."
         )
     if (
         rule.allows_internal_target
+        and structured_numbers is None
         and recipients
         and not recipients[0].startswith("+")
     ):

--- a/scripts/generated_outbound_preflight.py
+++ b/scripts/generated_outbound_preflight.py
@@ -145,10 +145,15 @@ def _structured_destination_numbers(
     raise ValueError("Structured call destination has no supported variant")
 
 
-def _is_true(value: object) -> bool:
+def _parse_click_bool(value: object) -> bool:
     if isinstance(value, bool):
         return value
-    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "t", "yes", "y", "on"}:
+        return True
+    if normalized in {"0", "false", "f", "no", "n", "off"}:
+        return False
+    raise ValueError(f"Invalid boolean value: {value!r}")
 
 
 def _body_from_args(command_args: list[str]) -> dict[str, object]:
@@ -179,14 +184,16 @@ def _preflight_meeting(
             "Meeting updates must explicitly set call_out because stored "
             "call-out state and participants cannot be validated locally."
         )
+    if call_out_value is None:
+        return
     if command == ("meetings", "meetings.update"):
-        if _is_true(call_out_value):
+        if _parse_click_bool(call_out_value):
             raise ValueError(
                 "Enabling meeting call-out is disabled because stored "
                 "participants cannot be validated locally."
             )
         return
-    if not _is_true(call_out_value):
+    if not _parse_click_bool(call_out_value):
         return
     if participants_value is None:
         return

--- a/scripts/generated_outbound_preflight.py
+++ b/scripts/generated_outbound_preflight.py
@@ -43,6 +43,7 @@ DESTINATION_RULES: dict[Command, DestinationRule] = {
     ("call", "call.call"): DestinationRule("phone_number"),
     ("call", "call.initiate_ivr_call"): DestinationRule("phone_number"),
     ("callback", "call.callback"): DestinationRule("phone_number"),
+    ("callback", "call.validate_callback"): DestinationRule("phone_number"),
     ("users", "users.initiate_call"): DestinationRule("phone_number"),
     ("call", "call.transfer_call"): DestinationRule(
         "to",
@@ -197,10 +198,15 @@ def _preflight_meeting(
         )
     if call_out_value is None:
         return
-    if _parse_click_bool(call_out_value):
+    call_out = _parse_click_bool(call_out_value)
+    if call_out:
         raise ValueError(
             "Meeting call-out is disabled because its effective participants "
             "cannot be validated locally."
+        )
+    if not data_supplied:
+        raise ValueError(
+            "Meeting call_out must be supplied through --data as a JSON boolean"
         )
 
 
@@ -256,6 +262,14 @@ def preflight_outbound_destination(argv: list[str]) -> None:
         )
     if recipient_value is None:
         return
+    if (
+        command == ("message", "schedules.update")
+        and not data_supplied
+    ):
+        raise ValueError(
+            "Schedule update recipients must be supplied through --data as a "
+            "JSON array"
+        )
     structured_numbers = _structured_destination_numbers(recipient_value, rule)
     if structured_numbers is not None:
         recipients = structured_numbers.phone_numbers

--- a/scripts/generated_outbound_preflight.py
+++ b/scripts/generated_outbound_preflight.py
@@ -190,12 +190,6 @@ def _preflight_meeting(
         body,
         data_supplied,
     )
-    participants_value = _effective_value(
-        "participants_info",
-        command_args,
-        body,
-        data_supplied,
-    )
     if command == ("meetings", "meetings.update") and call_out_value is None:
         raise ValueError(
             "Meeting updates must explicitly set call_out because stored "
@@ -203,34 +197,11 @@ def _preflight_meeting(
         )
     if call_out_value is None:
         return
-    if command == ("meetings", "meetings.update"):
-        if _parse_click_bool(call_out_value):
-            raise ValueError(
-                "Enabling meeting call-out is disabled because stored "
-                "participants cannot be validated locally."
-            )
-        return
-    if not _parse_click_bool(call_out_value):
-        return
-    if participants_value is None:
+    if _parse_click_bool(call_out_value):
         raise ValueError(
-            "Meeting call-out requires explicit participants because implicit "
-            "recipients cannot be validated locally."
+            "Meeting call-out is disabled because its effective participants "
+            "cannot be validated locally."
         )
-    if isinstance(participants_value, str):
-        participants_value = json.loads(participants_value)
-    if not isinstance(participants_value, list) or any(
-        not isinstance(participant, dict) for participant in participants_value
-    ):
-        raise ValueError("Meeting participants must be a JSON list of objects")
-    phone_numbers = [
-        str(participant[field])
-        for participant in participants_value
-        for field in ("phone", "phone_number")
-        if participant.get(field) is not None
-    ]
-    if phone_numbers:
-        require_supported_outbound_destinations(phone_numbers)
 
 
 def preflight_outbound_destination(argv: list[str]) -> None:

--- a/scripts/generated_outbound_preflight.py
+++ b/scripts/generated_outbound_preflight.py
@@ -17,6 +17,7 @@ class DestinationRule:
     supports_country_inference: bool = False
     allows_internal_target: bool = False
     requires_explicit_destination: bool = False
+    internal_variants: tuple[frozenset[str], ...] = ()
 
 
 DESTINATION_RULES: dict[Command, DestinationRule] = {
@@ -37,10 +38,16 @@ DESTINATION_RULES: dict[Command, DestinationRule] = {
     ("call", "call.transfer_call"): DestinationRule(
         "to",
         allows_internal_target=True,
+        internal_variants=(
+            frozenset({"call_id"}),
+            frozenset({"operator_id", "target_id"}),
+            frozenset({"target_id", "target_type"}),
+        ),
     ),
     ("call", "call.participants.add"): DestinationRule(
         "participant",
         allows_internal_target=True,
+        internal_variants=(frozenset({"target_id", "target_type"}),),
     ),
 }
 
@@ -61,6 +68,20 @@ def _command_start(argv: list[str]) -> int:
             continue
         return index
     return len(argv)
+
+
+def subcommand_help_requested(argv: list[str]) -> bool:
+    """Return whether Click will treat a trailing help token as an option."""
+
+    if not argv or argv[-1] not in {"-h", "--help"}:
+        return False
+    command_start = _command_start(argv)
+    previous = argv[-2] if len(argv) >= 2 else ""
+    return (
+        len(argv) == command_start + 3
+        or not previous.startswith("-")
+        or "=" in previous
+    )
 
 
 def _option_value(argv: list[str], option: str) -> str | None:
@@ -92,6 +113,24 @@ def _recipient_list(value: object) -> list[str]:
     raise ValueError(
         "Outbound recipients must be a phone number or list of phone numbers"
     )
+
+
+def _structured_destination_numbers(
+    value: object,
+    rule: DestinationRule,
+) -> list[str] | None:
+    if not rule.allows_internal_target:
+        return None
+    if isinstance(value, str) and value.lstrip().startswith("{"):
+        value = json.loads(value.lstrip())
+    if not isinstance(value, dict):
+        return None
+    if "number" in value:
+        return [str(value["number"])]
+    keys = frozenset(value)
+    if any(required_keys <= keys for required_keys in rule.internal_variants):
+        return []
+    raise ValueError("Structured call destination has no supported variant")
 
 
 def _is_true(value: object) -> bool:
@@ -187,11 +226,13 @@ def preflight_outbound_destination(argv: list[str]) -> None:
             "Schedule updates must include explicit recipients because stored "
             "recipients cannot be validated locally."
         )
-    recipients = (
-        _recipient_list(recipient_value)
-        if rule.field == "to_numbers"
-        else ([str(recipient_value)] if recipient_value is not None else [])
-    )
+    structured_numbers = _structured_destination_numbers(recipient_value, rule)
+    if structured_numbers is not None:
+        recipients = structured_numbers
+    elif rule.field == "to_numbers":
+        recipients = _recipient_list(recipient_value)
+    else:
+        recipients = [str(recipient_value)] if recipient_value is not None else []
     if rule.requires_explicit_destination and not recipients:
         raise ValueError(
             "Schedule updates must include explicit recipients because stored "

--- a/scripts/make_call.py
+++ b/scripts/make_call.py
@@ -18,6 +18,8 @@ import urllib.request
 import urllib.error
 import urllib.parse
 
+from outbound_destination_policy import require_supported_outbound_destinations
+
 
 # Configuration
 DIALPAD_API_KEY = os.environ.get("DIALPAD_API_KEY")
@@ -57,11 +59,13 @@ def make_call(to_number, from_number=None, user_id=None, text_to_speak=None):
     Returns:
         dict: API response with call details
     """
-    if not DIALPAD_API_KEY:
-        raise ValueError("DIALPAD_API_KEY environment variable not set")
-
     if not to_number:
         raise ValueError("Recipient number is required")
+
+    require_supported_outbound_destinations((to_number,))
+
+    if not DIALPAD_API_KEY:
+        raise ValueError("DIALPAD_API_KEY environment variable not set")
 
     # Get user_id from known users if not provided
     if not user_id:

--- a/scripts/outbound_destination_policy.py
+++ b/scripts/outbound_destination_policy.py
@@ -1,0 +1,46 @@
+"""Allow NANP destinations and reject non-NANP outbound Dialpad actions.
+
+NANP includes every +1 territory, not only the United States and Canada.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+
+_NANP_E164_RE = re.compile(r"^\+1[0-9]{10}$")
+_NANP_NATIONAL_RE = re.compile(r"^[0-9]{10}$")
+_UNSUPPORTED_MESSAGE = (
+    "Outbound Dialpad SMS and calls support NANP (+1) destinations only; "
+    "non-NANP international destinations are not supported."
+)
+
+
+def is_supported_outbound_destination(
+    phone_number: str,
+    *,
+    allow_nanp_national: bool = False,
+) -> bool:
+    """Return whether a destination is a NANP number in canonical E.164 form."""
+    normalized = str(phone_number)
+    return bool(
+        _NANP_E164_RE.fullmatch(normalized)
+        or (allow_nanp_national and _NANP_NATIONAL_RE.fullmatch(normalized))
+    )
+
+
+def require_supported_outbound_destinations(
+    phone_numbers: Iterable[str],
+    *,
+    allow_nanp_national: bool = False,
+) -> None:
+    """Reject the whole action when any destination is outside the NANP."""
+    if any(
+        not is_supported_outbound_destination(
+            number,
+            allow_nanp_national=allow_nanp_national,
+        )
+        for number in phone_numbers
+    ):
+        raise ValueError(_UNSUPPORTED_MESSAGE)

--- a/scripts/outbound_destination_policy.py
+++ b/scripts/outbound_destination_policy.py
@@ -36,11 +36,26 @@ def require_supported_outbound_destinations(
     allow_nanp_national: bool = False,
 ) -> None:
     """Reject the whole action when any destination is outside the NANP."""
-    if any(
-        not is_supported_outbound_destination(
-            number,
-            allow_nanp_national=allow_nanp_national,
-        )
-        for number in phone_numbers
-    ):
-        raise ValueError(_UNSUPPORTED_MESSAGE)
+    normalize_supported_outbound_destinations(
+        phone_numbers,
+        allow_nanp_national=allow_nanp_national,
+    )
+
+
+def normalize_supported_outbound_destinations(
+    phone_numbers: Iterable[str],
+    *,
+    allow_nanp_national: bool = False,
+) -> list[str]:
+    """Return explicit NANP E.164 destinations or reject the whole action."""
+
+    normalized: list[str] = []
+    for number in phone_numbers:
+        candidate = str(number)
+        if _NANP_E164_RE.fullmatch(candidate):
+            normalized.append(candidate)
+        elif allow_nanp_national and _NANP_NATIONAL_RE.fullmatch(candidate):
+            normalized.append(f"+1{candidate}")
+        else:
+            raise ValueError(_UNSUPPORTED_MESSAGE)
+    return normalized

--- a/scripts/send_sms.py
+++ b/scripts/send_sms.py
@@ -15,6 +15,8 @@ import sys
 import urllib.request
 import urllib.error
 
+from outbound_destination_policy import require_supported_outbound_destinations
+
 
 # Configuration
 DIALPAD_API_KEY = os.environ.get("DIALPAD_API_KEY")
@@ -34,14 +36,19 @@ def send_sms(to_numbers, message, from_number=None, infer_country_code=False):
     Returns:
         dict: API response with SMS details
     """
-    if not DIALPAD_API_KEY:
-        raise ValueError("DIALPAD_API_KEY environment variable not set")
-
     if not to_numbers:
         raise ValueError("At least one recipient number is required")
 
     if len(to_numbers) > 10:
         raise ValueError("Maximum 10 recipients per SMS request")
+
+    require_supported_outbound_destinations(
+        to_numbers,
+        allow_nanp_national=infer_country_code,
+    )
+
+    if not DIALPAD_API_KEY:
+        raise ValueError("DIALPAD_API_KEY environment variable not set")
 
     url = f"{DIALPAD_API_BASE}/sms"
 

--- a/scripts/send_sms.py
+++ b/scripts/send_sms.py
@@ -15,7 +15,7 @@ import sys
 import urllib.request
 import urllib.error
 
-from outbound_destination_policy import require_supported_outbound_destinations
+from outbound_destination_policy import normalize_supported_outbound_destinations
 
 
 # Configuration
@@ -42,7 +42,7 @@ def send_sms(to_numbers, message, from_number=None, infer_country_code=False):
     if len(to_numbers) > 10:
         raise ValueError("Maximum 10 recipients per SMS request")
 
-    require_supported_outbound_destinations(
+    to_numbers = normalize_supported_outbound_destinations(
         to_numbers,
         allow_nanp_national=infer_country_code,
     )

--- a/tests/test_generated_facade_policy.py
+++ b/tests/test_generated_facade_policy.py
@@ -147,6 +147,20 @@ def test_generated_facade_allows_meeting_create_without_callout():
     )
 
 
+def test_generated_facade_rejects_meeting_callout_without_participants():
+    with pytest.raises(ValueError, match="explicit participants"):
+        facade._preflight_outbound_destination(
+            [
+                "meetings",
+                "meetings.create",
+                "--call-out",
+                "true",
+                "--title",
+                "Call-out meeting",
+            ]
+        )
+
+
 def test_generated_facade_rejects_unverifiable_meeting_update():
     with pytest.raises(ValueError, match="stored call-out state"):
         facade._preflight_outbound_destination(

--- a/tests/test_generated_facade_policy.py
+++ b/tests/test_generated_facade_policy.py
@@ -205,22 +205,14 @@ def test_generated_facade_requires_explicit_nanp_even_with_country_inference(com
     [
         ["sms", "sms.send", "--channel-hashtag", "sales"],
         ["message", "schedules.create", "--channel-hashtag", "sales"],
-        [
-            "message",
-            "schedules.update",
-            "--id",
-            "schedule-123",
-            "--channel-hashtag",
-            "sales",
-        ],
     ],
 )
 def test_generated_facade_allows_explicit_channel_destination(argv):
     facade._preflight_outbound_destination(argv)
 
 
-@pytest.mark.parametrize("channel_hashtag", ["", " sales "])
-def test_generated_facade_rejects_empty_or_noncanonical_schedule_channel(
+@pytest.mark.parametrize("channel_hashtag", ["", "sales", " sales "])
+def test_generated_facade_rejects_channel_only_schedule_update(
     channel_hashtag,
 ):
     with pytest.raises(ValueError, match="stored recipients"):

--- a/tests/test_generated_facade_policy.py
+++ b/tests/test_generated_facade_policy.py
@@ -147,7 +147,7 @@ def test_generated_facade_rejects_unverifiable_meeting_update():
             ]
         )
 
-    with pytest.raises(ValueError, match="stored participants"):
+    with pytest.raises(ValueError, match="Enabling meeting call-out"):
         facade._preflight_outbound_destination(
             [
                 "meetings",
@@ -173,29 +173,39 @@ def test_generated_facade_allows_meeting_update_that_disables_callout():
     )
 
 
-def test_generated_facade_preserves_explicit_nanp_country_inference():
-    facade._preflight_outbound_destination(
-        [
-            "sms",
-            "sms.send",
-            "--to-numbers",
-            '["4155550100"]',
-            "--infer-country-code",
-            "true",
-        ]
-    )
-
-
-def test_generated_facade_limits_country_inference_to_sms_contract():
+@pytest.mark.parametrize("command", [["sms", "sms.send"], ["call", "call.call"]])
+def test_generated_facade_requires_explicit_nanp_even_with_country_inference(command):
     with pytest.raises(ValueError, match="NANP"):
         facade._preflight_outbound_destination(
             [
-                "call",
-                "call.call",
+                *command,
                 "--data",
-                '{"phone_number":"4155550100","infer_country_code":true}',
+                (
+                    '{"to_numbers":["4155550100"],"infer_country_code":true}'
+                    if command[0] == "sms"
+                    else '{"phone_number":"4155550100","infer_country_code":true}'
+                ),
             ]
         )
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["sms", "sms.send", "--channel-hashtag", "sales"],
+        ["message", "schedules.create", "--channel-hashtag", "sales"],
+        [
+            "message",
+            "schedules.update",
+            "--id",
+            "schedule-123",
+            "--channel-hashtag",
+            "sales",
+        ],
+    ],
+)
+def test_generated_facade_allows_explicit_channel_destination(argv):
+    facade._preflight_outbound_destination(argv)
 
 
 def test_generated_facade_allows_non_phone_transfer_target():

--- a/tests/test_generated_facade_policy.py
+++ b/tests/test_generated_facade_policy.py
@@ -116,6 +116,20 @@ def test_generated_facade_rejects_schedule_update_without_recipients():
         )
 
 
+def test_generated_facade_data_does_not_inherit_ignored_schedule_options():
+    with pytest.raises(ValueError, match="stored recipients"):
+        facade._preflight_outbound_destination(
+            [
+                "message",
+                "schedules.update",
+                "--data",
+                '{"start_date":"1785000000"}',
+                "--to-numbers",
+                '["+14155550100"]',
+            ]
+        )
+
+
 def test_generated_facade_rejects_international_meeting_callout():
     with pytest.raises(ValueError, match="NANP"):
         facade._preflight_outbound_destination(
@@ -181,6 +195,20 @@ def test_generated_facade_rejects_unverifiable_meeting_update():
                 "true",
                 "--title",
                 "Rescheduled",
+            ]
+        )
+
+
+def test_generated_facade_data_does_not_inherit_ignored_meeting_options():
+    with pytest.raises(ValueError, match="stored call-out state"):
+        facade._preflight_outbound_destination(
+            [
+                "meetings",
+                "meetings.update",
+                "--data",
+                '{"participants_info":[{"phone_number":"+442071838750"}]}',
+                "--call-out",
+                "false",
             ]
         )
 

--- a/tests/test_generated_facade_policy.py
+++ b/tests/test_generated_facade_policy.py
@@ -43,6 +43,18 @@ FACADE_SPEC.loader.exec_module(facade)
             '{"phone_number":"+442071838750"}',
         ],
         ["callback", "call.callback", "--phone-number", "+442071838750"],
+        [
+            "callback",
+            "call.validate_callback",
+            "--phone-number",
+            "+442071838750",
+        ],
+        [
+            "callback",
+            "call.validate_callback",
+            "--data",
+            '{"phone_number":"+442071838750"}',
+        ],
         ["users", "users.initiate_call", "--phone-number", "+442071838750"],
         ["call", "call.transfer_call", "--to", "+442071838750"],
         ["call", "call.participants.add", "--participant", "+442071838750"],
@@ -86,6 +98,18 @@ def test_generated_facade_rejects_international_destinations(argv):
             '{"phone_number":"+14155550100"}',
         ],
         ["callback", "call.callback", "--phone-number", "+14155550100"],
+        [
+            "callback",
+            "call.validate_callback",
+            "--phone-number",
+            "+14155550100",
+        ],
+        [
+            "callback",
+            "call.validate_callback",
+            "--data",
+            '{"phone_number":"+14155550100"}',
+        ],
         ["users", "users.initiate_call", "--phone-number", "+14155550100"],
         ["call", "call.transfer_call", "--to", "+14155550100"],
         ["call", "call.participants.add", "--participant", "+14155550100"],
@@ -213,15 +237,51 @@ def test_generated_facade_data_does_not_inherit_ignored_meeting_options():
         )
 
 
-def test_generated_facade_allows_meeting_update_that_disables_callout():
+@pytest.mark.parametrize("operation", ["meetings.create", "meetings.update"])
+def test_generated_facade_rejects_string_false_meeting_callout(operation):
+    with pytest.raises(ValueError, match="JSON boolean"):
+        facade._preflight_outbound_destination(
+            [
+                "meetings",
+                operation,
+                "--call-out",
+                "false",
+                "--title",
+                "Rescheduled",
+            ]
+        )
+
+
+def test_generated_facade_allows_json_false_meeting_update_callout():
     facade._preflight_outbound_destination(
         [
             "meetings",
             "meetings.update",
-            "--call-out",
-            "false",
-            "--title",
-            "Rescheduled",
+            "--data",
+            '{"call_out":false}',
+        ]
+    )
+
+
+def test_generated_facade_rejects_string_schedule_recipient_array():
+    with pytest.raises(ValueError, match="JSON array"):
+        facade._preflight_outbound_destination(
+            [
+                "message",
+                "schedules.update",
+                "--to-numbers",
+                '["+14155550100"]',
+            ]
+        )
+
+
+def test_generated_facade_allows_json_schedule_recipient_array():
+    facade._preflight_outbound_destination(
+        [
+            "message",
+            "schedules.update",
+            "--data",
+            '{"to_numbers":["+14155550100"]}',
         ]
     )
 

--- a/tests/test_generated_facade_policy.py
+++ b/tests/test_generated_facade_policy.py
@@ -174,6 +174,18 @@ def test_generated_facade_preserves_explicit_nanp_country_inference():
     )
 
 
+def test_generated_facade_limits_country_inference_to_sms_contract():
+    with pytest.raises(ValueError, match="NANP"):
+        facade._preflight_outbound_destination(
+            [
+                "call",
+                "call.call",
+                "--data",
+                '{"phone_number":"4155550100","infer_country_code":true}',
+            ]
+        )
+
+
 def test_generated_facade_allows_non_phone_transfer_target():
     facade._preflight_outbound_destination(
         ["call", "call.transfer_call", "--to", "user-id-123"]

--- a/tests/test_generated_facade_policy.py
+++ b/tests/test_generated_facade_policy.py
@@ -130,8 +130,8 @@ def test_generated_facade_data_does_not_inherit_ignored_schedule_options():
         )
 
 
-def test_generated_facade_rejects_international_meeting_callout():
-    with pytest.raises(ValueError, match="NANP"):
+def test_generated_facade_rejects_meeting_create_callout():
+    with pytest.raises(ValueError, match="Meeting call-out is disabled"):
         facade._preflight_outbound_destination(
             [
                 "meetings",
@@ -161,8 +161,8 @@ def test_generated_facade_allows_meeting_create_without_callout():
     )
 
 
-def test_generated_facade_rejects_meeting_callout_without_participants():
-    with pytest.raises(ValueError, match="explicit participants"):
+def test_generated_facade_rejects_meeting_create_callout_without_participants():
+    with pytest.raises(ValueError, match="Meeting call-out is disabled"):
         facade._preflight_outbound_destination(
             [
                 "meetings",
@@ -186,7 +186,7 @@ def test_generated_facade_rejects_unverifiable_meeting_update():
             ]
         )
 
-    with pytest.raises(ValueError, match="Enabling meeting call-out"):
+    with pytest.raises(ValueError, match="Meeting call-out is disabled"):
         facade._preflight_outbound_destination(
             [
                 "meetings",
@@ -283,7 +283,7 @@ def test_generated_facade_allows_non_phone_participant_target():
 
 @pytest.mark.parametrize("call_out", ["true", "t", "yes", "y", "on", "1"])
 def test_generated_facade_rejects_all_click_true_meeting_update_values(call_out):
-    with pytest.raises(ValueError, match="Enabling meeting call-out"):
+    with pytest.raises(ValueError, match="Meeting call-out is disabled"):
         facade._preflight_outbound_destination(
             [
                 "meetings",

--- a/tests/test_generated_facade_policy.py
+++ b/tests/test_generated_facade_policy.py
@@ -46,6 +46,18 @@ FACADE_SPEC.loader.exec_module(facade)
         ["users", "users.initiate_call", "--phone-number", "+442071838750"],
         ["call", "call.transfer_call", "--to", "+442071838750"],
         ["call", "call.participants.add", "--participant", "+442071838750"],
+        [
+            "call",
+            "call.transfer_call",
+            "--data",
+            '{"to":{"number":"+442071838750"}}',
+        ],
+        [
+            "call",
+            "call.participants.add",
+            "--data",
+            '{"participant":{"number":"+442071838750"}}',
+        ],
     ],
 )
 def test_generated_facade_rejects_international_destinations(argv):
@@ -198,6 +210,45 @@ def test_generated_facade_allows_non_phone_participant_target():
     )
 
 
+@pytest.mark.parametrize(
+    "argv",
+    [
+        [
+            "call",
+            "call.transfer_call",
+            "--data",
+            '{"to":{"call_id":123}}',
+        ],
+        [
+            "call",
+            "call.transfer_call",
+            "--data",
+            '{"to":{"target_id":123,"target_type":"user"}}',
+        ],
+        [
+            "call",
+            "call.participants.add",
+            "--data",
+            '{"participant":{"target_id":123,"target_type":"user"}}',
+        ],
+    ],
+)
+def test_generated_facade_allows_structured_internal_targets(argv):
+    facade._preflight_outbound_destination(argv)
+
+
+def test_generated_facade_rejects_unknown_structured_destination():
+    with pytest.raises(ValueError, match="supported variant"):
+        facade._preflight_outbound_destination(
+            [
+                "call",
+                "call.transfer_call",
+                "--data",
+                '{"to":{"unexpected":"+442071838750"}}',
+            ]
+        )
+
+
 def test_generated_facade_uses_last_duplicate_option_like_click():
     with pytest.raises(ValueError, match="NANP"):
         facade._preflight_outbound_destination(
@@ -237,6 +288,53 @@ def test_generated_facade_main_rejects_before_raw_cli_subprocess():
         ],
     ), patch.object(facade, "_raw_cli_runner") as runner, patch.object(
         facade.subprocess, "run"
+    ) as run:
+        assert facade.main() == 2
+
+    runner.assert_not_called()
+    run.assert_not_called()
+
+
+def test_generated_facade_subcommand_help_bypasses_request_preflight():
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "generated/dialpad",
+            "message",
+            "schedules.update",
+            "--help",
+        ],
+    ), patch.object(
+        facade,
+        "_raw_cli_runner",
+        return_value=["python3"],
+    ), patch.object(
+        facade.subprocess,
+        "run",
+        return_value=type("Completed", (), {"returncode": 0})(),
+    ) as run:
+        assert facade.main() == 0
+
+    run.assert_called_once()
+
+
+def test_generated_facade_does_not_mistake_option_value_for_help():
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "generated/dialpad",
+            "sms",
+            "send",
+            "--to-numbers",
+            '["+442071838750"]',
+            "--text",
+            "--help",
+        ],
+    ), patch.object(facade, "_raw_cli_runner") as runner, patch.object(
+        facade.subprocess,
+        "run",
     ) as run:
         assert facade.main() == 2
 

--- a/tests/test_generated_facade_policy.py
+++ b/tests/test_generated_facade_policy.py
@@ -208,6 +208,22 @@ def test_generated_facade_allows_explicit_channel_destination(argv):
     facade._preflight_outbound_destination(argv)
 
 
+@pytest.mark.parametrize("channel_hashtag", ["", " sales "])
+def test_generated_facade_rejects_empty_or_noncanonical_schedule_channel(
+    channel_hashtag,
+):
+    with pytest.raises(ValueError, match="stored recipients"):
+        facade._preflight_outbound_destination(
+            [
+                "message",
+                "schedules.update",
+                "--id",
+                "schedule-123",
+                f"--channel-hashtag={channel_hashtag}",
+            ]
+        )
+
+
 def test_generated_facade_allows_non_phone_transfer_target():
     facade._preflight_outbound_destination(
         ["call", "call.transfer_call", "--to", "user-id-123"]
@@ -255,6 +271,23 @@ def test_generated_facade_rejects_unknown_structured_destination():
                 "call.transfer_call",
                 "--data",
                 '{"to":{"unexpected":"+442071838750"}}',
+            ]
+        )
+
+
+@pytest.mark.parametrize("field", ["to", "participant"])
+def test_generated_facade_rejects_non_e164_structured_phone(field):
+    command = (
+        ["call", "call.transfer_call"]
+        if field == "to"
+        else ["call", "call.participants.add"]
+    )
+    with pytest.raises(ValueError, match="NANP"):
+        facade._preflight_outbound_destination(
+            [
+                *command,
+                "--data",
+                json.dumps({field: {"number": "442071838750"}}),
             ]
         )
 
@@ -350,3 +383,29 @@ def test_generated_facade_does_not_mistake_option_value_for_help():
 
     runner.assert_not_called()
     run.assert_not_called()
+
+
+def test_generated_facade_recognizes_eager_help_before_other_options():
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "generated/dialpad",
+            "call",
+            "make",
+            "--help",
+            "--phone-number",
+            "+442071838750",
+        ],
+    ), patch.object(
+        facade,
+        "_raw_cli_runner",
+        return_value=["python3"],
+    ), patch.object(
+        facade.subprocess,
+        "run",
+        return_value=type("Completed", (), {"returncode": 0})(),
+    ) as run:
+        assert facade.main() == 0
+
+    run.assert_called_once()

--- a/tests/test_generated_facade_policy.py
+++ b/tests/test_generated_facade_policy.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+FACADE_PATH = Path(__file__).resolve().parent.parent / "generated" / "dialpad"
+FACADE_SPEC = importlib.util.spec_from_loader(
+    "generated_dialpad_facade_policy_test",
+    SourceFileLoader("generated_dialpad_facade_policy_test", str(FACADE_PATH)),
+)
+assert FACADE_SPEC is not None and FACADE_SPEC.loader is not None
+facade = importlib.util.module_from_spec(FACADE_SPEC)
+FACADE_SPEC.loader.exec_module(facade)
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["sms", "send", "--to-numbers", '["+442071838750"]'],
+        [
+            "message",
+            "bulk_messages.send",
+            "--data",
+            '{"to_numbers":["+442071838750"]}',
+        ],
+        [
+            "message",
+            "schedules.create",
+            "--to-numbers=+442071838750",
+        ],
+        ["call", "make", "--phone-number", "+442071838750"],
+        [
+            "call",
+            "call.initiate_ivr_call",
+            "--data",
+            '{"phone_number":"+442071838750"}',
+        ],
+        ["callback", "call.callback", "--phone-number", "+442071838750"],
+        ["users", "users.initiate_call", "--phone-number", "+442071838750"],
+        ["call", "call.transfer_call", "--to", "+442071838750"],
+        ["call", "call.participants.add", "--participant", "+442071838750"],
+    ],
+)
+def test_generated_facade_rejects_international_destinations(argv):
+    translated = facade._translate(argv)
+
+    with pytest.raises(ValueError, match="NANP"):
+        facade._preflight_outbound_destination(translated)
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["sms", "send", "--to-numbers", '["+14155550100"]'],
+        [
+            "message",
+            "bulk_messages.send",
+            "--data",
+            '{"to_numbers":["+14155550100","+16045550101"]}',
+        ],
+        ["message", "schedules.create", "--to-numbers=+14155550100"],
+        ["call", "make", "--phone-number", "+14155550100"],
+        [
+            "call",
+            "call.initiate_ivr_call",
+            "--data",
+            '{"phone_number":"+14155550100"}',
+        ],
+        ["callback", "call.callback", "--phone-number", "+14155550100"],
+        ["users", "users.initiate_call", "--phone-number", "+14155550100"],
+        ["call", "call.transfer_call", "--to", "+14155550100"],
+        ["call", "call.participants.add", "--participant", "+14155550100"],
+    ],
+)
+def test_generated_facade_allows_nanp_destinations(argv):
+    facade._preflight_outbound_destination(facade._translate(argv))
+
+
+def test_generated_facade_disables_unverifiable_scheduled_send():
+    with pytest.raises(ValueError, match="cannot validate"):
+        facade._preflight_outbound_destination(
+            ["message", "schedules.send_now", "--id", "schedule-123"]
+        )
+
+
+def test_generated_facade_rejects_schedule_update_without_recipients():
+    with pytest.raises(ValueError, match="stored recipients"):
+        facade._preflight_outbound_destination(
+            [
+                "message",
+                "schedules.update",
+                "--id",
+                "schedule-123",
+                "--start-date",
+                "1785000000",
+            ]
+        )
+
+
+def test_generated_facade_rejects_international_meeting_callout():
+    with pytest.raises(ValueError, match="NANP"):
+        facade._preflight_outbound_destination(
+            [
+                "meetings",
+                "meetings.create",
+                "--data",
+                json.dumps(
+                    {
+                        "call_out": True,
+                        "participants_info": [
+                            {"phone_number": "+442071838750"},
+                            {"email": "internal@example.com"},
+                        ],
+                    }
+                ),
+            ]
+        )
+
+
+def test_generated_facade_rejects_unverifiable_meeting_update():
+    with pytest.raises(ValueError, match="stored call-out state"):
+        facade._preflight_outbound_destination(
+            [
+                "meetings",
+                "meetings.update",
+                "--title",
+                "Rescheduled",
+            ]
+        )
+
+    with pytest.raises(ValueError, match="stored participants"):
+        facade._preflight_outbound_destination(
+            [
+                "meetings",
+                "meetings.update",
+                "--call-out",
+                "true",
+                "--title",
+                "Rescheduled",
+            ]
+        )
+
+
+def test_generated_facade_allows_meeting_update_that_disables_callout():
+    facade._preflight_outbound_destination(
+        [
+            "meetings",
+            "meetings.update",
+            "--call-out",
+            "false",
+            "--title",
+            "Rescheduled",
+        ]
+    )
+
+
+def test_generated_facade_preserves_explicit_nanp_country_inference():
+    facade._preflight_outbound_destination(
+        [
+            "sms",
+            "sms.send",
+            "--to-numbers",
+            '["4155550100"]',
+            "--infer-country-code",
+            "true",
+        ]
+    )
+
+
+def test_generated_facade_allows_non_phone_transfer_target():
+    facade._preflight_outbound_destination(
+        ["call", "call.transfer_call", "--to", "user-id-123"]
+    )
+
+
+def test_generated_facade_allows_non_phone_participant_target():
+    facade._preflight_outbound_destination(
+        ["call", "call.participants.add", "--participant", "user-id-123"]
+    )
+
+
+def test_generated_facade_uses_last_duplicate_option_like_click():
+    with pytest.raises(ValueError, match="NANP"):
+        facade._preflight_outbound_destination(
+            [
+                "sms",
+                "sms.send",
+                "--data",
+                '{"to_numbers":["+14155550100"]}',
+                "--data",
+                '{"to_numbers":["+442071838750"]}',
+            ]
+        )
+
+
+def test_generated_facade_rejects_whitespace_it_would_send_unchanged():
+    with pytest.raises(ValueError, match="NANP"):
+        facade._preflight_outbound_destination(
+            [
+                "sms",
+                "sms.send",
+                "--to-numbers",
+                " +14155550100 ",
+            ]
+        )
+
+
+def test_generated_facade_main_rejects_before_raw_cli_subprocess():
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "generated/dialpad",
+            "sms",
+            "send",
+            "--to-numbers",
+            '["+442071838750"]',
+        ],
+    ), patch.object(facade, "_raw_cli_runner") as runner, patch.object(
+        facade.subprocess, "run"
+    ) as run:
+        assert facade.main() == 2
+
+    runner.assert_not_called()
+    run.assert_not_called()

--- a/tests/test_generated_facade_policy.py
+++ b/tests/test_generated_facade_policy.py
@@ -136,6 +136,17 @@ def test_generated_facade_rejects_international_meeting_callout():
         )
 
 
+def test_generated_facade_allows_meeting_create_without_callout():
+    facade._preflight_outbound_destination(
+        [
+            "meetings",
+            "meetings.create",
+            "--title",
+            "Internal meeting",
+        ]
+    )
+
+
 def test_generated_facade_rejects_unverifiable_meeting_update():
     with pytest.raises(ValueError, match="stored call-out state"):
         facade._preflight_outbound_destination(
@@ -234,6 +245,35 @@ def test_generated_facade_allows_non_phone_participant_target():
     facade._preflight_outbound_destination(
         ["call", "call.participants.add", "--participant", "user-id-123"]
     )
+
+
+@pytest.mark.parametrize("call_out", ["true", "t", "yes", "y", "on", "1"])
+def test_generated_facade_rejects_all_click_true_meeting_update_values(call_out):
+    with pytest.raises(ValueError, match="Enabling meeting call-out"):
+        facade._preflight_outbound_destination(
+            [
+                "meetings",
+                "meetings.update",
+                "--call-out",
+                call_out,
+                "--title",
+                "Rescheduled",
+            ]
+        )
+
+
+def test_generated_facade_rejects_invalid_meeting_boolean():
+    with pytest.raises(ValueError, match="Invalid boolean"):
+        facade._preflight_outbound_destination(
+            [
+                "meetings",
+                "meetings.update",
+                "--call-out",
+                "maybe",
+                "--title",
+                "Rescheduled",
+            ]
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_generated_facade_policy.py
+++ b/tests/test_generated_facade_policy.py
@@ -269,16 +269,18 @@ def test_generated_facade_rejects_channel_only_schedule_update(
         )
 
 
-def test_generated_facade_allows_non_phone_transfer_target():
-    facade._preflight_outbound_destination(
-        ["call", "call.transfer_call", "--to", "user-id-123"]
-    )
-
-
-def test_generated_facade_allows_non_phone_participant_target():
-    facade._preflight_outbound_destination(
-        ["call", "call.participants.add", "--participant", "user-id-123"]
-    )
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["call", "call.transfer_call", "--to", "442071838750"],
+        ["call", "call.transfer_call", "--to", "user-id-123"],
+        ["call", "call.participants.add", "--participant", "442071838750"],
+        ["call", "call.participants.add", "--participant", "user-id-123"],
+    ],
+)
+def test_generated_facade_rejects_bare_internal_targets(argv):
+    with pytest.raises(ValueError, match="structured object"):
+        facade._preflight_outbound_destination(argv)
 
 
 @pytest.mark.parametrize("call_out", ["true", "t", "yes", "y", "on", "1"])

--- a/tests/test_json_contract.py
+++ b/tests/test_json_contract.py
@@ -373,6 +373,26 @@ class JsonContractTests(unittest.TestCase):
         self.assertEqual(err, "")
         self._assert_success(self._parse(out), "make_call.call")
 
+    def test_make_call_rejects_non_nanp_recipient_before_api(self):
+        with patch("make_call.require_generated_cli"), \
+                patch("make_call.require_api_key") as require_key, \
+                patch("make_call.resolve_user_id") as resolve_user, \
+                patch("make_call.run_generated_json") as run_generated_json:
+            code, out, err = self._run(
+                make_call,
+                ["bin/make_call.py", "--to", "+442071838750", "--user-id", "u1", "--json"],
+            )
+
+        self.assertEqual(code, 2)
+        self.assertEqual(err, "")
+        parsed = self._parse(out)
+        self._assert_error(parsed, "make_call.call")
+        self.assertEqual(parsed["error"]["code"], "invalid_argument")
+        self.assertIn("NANP", parsed["error"]["message"])
+        require_key.assert_not_called()
+        resolve_user.assert_not_called()
+        run_generated_json.assert_not_called()
+
     def test_list_calls_json_success_envelope(self):
         with patch.object(list_calls_wrapper, "require_api_key"), \
                 patch.object(

--- a/tests/test_outbound_destination_policy.py
+++ b/tests/test_outbound_destination_policy.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+POLICY_SPEC = importlib.util.spec_from_file_location(
+    "outbound_destination_policy",
+    SCRIPTS_DIR / "outbound_destination_policy.py",
+)
+assert POLICY_SPEC is not None and POLICY_SPEC.loader is not None
+outbound_destination_policy = importlib.util.module_from_spec(POLICY_SPEC)
+sys.modules["outbound_destination_policy"] = outbound_destination_policy
+POLICY_SPEC.loader.exec_module(outbound_destination_policy)
+
+SEND_SMS_SPEC = importlib.util.spec_from_file_location(
+    "legacy_send_sms_policy_test",
+    SCRIPTS_DIR / "send_sms.py",
+)
+assert SEND_SMS_SPEC is not None and SEND_SMS_SPEC.loader is not None
+legacy_send_sms = importlib.util.module_from_spec(SEND_SMS_SPEC)
+SEND_SMS_SPEC.loader.exec_module(legacy_send_sms)
+
+MAKE_CALL_SPEC = importlib.util.spec_from_file_location(
+    "legacy_make_call_policy_test",
+    SCRIPTS_DIR / "make_call.py",
+)
+assert MAKE_CALL_SPEC is not None and MAKE_CALL_SPEC.loader is not None
+legacy_make_call = importlib.util.module_from_spec(MAKE_CALL_SPEC)
+MAKE_CALL_SPEC.loader.exec_module(legacy_make_call)
+
+
+def test_approval_lane_transport_rejects_non_nanp_recipient_before_api(monkeypatch):
+    monkeypatch.setattr(legacy_send_sms, "DIALPAD_API_KEY", "test-key")
+
+    with patch.object(legacy_send_sms.urllib.request, "urlopen") as urlopen:
+        with pytest.raises(ValueError, match="NANP"):
+            legacy_send_sms.send_sms(
+                ["+442071838750"],
+                "Hello",
+                from_number="+14155201316",
+            )
+
+    urlopen.assert_not_called()
+
+
+def test_approval_lane_transport_rejects_mixed_batch_before_api(monkeypatch):
+    monkeypatch.setattr(legacy_send_sms, "DIALPAD_API_KEY", "test-key")
+
+    with patch.object(legacy_send_sms.urllib.request, "urlopen") as urlopen:
+        with pytest.raises(ValueError, match="NANP"):
+            legacy_send_sms.send_sms(
+                ["+14155550100", "+442071838750"],
+                "Hello",
+                from_number="+14155201316",
+            )
+
+    urlopen.assert_not_called()
+
+
+def test_operator_call_transport_rejects_non_nanp_recipient_before_api(monkeypatch):
+    monkeypatch.setattr(legacy_make_call, "DIALPAD_API_KEY", "test-key")
+
+    with patch.object(legacy_make_call.urllib.request, "urlopen") as urlopen:
+        with pytest.raises(ValueError, match="NANP"):
+            legacy_make_call.make_call(
+                "+442071838750",
+                user_id="test-user",
+            )
+
+    urlopen.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "phone_number",
+    [
+        "+1١٢٣٤٥٦٧٨٩٠",
+        "+1１２３４５６７８９０",
+    ],
+)
+def test_policy_rejects_unicode_digits(phone_number):
+    with pytest.raises(ValueError, match="NANP"):
+        outbound_destination_policy.require_supported_outbound_destinations(
+            [phone_number]
+        )
+
+
+def test_policy_allows_nanp_national_only_when_country_inference_is_explicit():
+    with pytest.raises(ValueError, match="NANP"):
+        outbound_destination_policy.require_supported_outbound_destinations(
+            ["4155550100"]
+        )
+
+    outbound_destination_policy.require_supported_outbound_destinations(
+        ["4155550100"],
+        allow_nanp_national=True,
+    )
+
+
+def test_policy_rejects_whitespace_instead_of_validating_a_changed_value():
+    with pytest.raises(ValueError, match="NANP"):
+        outbound_destination_policy.require_supported_outbound_destinations(
+            [" +14155550100 "]
+        )
+
+
+def test_policy_explicitly_allows_non_us_nanp_territory():
+    outbound_destination_policy.require_supported_outbound_destinations(
+        ["+18095550123"]
+    )

--- a/tests/test_outbound_destination_policy.py
+++ b/tests/test_outbound_destination_policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -63,6 +64,24 @@ def test_approval_lane_transport_rejects_mixed_batch_before_api(monkeypatch):
     urlopen.assert_not_called()
 
 
+def test_legacy_sms_normalizes_inferred_nanp_before_api(monkeypatch):
+    monkeypatch.setattr(legacy_send_sms, "DIALPAD_API_KEY", "test-key")
+
+    with patch.object(legacy_send_sms.urllib.request, "urlopen") as urlopen:
+        urlopen.return_value.__enter__.return_value.read.return_value = (
+            b'{"id":"sms-1","message_status":"pending"}'
+        )
+        legacy_send_sms.send_sms(
+            ["4155550100"],
+            "Hello",
+            from_number="+14155201316",
+            infer_country_code=True,
+        )
+
+    request = urlopen.call_args.args[0]
+    assert json.loads(request.data)["to_numbers"] == ["+14155550100"]
+
+
 def test_operator_call_transport_rejects_non_nanp_recipient_before_api(monkeypatch):
     monkeypatch.setattr(legacy_make_call, "DIALPAD_API_KEY", "test-key")
 
@@ -96,10 +115,10 @@ def test_policy_allows_nanp_national_only_when_country_inference_is_explicit():
             ["4155550100"]
         )
 
-    outbound_destination_policy.require_supported_outbound_destinations(
+    assert outbound_destination_policy.normalize_supported_outbound_destinations(
         ["4155550100"],
         allow_nanp_national=True,
-    )
+    ) == ["+14155550100"]
 
 
 def test_policy_rejects_whitespace_instead_of_validating_a_changed_value():

--- a/tests/test_send_sms_group_intro.py
+++ b/tests/test_send_sms_group_intro.py
@@ -237,7 +237,7 @@ class SendSmsWrapperTests(unittest.TestCase):
         self.assertEqual(err, "")
         self.assertTrue(json.loads(out)["ok"])
         payload = json.loads(calls[0][3])
-        self.assertEqual(payload["to_numbers"], ["4155550100"])
+        self.assertEqual(payload["to_numbers"], ["+14155550100"])
         self.assertTrue(payload["infer_country_code"])
 
     def test_send_sms_message_file_preserves_dollar_sign_in_payload(self):

--- a/tests/test_send_sms_group_intro.py
+++ b/tests/test_send_sms_group_intro.py
@@ -178,6 +178,68 @@ class SendSmsWrapperTests(unittest.TestCase):
         self.assertIn("Message preview:", out)
         self.assertIn("Hello", out)
 
+    def test_send_sms_rejects_non_nanp_recipient_before_api(self):
+        with patch("send_sms.require_generated_cli"), \
+                patch("send_sms.require_api_key") as require_key, \
+                patch("send_sms.run_generated_json") as run_json:
+            code, out, err = self._run_main(send_sms, [
+                "--to", "+442071838750",
+                "--from", "+14155201316",
+                "--message", "Hello",
+            ])
+
+        self.assertEqual(code, 2)
+        self.assertEqual(out, "")
+        self.assertIn("NANP", err)
+        require_key.assert_not_called()
+        run_json.assert_not_called()
+
+    def test_send_sms_json_rejection_is_non_retryable_invalid_argument(self):
+        with patch("send_sms.require_generated_cli") as require_cli, \
+                patch("send_sms.require_api_key") as require_key, \
+                patch("send_sms.run_generated_json") as run_json:
+            code, out, err = self._run_main(send_sms, [
+                "--to", "+442071838750",
+                "--from", "+14155201316",
+                "--message", "Hello",
+                "--json",
+            ])
+
+        envelope = json.loads(out)
+        self.assertEqual(code, 2)
+        self.assertEqual(err, "")
+        self.assertFalse(envelope["ok"])
+        self.assertEqual(envelope["error"]["code"], "invalid_argument")
+        self.assertFalse(envelope["error"]["retryable"])
+        require_cli.assert_not_called()
+        require_key.assert_not_called()
+        run_json.assert_not_called()
+
+    def test_send_sms_preserves_nanp_country_inference_contract(self):
+        calls: list[list[str]] = []
+
+        with patch("send_sms.require_generated_cli"), \
+                patch("send_sms.require_api_key"), \
+                patch(
+                    "send_sms.run_generated_json",
+                    side_effect=lambda command: calls.append(command)
+                    or {"id": "msg-1", "message_status": "pending"},
+                ):
+            code, out, err = self._run_main(send_sms, [
+                "--to", "4155550100",
+                "--from", "+14155201316",
+                "--message", "Hello",
+                "--infer-country-code",
+                "--json",
+            ])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(err, "")
+        self.assertTrue(json.loads(out)["ok"])
+        payload = json.loads(calls[0][3])
+        self.assertEqual(payload["to_numbers"], ["4155550100"])
+        self.assertTrue(payload["infer_country_code"])
+
     def test_send_sms_message_file_preserves_dollar_sign_in_payload(self):
         calls: list[list[str]] = []
 
@@ -331,6 +393,44 @@ class SendGroupIntroTests(unittest.TestCase):
         self.assertTrue(parsed["data"]["dry_run"])
         self.assertEqual(parsed["data"]["prospect"]["to"], "+14155550111")
         self.assertEqual(parsed["data"]["reference"]["to"], "+14155559999")
+
+    def test_send_group_intro_rejects_non_nanp_party_before_api(self):
+        with patch("send_group_intro.require_generated_cli"), \
+                patch("send_group_intro.resolve_sender", return_value=("+14155201316", "--from")), \
+                patch("send_group_intro.require_api_key") as require_key, \
+                patch("send_group_intro.run_generated_json") as run_json:
+            code, out, err = self._run_main([
+                "--prospect", "+14155550111",
+                "--reference", "+442071838750",
+                "--confirm-share",
+            ])
+
+        self.assertEqual(code, 2)
+        self.assertEqual(out, "")
+        self.assertIn("NANP", err)
+        require_key.assert_not_called()
+        run_json.assert_not_called()
+
+    def test_send_group_intro_json_rejection_is_non_retryable_invalid_argument(self):
+        with patch("send_group_intro.require_generated_cli") as require_cli, \
+                patch("send_group_intro.require_api_key") as require_key, \
+                patch("send_group_intro.run_generated_json") as run_json:
+            code, out, err = self._run_main([
+                "--prospect", "+14155550111",
+                "--reference", "+442071838750",
+                "--confirm-share",
+                "--json",
+            ])
+
+        envelope = json.loads(out)
+        self.assertEqual(code, 2)
+        self.assertEqual(err, "")
+        self.assertFalse(envelope["ok"])
+        self.assertEqual(envelope["error"]["code"], "invalid_argument")
+        self.assertFalse(envelope["error"]["retryable"])
+        require_cli.assert_not_called()
+        require_key.assert_not_called()
+        run_json.assert_not_called()
 
     def test_send_group_intro_success_sends_two_messages(self):
         calls: list[list[str]] = []

--- a/tests/test_sms_approval.py
+++ b/tests/test_sms_approval.py
@@ -4,16 +4,26 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import importlib.util
 import json
 import os
 import subprocess
 import sys
 import threading
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "scripts"))
 
 import sms_approval
+
+SEND_SMS_SPEC = importlib.util.spec_from_file_location(
+    "approval_default_send_sms_policy_test",
+    ROOT / "scripts" / "send_sms.py",
+)
+assert SEND_SMS_SPEC is not None and SEND_SMS_SPEC.loader is not None
+approval_default_send_sms = importlib.util.module_from_spec(SEND_SMS_SPEC)
+SEND_SMS_SPEC.loader.exec_module(approval_default_send_sms)
 
 
 class SmsApprovalTests(unittest.TestCase):
@@ -74,6 +84,29 @@ class SmsApprovalTests(unittest.TestCase):
         stored = sms_approval.get_draft(self.conn, draft["draft_id"])
         self.assertEqual(stored["status"], sms_approval.STATUS_SENT)
         self.assertEqual(stored["approved_by"], "12345")
+
+    def test_approve_international_draft_fails_before_default_transport_api(self):
+        draft = self._draft(customer_number="+442071838750")
+        approval_default_send_sms.DIALPAD_API_KEY = "test-key"
+
+        with patch.dict(sys.modules, {"send_sms": approval_default_send_sms}), patch.object(
+            approval_default_send_sms.urllib.request,
+            "urlopen",
+        ) as urlopen:
+            result = sms_approval.approve_draft(
+                self.conn,
+                draft_id=draft["draft_id"],
+                actor_id="12345",
+            )
+
+        self.assertFalse(result["sent"])
+        self.assertEqual(result["status"], sms_approval.STATUS_FAILED)
+        self.assertIn("NANP", result["error"])
+        self.assertEqual(
+            sms_approval.get_draft(self.conn, draft["draft_id"])["status"],
+            sms_approval.STATUS_FAILED,
+        )
+        urlopen.assert_not_called()
 
     def test_stale_draft_does_not_send(self):
         draft = self._draft()


### PR DESCRIPTION
## TL;DR

Reject non-NANP destinations before any supported Dialpad SMS or voice request. This prevents unsupported international numbers from reaching Dialpad and turning into retryable HTTP 400 failures.

## What Problem This Solves

Outbound workflows could attempt SMS delivery or calls to non-NANP numbers even though this Dialpad account does not support those destinations. The provider rejected them only after the request was made.

## Why This Change Was Made

A shared destination policy now owns the rule and is enforced by direct SMS, approval-lane SMS, mirrored group introductions, call wrappers, and the generated operator facade. The facade also validates bulk messages, callbacks, transfers, and participant additions. Stored-recipient schedule operations and generated meeting call-out fail closed when their effective phone destinations cannot be proven locally.

## User Impact

Non-NANP destinations are rejected locally with a non-retryable validation error. NANP destinations, including all `+1` territories, retain the existing request contract, and explicit SMS country inference normalizes ten-digit NANP numbers to `+1` E.164 before delivery.

## Risk and Rollout

This intentionally narrows supported outbound destinations to NANP. The raw generated OpenAPI client remains an internal operator escape hatch; supported wrappers and the documented facade are guarded.

## Evidence

- `python3 -m pytest -q` - 782 passed
- `python3 -m py_compile ...` - passed
- `git diff --check` - passed
- Thermo-nuclear maintainability review completed; endpoint capabilities are explicit and the generated facade remains decomposed
- Final confined Codex autoreview: `autoreview clean: no accepted/actionable findings reported` (confidence 0.91)
- Structured correctness, testing, API-contract, reliability, security, agent-native, and independent Claude Opus adversarial reviews completed; all accepted findings were resolved

## AI Assistance

AI assistance was used for implementation and review. The destination policy, transport coverage, CLI contracts, and regression tests were manually verified and are understood.