### PR TITLE
docs: declare the native OpenClaw tools this skill drives

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -10,6 +10,8 @@ Send SMS and make voice calls via the Dialpad API.
 
 ## When to Use
 
+**Native tools:** `submit_draft` (registered by this skill's `dialpad-draft-callback` plugin). **Owned entrypoints:** `list_sms_thread.py`, `lookup_contact.py`, `poll_voicemails.py`.
+
 Use this skill to:
 - Send SMS messages (individual or batch)
 - Make voice calls (with TTS or custom voices)


### PR DESCRIPTION
## TL;DR

This skill ships the `dialpad-draft-callback` plugin that *defines* the `submit_draft` tool, yet no guidance file in my fleet named it — so `submit_draft` failures, the biggest tool-failure cluster of the week, were filed with no owner. I added one line declaring `submit_draft` plus the three `bin/` entrypoints that also never grounded.

## What Problem This Solves

My Opik weekly correction loop proposes a fix location only when a guidance file explicitly names the failing tool identifier or the failing command's head token. Two separate defects were hitting this skill:

1. **`submit_draft` had zero claimants.** The tool is registered by `extensions/dialpad-draft-callback` in this repo, but the identifier appears only in that extension's manifest and in planning docs — never in `SKILL.md`. Two clusters in one week (12 and 6 signals) both resolved to *"no allowlisted file mentions the `submit_draft` tool"*.

2. **Path-prefixed script references never ground.** The loop reduces a failing command to its basename (`list_sms_thread.py`), while its token matcher deliberately refuses a token preceded by `/` so that a file path is not misread as a command mention. `bin/list_sms_thread.py` is written that way everywhere in this skill, so a command that this skill unambiguously owns could not ground against it. This one surprised me and is, I suspect, a common shape across the fleet.

## Why This Change Was Made

Ownership here is not a judgement call — the plugin in this repo is where the tool comes from, which makes `SKILL.md` the correct place to look when it breaks.

I put the declaration in the first `## ` section because the loop's inventory indexes H2 blocks as sections and ranks a section mention above a preamble mention. The bare basenames are what the matcher needs; the existing `bin/...` usage lines are untouched.

## User Impact

- `submit_draft` failures route here at grounding 3, naming `When to Use` as the section.
- `list_sms_thread.py`, `lookup_contact.py` and `poll_voicemails.py` failures also route here now.
- No SMS/voice behaviour, guardrail, approval rule, key rule or description changed. One added line.

## Evidence

Replaying my W28 weekly bundle (2000 traces) through the real resolver against a freshly generated 543-entry live inventory:

| Cluster | Before | After |
| --- | --- | --- |
| `submit_draft` failure (12 signals) | unrouted / `no_grounded_target` | resolved → `dialpad/SKILL.md` §`When to Use`, grounding 3 |
| `submit_draft` retry (6 signals) | unrouted / `no_grounded_target` | resolved → same, grounding 3 |

Command-lane claimant check over the same inventory:

```
list_sms_thread.py   before: 0 claimants   after: resolved  dialpad/SKILL.md (g3)
lookup_contact.py    before: 0 claimants   after: resolved  dialpad/SKILL.md (g3)
poll_voicemails.py   before: 0 claimants   after: resolved  dialpad/SKILL.md (g3)
```

Sole claimant in every case.

## Risk and Rollout

Very low: one additive line, no instruction or guardrail touched. The declaration is a routing hint for a loop that only ever proposes review pointers — it never edits target files. Rollback is a revert. It reaches the gateway through the normal boot-sync of the skill sources.

## AI Assistance

Implemented by a Claude Opus 5 subagent under my direction. The agent traced `submit_draft` back to this repo's plugin manifest and the gateway's tool registration before declaring it, and found the `/`-prefix grounding defect while checking why an already-documented script still failed to route. I am reviewing before merge.
