### PR TITLE
docs: document hook routing env vars, fix stale layout tree, dedupe and trim

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ export OPENCLAW_HOOKS_NAME="Dialpad SMS"
 export OPENCLAW_HOOKS_CALL_NAME="Dialpad Missed Call"
 export OPENCLAW_HOOKS_AGENT_ID="niemand-work"
 
+# Optional hook delivery routing (wired in scripts/webhook_server.py):
+# channel for hook delivery (e.g. "telegram") and its target; OPENCLAW_HOOKS_TO
+# accepts "<chat>:topic:<id>" or a bare chat id.
+export OPENCLAW_HOOKS_CHANNEL="telegram"
+export OPENCLAW_HOOKS_TO="-1001234567890:topic:2"
+
 # Optional per-event hook controls (disabled by default)
 export OPENCLAW_HOOKS_SMS_ENABLED="1"
 export OPENCLAW_HOOKS_CALL_ENABLED="1"
@@ -187,19 +193,8 @@ generated/dialpad --api-key "$DIALPAD_API_KEY" company company.get >/dev/null
 
 ## Repository Layout
 
-```text
-dialpad-openclaw-skill/
-├── SKILL.md
-├── README.md
-├── bin/
-│   ├── get_call_transcript.py
-│   ├── list_calls.py
-├── generated/
-├── scripts/
-├── references/
-├── tests/
-└── LICENSE
-```
+See `references/architecture.md` for the accurate, complete layout (the `bin/`
+wrapper surface alone has 16 commands — don't work from a partial tree).
 
 ## Reference Docs
 

--- a/README.md
+++ b/README.md
@@ -100,9 +100,10 @@ export OPENCLAW_HOOKS_AGENT_ID="niemand-work"
 
 # Optional hook delivery routing (wired in scripts/webhook_server.py):
 # channel for hook delivery (e.g. "telegram") and its target; OPENCLAW_HOOKS_TO
-# accepts "<chat>:topic:<id>" or a bare chat id.
+# accepts the full route format "telegram:group:<chat>:topic:<id>" or a bare
+# numeric chat id.
 export OPENCLAW_HOOKS_CHANNEL="telegram"
-export OPENCLAW_HOOKS_TO="-1001234567890:topic:2"
+export OPENCLAW_HOOKS_TO="telegram:group:-1001234567890:topic:2"
 
 # Optional per-event hook controls (disabled by default)
 export OPENCLAW_HOOKS_SMS_ENABLED="1"
@@ -193,8 +194,10 @@ generated/dialpad --api-key "$DIALPAD_API_KEY" company company.get >/dev/null
 
 ## Repository Layout
 
-See `references/architecture.md` for the accurate, complete layout (the `bin/`
-wrapper surface alone has 16 commands — don't work from a partial tree).
+List the live wrapper surface with `ls bin/` (14 command wrappers plus the
+internal `_dialpad_compat.py` helper) — don't work from a partial tree.
+`references/architecture.md` has the structural overview of how `bin/`,
+`generated/`, `scripts/`, and `references/` fit together.
 
 ## Reference Docs
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -91,8 +91,7 @@ bin/update_contact.py --id "contact_123" --phone "+14155550123" --job-title "VP"
 3. **Safer message input:** Prefer `--message-file` or `--message-stdin` for pricing text, multi-line copy, or anything shell-sensitive.
 4. **Supported agent interface:** use `bin/*.py` wrappers for normal work. They are the stable command contract for agents.
 5. **Operator-only surfaces:** `generated/dialpad` and `scripts/*` are for manual troubleshooting, storage inspection, or operational maintenance, not normal agent task execution.
-6. **Auth canonical source:** `DIALPAD_API_KEY` is canonical. `DIALPAD_TOKEN` is only needed for manual generated CLI troubleshooting.
-   - Operator example: `export DIALPAD_TOKEN="${DIALPAD_TOKEN:-$DIALPAD_API_KEY}"`
+6. **Auth canonical source:** `DIALPAD_API_KEY` is canonical. `DIALPAD_TOKEN` is only needed for manual generated CLI troubleshooting (bridge command in Setup below).
 7. **SMS sender safety:** `--from` and `--profile work|sales` are supported. Prefer explicit `--from` for deterministic routing.
    - `--profile` maps to configured env vars:
      - work: `DIALPAD_PROFILE_WORK_FROM`
@@ -123,6 +122,7 @@ bin/update_contact.py --id "contact_123" --phone "+14155550123" --job-title "VP"
 - **`references/sms-storage.md`** — SQLite commands, FTS5 search, legacy storage
 - **`references/voice-options.md`** — List of available TTS voices (Budget & Premium)
 - **`references/architecture.md`** — System architecture, wrappers, and CLI generation
+- **`THEORY.MD`** — Design rationale: shell-corruption invariant, 401 classification, inbound-policy-once model
 
 ## Operational Tools
 

--- a/references/api-reference.md
+++ b/references/api-reference.md
@@ -61,98 +61,28 @@ bin/sync_sms_export.py --start-date 2026-05-13 --end-date 2026-05-13 --json
 
 ### Manual Operator CLI Examples
 
-These examples are for human operators doing deep inspection or advanced troubleshooting.
+These examples are for human operators doing deep inspection or advanced
+troubleshooting. The generated CLI covers the full API surface (241 operations) —
+discover commands with `generated/dialpad --help` and
+`generated/dialpad <resource> --help` rather than working from a catalog here.
+Representative invocation shapes:
 
-### Campaign & Automation
 ```bash
-# Bulk SMS campaigns
-dialpad message bulk_messages.send --recipients '["+14155551234"]' --text "Campaign message"
-
-# Schedule SMS for later delivery
-dialpad message schedules.create --send-time "2026-02-15T09:00:00Z" --text "Reminder"
-
-# Manage SMS templates
-dialpad message templates.list
-dialpad message templates.create --name "Welcome" --text "Welcome to ShapeScale!"
-```
-
-### Advanced Call Management
-```bash
-# Transfer live call to another user
+# Resource + dotted operation, flags per --help
 dialpad call transfer_call --call-id "12345" --target-user-id "67890"
-
-# Get AI-generated call summary
-dialpad call ai_recap --call-id "12345"
-
-# List call dispositions (outcomes)
-dialpad dispositions list
-dialpad dispositions.create --name "Demo Scheduled" --color "#00FF00"
-
-# Initiate IVR flow
-dialpad call initiate_ivr_call --phone-number "+14155551234" --ivr-id "menu_123"
-
-# Control call recording
-dialpad call recording.start --call-id "12345"
-dialpad call recording.stop --call-id "12345"
-
-# Add call labels
-dialpad call put_call_labels --call-id "12345" --labels '["hot-lead", "follow-up"]'
-```
-
-### Organization Management
-```bash
-# User management
-dialpad users users.list
 dialpad users users.get --id "5765607478525952"
-dialpad users users.update --id "5765607478525952" --status "away"
-
-# Office/Department management
-dialpad offices offices.list
-dialpad offices offices.create --name "SF Office" --timezone "America/Los_Angeles"
-dialpad departments departments.list
-
-# Call center queues
-dialpad callcenters callcenters.list
-dialpad callcenters operators.list --callcenter-id "12345"
-
-# Access control
-dialpad accesscontrolpolicies accesscontrolpolicies.list
-dialpad accesscontrolpolicies accesscontrolpolicies.assign --id "policy_123" --user-id "456"
+dialpad stats stats.create --stat-type "calls" --days-ago-start 7 --days-ago-end 0
 ```
 
-### Contact & CRM
+Wrapper-specific behavior worth knowing (not in `--help`):
+
 ```bash
-# Full contact CRUD (manual operator use)
-dialpad contacts contacts.create --first-name "John" --last-name "Doe" --phones '["+14155551234"]'
-dialpad contacts contacts.update --id "contact_123" --first-name "John" --job-title "VP"
-dialpad contacts contacts.delete --id "contact_123"
-
-# Backward-compatible wrapper
-bin/create_contact.py --first-name "Jane" --last-name "Doe" --phone "+14155550123" --email "jane@example.com"
-bin/update_contact.py --id "contact_123" --job-title "VP"
-
-# Company management
-dialpad companies companies.list
-dialpad companies companies.create --name "Acme Corp"
-
 # Contact upsert behavior (wrapper)
 # - create_contact.py matches by phone/email for shared and/or local scope and updates on match.
 # - --scope controls targets: shared, local, both, auto (owner provided => both, else shared).
 # - --allow-duplicate bypasses matching and forces create.
-
-# Contact import/export
-dialpad contacts imports.create --file "contacts.csv"
-```
-
-### Analytics & Reporting
-```bash
-# Generate stats reports
-dialpad stats stats.create --stat-type "calls" --days-ago-start 7 --days-ago-end 0
-dialpad stats stats.create --stat-type "csat" --export-type "records"
-dialpad stats stats.create --stat-type "dispositions" --target-id "office_123" --target-type "office"
-
-# Get report status and download
-dialpad stats stats.get --id "request_123"
+bin/create_contact.py --first-name "Jane" --last-name "Doe" --phone "+14155550123" --email "jane@example.com"
+bin/update_contact.py --id "contact_123" --job-title "VP"
 ```
 
 ## Webhooks

--- a/references/api-reference.md
+++ b/references/api-reference.md
@@ -69,9 +69,9 @@ Representative invocation shapes:
 
 ```bash
 # Resource + dotted operation, flags per --help
-dialpad call transfer_call --call-id "12345" --target-user-id "67890"
+dialpad call call.transfer_call --id "12345" --to "+14155551234"
 dialpad users users.get --id "5765607478525952"
-dialpad stats stats.create --stat-type "calls" --days-ago-start 7 --days-ago-end 0
+dialpad stats stats.create --stat-type "calls" --export-type "stats" --days-ago-start 7 --days-ago-end 0
 ```
 
 Wrapper-specific behavior worth knowing (not in `--help`):

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -15,7 +15,11 @@ Dialpad OpenClaw Skill
 │   ├── update_contact.py
 │   ├── export_sms.py
 │   ├── create_sms_webhook.py
-│   └── _dialpad_compat.py
+│   ├── create_sms_draft.py
+│   ├── approve_sms_draft.py
+│   ├── list_sms_thread.py
+│   ├── sync_sms_export.py
+│   └── _dialpad_compat.py       # internal helper, not a command
 ├── generated/                    # Internal backend CLI used by wrappers
 │   ├── dialpad
 │   └── dialpad.openapi

--- a/references/openclaw-integration.md
+++ b/references/openclaw-integration.md
@@ -62,6 +62,10 @@ export OPENCLAW_HOOKS_PATH="/hooks/agent"
 export OPENCLAW_HOOKS_NAME="Dialpad SMS"
 export OPENCLAW_HOOKS_CALL_NAME="Dialpad Missed Call"
 export OPENCLAW_HOOKS_AGENT_ID="niemand-work"
+# Optional hook delivery routing: channel (e.g. "telegram") and target;
+# OPENCLAW_HOOKS_TO accepts "<chat>:topic:<id>" or a bare chat id.
+export OPENCLAW_HOOKS_CHANNEL="telegram"
+export OPENCLAW_HOOKS_TO="-1001234567890:topic:2"
 export OPENCLAW_HOOKS_SMS_ENABLED="0"
 export OPENCLAW_HOOKS_CALL_ENABLED="0"
 export DIALPAD_ALLOW_DUPLICATE_OPERATOR_DELIVERY="0"

--- a/references/openclaw-integration.md
+++ b/references/openclaw-integration.md
@@ -63,9 +63,10 @@ export OPENCLAW_HOOKS_NAME="Dialpad SMS"
 export OPENCLAW_HOOKS_CALL_NAME="Dialpad Missed Call"
 export OPENCLAW_HOOKS_AGENT_ID="niemand-work"
 # Optional hook delivery routing: channel (e.g. "telegram") and target;
-# OPENCLAW_HOOKS_TO accepts "<chat>:topic:<id>" or a bare chat id.
+# OPENCLAW_HOOKS_TO accepts "telegram:group:<chat>:topic:<id>" or a bare
+# numeric chat id.
 export OPENCLAW_HOOKS_CHANNEL="telegram"
-export OPENCLAW_HOOKS_TO="-1001234567890:topic:2"
+export OPENCLAW_HOOKS_TO="telegram:group:-1001234567890:topic:2"
 export OPENCLAW_HOOKS_SMS_ENABLED="0"
 export OPENCLAW_HOOKS_CALL_ENABLED="0"
 export DIALPAD_ALLOW_DUPLICATE_OPERATOR_DELIVERY="0"


### PR DESCRIPTION
## What Problem This Solves

`OPENCLAW_HOOKS_CHANNEL` and `OPENCLAW_HOOKS_TO` are wired in `scripts/webhook_server.py` (lines 126-127, target resolution at 484-531) but documented in no env-var block — an operator configuring hook delivery from the docs couldn't route it. README's Repository Layout tree showed 2 of 16 `bin/` wrappers (misleadingly partial). `THEORY.MD` — the repo's design-rationale doc — had zero inbound links. SKILL.md stated the DIALPAD_TOKEN auth bridge twice, and `references/api-reference.md` carried ~85 lines of operator-CLI catalog derivable from `generated/dialpad <resource> --help`.

## Why This Change Was Made

Context-engineering audit (claims re-verified against current main after the recent webhook-forwarding merge; the earlier idea of collapsing README to a thin pointer was dropped — its webhook section has since become primary documentation and is no longer a duplicate).

## User Impact

Hook delivery routing is now configurable from the docs (README + references/openclaw-integration.md, matched env-block comments); the layout pointer goes to the accurate tree in references/architecture.md; THEORY.MD is discoverable from SKILL.md's reference list; the CLI reference teaches the discovery pattern (--help) plus the wrapper-only upsert semantics instead of a drifting catalog.

## Risk and Rollout

Docs only. All safety-critical guidance untouched (NANP-only sends, disabled send_now, approval-token lane, receipt ledger, dry-run preview). Trimmed catalog content is fully recoverable via `generated/dialpad <resource> --help` (241 operations, count verified against openapi.json previously).

## Evidence

- `rg OPENCLAW_HOOKS_CHANNEL` now hits webhook_server.py + both env docs; env-var names and TO format ("<chat>:topic:<id>" or bare id) taken from the code's own docstring and fallback logic.
- `ls bin | wc -l` = 16 vs the deleted tree's 2 entries.
- THEORY.MD description in the reference list matches its actual contents (shell-corruption invariant, 401 classification, inbound-policy-once).